### PR TITLE
Fix off-by-one cursor causing spurious session rebuilds every turn

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -491,8 +491,17 @@ function syncSharedSession(
 	}
 
 	const missed = priorMessages.slice(sharedSession.cursor);
-	if (missed.length === 0) {
-		debug(`Case 3: no missed messages, resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${sharedSession.cursor}`);
+	// Case 3: no missed messages, OR just the trailing final-assistant from the previous turn.
+	// pi appends the final assistant message after streamSimple returns, so our cursor is always
+	// 1 behind by exactly that one message. It's already in CC's own session JSONL (the SDK
+	// persisted it when the query ended), so a plain resume is safe — no need to rebuild.
+	const isTrailingAssistantOnly =
+		missed.length === 1 && (missed[0] as { role?: string }).role === "assistant";
+	if (missed.length === 0 || isTrailingAssistantOnly) {
+		if (isTrailingAssistantOnly) {
+			sharedSession = { ...sharedSession, cursor: priorMessages.length };
+		}
+		debug(`Case 3: ${isTrailingAssistantOnly ? "advanced cursor past trailing assistant, " : ""}resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${sharedSession.cursor}`);
 		return { sessionId: sharedSession.sessionId };
 	}
 
@@ -1304,8 +1313,8 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 			// from the initial streamSimple call and is stale — tool result deliveries
 			// advanced sharedSession.cursor past it. We keep whichever is higher.
 			// Note: pi appends the final assistant message AFTER streamSimple returns,
-			// so cursor is always 1 behind — syncSharedSession will trigger a Case 4
-			// rebuild on the next turn. This is correct but not efficient.
+			// so cursor is 1 behind by exactly that message — syncSharedSession's
+			// trailing-assistant tolerance handles it on the next turn (no rebuild).
 			if (!wasAborted) {
 				const sessionId = capturedSessionId ?? sharedSession?.sessionId;
 				if (sessionId) {


### PR DESCRIPTION
## Problem

Every follow-up turn was triggering a Case 4 full session rebuild in `syncSharedSession` — the CC session id was discarded, a fresh session JSONL was created, and the entire history was reimported.

This broke prompt caching, polluted the session directory, and gave the user a "Claude doesn't remember the previous turn" feel even though context was technically preserved (sanitized tool_use ids in the reimported history visibly affect model behavior).

### Log evidence (before)

```
Turn 1: query done, session=94e6a67f, cursor=1
Turn 2: Case 4: 18 missed messages, 19 total → new session ae2e7a8a (was 94e6a67f)
```

## Root cause

Already documented in the code at index.ts:1303-1308:

> "pi appends the final assistant message AFTER streamSimple returns, so cursor is always 1 behind — syncSharedSession will trigger a Case 4 rebuild on the next turn. This is correct but not efficient."

The "not efficient" framing under-sold it: it also breaks prompt caching and creates a fresh CC session JSONL every turn.

## Fix

Treat a single trailing assistant message as a Case 3 (resume). That message is already in CC's own session JSONL — the SDK persisted it when the query ended — so a plain resume is safe.

```ts
const isTrailingAssistantOnly =
    missed.length === 1 && (missed[0] as { role?: string }).role === "assistant";
if (missed.length === 0 || isTrailingAssistantOnly) {
    if (isTrailingAssistantOnly) {
        sharedSession = { ...sharedSession, cursor: priorMessages.length };
    }
    debug(`Case 3: ...resuming session ${sharedSession.sessionId.slice(0, 8)}, cursor=${sharedSession.cursor}`);
    return { sessionId: sharedSession.sessionId };
}
```

A real Case 4 (subagent context manipulation, multiple injected messages, non-assistant trailing role) still falls through to the rebuild path — behavior unchanged.

## Verification

`npm run test:unit` → all 23 tests pass.

End-to-end with `CLAUDE_BRIDGE_DEBUG=1` across 6 turns including tool use:

```
Turn 1: Case 1: clean start                                          → session=a07d1a5a, cursor=1
Turn 2: Case 3: advanced cursor past trailing assistant, cursor=2    → resume=a07d1a5a, cursor=3
Turn 3: Case 3: advanced cursor past trailing assistant, cursor=4    → resume=a07d1a5a, cursor=5
Turn 4: Case 3: advanced cursor past trailing assistant, cursor=6    → resume=a07d1a5a, cursor=15  (tool use)
Turn 5: Case 3: advanced cursor past trailing assistant, cursor=16   → resume=a07d1a5a, cursor=19  (tool use)
Turn 6: Case 3: advanced cursor past trailing assistant, cursor=20   → resume=a07d1a5a, cursor=21
```

Same session id across all turns, no Case 4. `tests/cache-test.sh` (the 90% hit threshold one) should benefit measurably from this fix.