### PR TITLE
Add claude-opus-4-7 to selectable models

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -119,9 +119,26 @@ const DISALLOWED_BUILTIN_TOOLS = [
 	"AskUserQuestion", "TaskCreate", "TaskGet", "TaskList", "TaskUpdate",
 ];
 
+// Canonical selection + display order for the model picker.
+// `resolveModelId` returns the first partial match, so `opus` resolves to the first-listed opus entry.
+const MODEL_IDS_IN_ORDER = ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
+
+// Fallback definitions for models not yet registered in pi-ai.
+// Once pi-ai ships an update with the model, its definition takes precedence automatically.
+const FALLBACK_MODEL_DEFS = [
+	{
+		id: "claude-opus-4-7", name: "Claude Opus 4.7",
+		reasoning: true, input: ["text", "image"] as ("text" | "image")[],
+		cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+		contextWindow: 1000000, maxTokens: 128000,
+	},
+];
+
 // Strip baseUrl/api/provider/headers — pi's registerProvider supplies its own.
-const MODELS = getModels("anthropic")
-	.filter((model) => ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"].includes(model.id))
+const _piAiModels = getModels("anthropic");
+const MODELS = MODEL_IDS_IN_ORDER
+	.map((id) => _piAiModels.find((m) => m.id === id) ?? FALLBACK_MODEL_DEFS.find((m) => m.id === id))
+	.filter((m): m is NonNullable<typeof m> => m != null)
 	.map(({ id, name, reasoning, input, cost, contextWindow, maxTokens }) => ({
 		id, name, reasoning, input, cost, contextWindow, maxTokens,
 	}));


### PR DESCRIPTION
Closes #6.

As discussed in the issue, this keeps both `claude-opus-4-6` and `claude-opus-4-7` selectable. `MODEL_IDS_IN_ORDER` lists 4.7 first so the `opus` shortcut — via `resolveModelId`'s partial-match — resolves to the newest available (4.7 now, 4.8 later); users can still pin to a specific version with `opus-4-6` / `opus-4-7`.

### Why the fallback?

`@mariozechner/pi-ai@0.52.0`'s `models.generated.js` doesn't have `claude-opus-4-7` yet, so `getModels("anthropic")` returns nothing for that id. `FALLBACK_MODEL_DEFS` supplies a definition in the meantime. Once pi-ai ships an update with the model, the pi-ai entry takes precedence automatically — no further changes needed here.

### Caveat

Cost values for the fallback are copied from 4.6 as a placeholder (I don't have the real numbers). Happy to update them if you have a source, or to leave that as a follow-up.

### Ordering preference

Went with newest-first based on the issue thread. Easy to flip to 4.6-first if you'd rather preserve the current `opus` → 4.6 behavior for existing users — just reorder `MODEL_IDS_IN_ORDER`.

### Verification

Confirmed locally that `claude-opus-4-7` shows up in the model picker and responds correctly via the Claude Code SDK.
