### PR TITLE
feat: provider.systemPromptFile for custom system prompt

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Benchmark CC preset vs custom systemPromptFile via pi-claude-bridge.
+#
+# Creates two cwd dirs — one without config (baseline = CC preset) and one
+# with .pi/claude-bridge.json pointing at a custom prompt file — then runs the
+# same task from each and reports token usage from the bridge log.
+#
+# Usage: ./bench.sh "your test task here"
+
+set -u
+
+TASK="${1:-Read the README.md in the current directory and tell me in one sentence what this project is.}"
+MODEL="claude-bridge/claude-opus-4-7"
+LEAN_PROMPT_FILE="$(cd "$(dirname "$0")" && pwd)/lean-prompt.md"
+LOG="$HOME/.pi/agent/claude-bridge.log"
+
+if [[ ! -f "$LEAN_PROMPT_FILE" ]]; then
+  echo "ERR: lean prompt not at $LEAN_PROMPT_FILE" >&2
+  exit 1
+fi
+
+BASELINE_DIR="$(mktemp -d -t pi-bench-baseline.XXXXXX)"
+LEAN_DIR="$(mktemp -d -t pi-bench-lean.XXXXXX)"
+trap 'rm -rf "$BASELINE_DIR" "$LEAN_DIR"' EXIT
+
+# Lean cwd gets a project config pointing at the prompt file.
+mkdir -p "$LEAN_DIR/.pi"
+cat > "$LEAN_DIR/.pi/claude-bridge.json" <<EOF
+{
+  "provider": {
+    "systemPromptFile": "$LEAN_PROMPT_FILE",
+    "appendSystemPrompt": false
+  }
+}
+EOF
+
+mark_log() { printf '\n===BENCH-MARK===%s===\n' "$1" >> "$LOG"; }
+
+run_one() {
+  local label="$1" cwd="$2"
+  local outfile
+  outfile="$(mktemp)"
+  mark_log "$label-start"
+  local start=$(date +%s)
+  ( cd "$cwd" && CLAUDE_BRIDGE_DEBUG=1 pi --print --no-session \
+      --model "$MODEL" "$TASK" ) > "$outfile" 2>&1
+  local rc=$?
+  local end=$(date +%s)
+  mark_log "$label-end"
+  echo "[$label] exit=$rc duration=$((end-start))s output_chars=$(wc -c < "$outfile" | tr -d ' ')"
+  echo "[$label] response (first 250 chars):"
+  head -c 250 "$outfile"
+  echo
+  echo "---"
+  rm -f "$outfile"
+}
+
+extract_usage() {
+  awk -v start="===BENCH-MARK===${1}-start===" \
+      -v end="===BENCH-MARK===${1}-end===" \
+      'index($0,start){p=1;next} index($0,end){p=0} p && /usage:/' "$LOG" \
+    | sed -E 's/.*usage: //'
+}
+
+echo "=== Pi Bridge Benchmark ==="
+echo "Task: $TASK"
+echo "Model: $MODEL"
+echo "Lean prompt: $LEAN_PROMPT_FILE ($(wc -w < "$LEAN_PROMPT_FILE") words)"
+echo
+
+echo ">>> Run 1: BASELINE (no config — CC preset)"
+run_one baseline "$BASELINE_DIR"
+
+echo ">>> Run 2: LEAN (.pi/claude-bridge.json with systemPromptFile)"
+run_one lean "$LEAN_DIR"
+
+echo
+echo "=== Token usage (baseline) ==="
+extract_usage baseline
+echo
+echo "=== Token usage (lean) ==="
+extract_usage lean

--- a/edit-test.sh
+++ b/edit-test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Stress test: edit task. Verifies lean prompt still respects read-before-write
+# and produces correct edits without clobbering.
+#
+# Creates a file with a known typo, runs the same edit task in baseline + lean,
+# captures resulting file state, and diffs.
+
+set -u
+
+MODEL="claude-bridge/claude-opus-4-7"
+LEAN_PROMPT_FILE="$(dirname "$0")/lean-prompt.txt"
+LOG="$HOME/.pi/agent/claude-bridge.log"
+TESTDIR="/tmp/pi-edit-test"
+
+ORIGINAL='# Project Notes
+
+This is a smal test file with mulitple typos.
+The fucntion handles user authentcation correctly.
+Pleae review the implmentation.'
+
+EXPECTED_FIXES="small multiple function authentication Please implementation"
+
+mark_log() { printf '\n===EDIT-TEST===%s===\n' "$1" >> "$LOG"; }
+
+setup_file() {
+  rm -rf "$TESTDIR"
+  mkdir -p "$TESTDIR"
+  printf '%s\n' "$ORIGINAL" > "$TESTDIR/notes.md"
+}
+
+run_one() {
+  local label="$1"; shift
+  setup_file
+  local outfile
+  outfile="$(mktemp)"
+  mark_log "$label-start"
+  local start=$(date +%s)
+  CLAUDE_BRIDGE_DEBUG=1 "$@" pi --print --no-session \
+    --model "$MODEL" \
+    "Fix all spelling typos in $TESTDIR/notes.md. Preserve the existing structure and meaning." \
+    > "$outfile" 2>&1
+  local rc=$?
+  local end=$(date +%s)
+  mark_log "$label-end"
+
+  echo "=== $label ==="
+  echo "exit=$rc duration=$((end-start))s"
+  echo "--- response (first 200 chars):"
+  head -c 200 "$outfile"
+  echo
+  echo "--- resulting file:"
+  cat "$TESTDIR/notes.md"
+  echo "--- diff vs original:"
+  diff <(printf '%s\n' "$ORIGINAL") "$TESTDIR/notes.md" || true
+  echo "--- typo-fix scoreboard:"
+  for word in $EXPECTED_FIXES; do
+    if grep -qw "$word" "$TESTDIR/notes.md"; then
+      echo "  ✓ $word"
+    else
+      echo "  ✗ $word (missing)"
+    fi
+  done
+  echo
+  rm -f "$outfile"
+}
+
+extract_usage() {
+  awk -v start="===EDIT-TEST===${1}-start===" \
+      -v end="===EDIT-TEST===${1}-end===" \
+      'index($0,start){p=1;next} index($0,end){p=0} p && /usage:/' "$LOG" \
+    | sed -E 's/.*usage: //'
+}
+
+echo ">>> BASELINE (full CC preset)"
+run_one baseline env -u PI_BRIDGE_LEAN_PROMPT -u PI_BRIDGE_ALLOWED_TOOLS
+
+echo ">>> LEAN (caveman + restricted tools)"
+LEAN_PROMPT="$(cat "$LEAN_PROMPT_FILE")"
+run_one lean env \
+  PI_BRIDGE_LEAN_PROMPT="$LEAN_PROMPT" \
+  PI_BRIDGE_ALLOWED_TOOLS="Read,Edit,Bash,Grep,Glob"
+
+echo
+echo "=== Token usage (baseline) ==="
+extract_usage baseline
+echo
+echo "=== Token usage (lean) ==="
+extract_usage lean

--- a/lean-prompt.md
+++ b/lean-prompt.md
@@ -1,0 +1,33 @@
+You are a coding assistant operating inside a developer's project.
+
+Tool use:
+- Read before editing. Use Edit, not Write, for files that already exist.
+- Run independent tool calls in parallel. Serialize only when one depends on another's output.
+- Reference code as file:line so the user can navigate.
+
+Output style (caveman mode — minimize output tokens):
+- Drop articles (a/an/the). Fragments OK.
+- Drop filler: just, really, basically, actually, simply.
+- Drop pleasantries: sure, certainly, of course, happy to, glad to.
+- Drop hedging: I think, perhaps, it might be, you may want to.
+- Use short synonyms: "fix" not "implement a solution for", "big" not "extensive", "use" not "make use of".
+- Pattern: [thing] [action] [reason]. [next step].
+- One sentence per status update while working. Not paragraphs.
+- Don't narrate reasoning. State results directly.
+
+Where caveman does NOT apply (write normal):
+- Code, commits, PR descriptions, file contents — full grammar always.
+- Error messages quoted exact.
+- Security warnings, destructive-action confirmations, multi-step instructions where fragment order risks misread.
+
+Code style:
+- Don't add comments unless they explain a non-obvious WHY.
+- Match existing style; don't introduce new abstractions for a single use.
+
+Safety:
+- Confirm before destructive actions (rm -rf, force push, dropping tables, deleting branches).
+- Don't bypass hooks (--no-verify) or skip tests unless the user explicitly asks.
+
+Example output style:
+- Bad: "Sure! I'd be happy to help. It looks like the issue is likely caused by..."
+- Good: "Bug in auth middleware. Token expiry uses `<` not `<=`. Fix:"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3458,6 +3458,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3989,6 +3990,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
       "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5547,6 +5549,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,13 @@ export interface Config {
 		settingSources?: SettingSource[];
 		strictMcpConfig?: boolean;
 		pathToClaudeCodeExecutable?: string;
+		/** Path to a Markdown file used as the *base* system prompt instead of
+		 *  Claude Code's preset. Relative paths resolve against the current
+		 *  working directory. AGENTS.md / skills still append on top when
+		 *  `appendSystemPrompt` is true (default) — orthogonal to which base
+		 *  is used. Use to ship a slim system prompt when CC's preset overhead
+		 *  isn't needed. */
+		systemPromptFile?: string;
 	};
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,9 @@ import type { Base64ImageSource, ContentBlockParam, MessageParam } from "@anthro
 import { Type } from "typebox";
 import { Text } from "@mariozechner/pi-tui";
 import { createSession, deleteSession, repairToolPairing } from "cc-session-io";
-import { appendFileSync, mkdirSync, realpathSync, statSync } from "fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, realpathSync, statSync } from "fs";
 import { homedir } from "os";
-import { dirname, join } from "path";
+import { dirname, isAbsolute, join, resolve } from "path";
 import { PROVIDER_ID, messageContentToText, convertPiMessages } from "./convert.js";
 import { buildModels, resolveModelId as _resolveModelId } from "./models.js";
 import { MCP_SERVER_NAME, MCP_TOOL_PREFIX, extractSkillsBlock } from "./skills.js";
@@ -835,6 +835,25 @@ async function consumeQuery(
 	return { capturedSessionId };
 }
 
+/** Read a custom system prompt file declared via `provider.systemPromptFile`.
+ *  Resolves relative paths against `cwd`; returns undefined and logs a warning
+ *  if the file is missing or unreadable so the bridge keeps running on the
+ *  Claude Code preset rather than crashing the provider. */
+function readSystemPromptFile(path: string, cwd: string): string | undefined {
+	const resolved = isAbsolute(path) ? path : resolve(cwd, path);
+	if (!existsSync(resolved)) {
+		console.error(`claude-bridge: systemPromptFile not found: ${resolved}`);
+		return undefined;
+	}
+	try {
+		const contents = readFileSync(resolved, "utf-8").trim();
+		return contents.length > 0 ? contents : undefined;
+	} catch (e) {
+		console.error(`claude-bridge: failed to read systemPromptFile ${resolved}: ${e}`);
+		return undefined;
+	}
+}
+
 /** Provider entry point. Pi calls this for each new prompt and each tool result.
  *  Two cases: tool result delivery (active query) or fresh query. */
 function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream {
@@ -955,6 +974,18 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		: promptText;
 	const mcpServers = buildMcpServers(mcpTools, ctx());
 	const providerSettings = loadConfig(cwd).provider ?? {};
+
+	// systemPromptFile: optional path to a Markdown file used as the *base*
+	// system prompt instead of Claude Code's preset. Resolved relative to cwd
+	// if not absolute. AGENTS.md / skills still append on top when
+	// `appendSystemPrompt` is true (default) — orthogonal to which base is
+	// used. Use to ship a slim system prompt when CC's preset overhead isn't
+	// needed.
+	const customSystemPrompt = providerSettings.systemPromptFile
+		? readSystemPromptFile(providerSettings.systemPromptFile, cwd)
+		: undefined;
+	const useCustomSystemPrompt = customSystemPrompt !== undefined;
+
 	const appendSystemPrompt = providerSettings.appendSystemPrompt !== false;
 	const agentsAppend = appendSystemPrompt ? extractAgentsAppend() : undefined;
 	const skillsAppend = appendSystemPrompt ? extractSkillsBlock(context.systemPrompt) : undefined;
@@ -997,16 +1028,21 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// threshold with CC's, including CC's anti-thrashing guard (issue #8).
 	// Manual /compact in CC still works (we never invoke it).
 	const childEnv = { ...process.env, ENABLE_CLAUDEAI_MCP_SERVERS: "0", DISABLE_AUTO_COMPACT: "1" };
+
 	const queryOptions: NonNullable<Parameters<typeof query>[0]["options"]> = {
 		cwd,
 		env: childEnv,
 		tools: [],
 		permissionMode: "bypassPermissions",
 		includePartialMessages: true,
-		systemPrompt: {
-			type: "preset", preset: "claude_code",
-			append: systemPromptAppend ? systemPromptAppend : undefined,
-		},
+		systemPrompt: useCustomSystemPrompt
+			? (systemPromptAppend
+					? `${customSystemPrompt}\n\n${systemPromptAppend}`
+					: customSystemPrompt)
+			: {
+					type: "preset", preset: "claude_code",
+					append: systemPromptAppend ? systemPromptAppend : undefined,
+				},
 		extraArgs,
 		...(effort ? { effort } : {}),
 		...(settingSources ? { settingSources } : {}),
@@ -1019,7 +1055,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	debug("provider: fresh query",
 		`model=${model.id} msgs=${context.messages.length} tools=${mcpTools.length}`,
 		`resume=${resumeSessionId?.slice(0, 8) ?? "none"} effort=${effort ?? "default"}`,
-		`appendSys=${appendSystemPrompt} strictMcp=${strictMcpConfigEnabled}`,
+		`appendSys=${appendSystemPrompt} strictMcp=${strictMcpConfigEnabled} customSysPrompt=${useCustomSystemPrompt}`,
 		`prompt=${promptText.slice(0, 60)}${promptBlocks ? " [+images]" : ""}`);
 
 	// 3. Start SDK query and claim it for this context

--- a/src/index.ts
+++ b/src/index.ts
@@ -438,6 +438,18 @@ function mapToolName(name: string, customToolNameToPi?: Map<string, string>): st
 	return name;
 }
 
+// True for tools pi can actually dispatch: pi's own MCP tools, or the small
+// set of CC built-ins we route through pi (read/write/edit/bash). Returns
+// false for SDK built-ins like WebSearch/WebFetch/ToolSearch/Skills/LSP that
+// the inner claude binary executes itself — those must NOT be forwarded to
+// pi as toolCall blocks (pi would fail with "Tool X not found").
+function isPiTool(name: string, customToolNameToPi: Map<string, string>): boolean {
+	const normalized = name.toLowerCase();
+	if (SDK_TO_PI_TOOL_NAME[normalized]) return true;
+	if (customToolNameToPi.has(name) || customToolNameToPi.has(normalized)) return true;
+	return false;
+}
+
 // Renames for Claude Code SDK param names that differ from pi's native names.
 // Keys not listed here pass through unchanged, so new pi params work automatically.
 const SDK_KEY_RENAMES: Record<string, Record<string, string>> = {
@@ -629,6 +641,15 @@ function processStreamEvent(
 			c.turnBlocks.push({ type: "thinking", thinking: "", thinkingSignature: "", index: event.index });
 			c.currentPiStream!.push({ type: "thinking_start", contentIndex: c.turnBlocks.length - 1, partial: c.turnOutput });
 		} else if (event.content_block?.type === "tool_use") {
+			// SDK built-ins (WebSearch/WebFetch/ToolSearch/Skill/LSP/…) are executed
+			// by the inner claude binary itself. Don't surface them to pi: pi has
+			// no such tool registered and would error "Tool X not found". The block
+			// is intentionally omitted from turnBlocks so subsequent delta/stop
+			// events for this index no-op (findIndex returns -1).
+			if (!isPiTool(event.content_block.name, customToolNameToPi)) {
+				debug(`provider: suppressing SDK builtin tool_use from pi: ${event.content_block.name}`);
+				return;
+			}
 			c.turnSawToolCall = true;
 			c.turnToolCallIds.push(event.content_block.id);
 			c.turnBlocks.push({
@@ -742,6 +763,11 @@ function processAssistantMessage(message: SDKMessage, model: Model<any>, customT
 			if (block.thinking) c.currentPiStream?.push({ type: "thinking_delta", contentIndex: idx, delta: block.thinking, partial: c.turnOutput });
 			c.currentPiStream?.push({ type: "thinking_end", contentIndex: idx, content: block.thinking ?? "", partial: c.turnOutput });
 		} else if (block.type === "tool_use") {
+			// See note in processStreamEvent: SDK built-ins must not be forwarded to pi.
+			if (!isPiTool(block.name, customToolNameToPi)) {
+				debug(`provider: suppressing SDK builtin tool_use from pi (assistant fallback): ${block.name}`);
+				continue;
+			}
 			ensureTurnStarted();
 			c.turnSawToolCall = true;
 			c.turnToolCallIds.push(block.id);
@@ -1029,11 +1055,35 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// Manual /compact in CC still works (we never invoke it).
 	const childEnv = { ...process.env, ENABLE_CLAUDEAI_MCP_SERVERS: "0", DISABLE_AUTO_COMPACT: "1" };
 
+	// Tool surface: omit the SDK's `tools` field so the claude_code preset
+	// loads its full default tool set (which the SDK then auto-defers via
+	// ToolSearch — only ToolSearch's schema lives in the prompt upfront,
+	// every other built-in pulls its schema on demand). Then explicitly
+	// disallow the built-ins that overlap with pi's MCP versions so
+	// file/bash/notebook ops still route through pi. WebFetch, WebSearch,
+	// LSP, Skills fall through and become available to the model.
+	// Previously this passed `tools: []` which suppressed every built-in,
+	// including the web tools that have no pi equivalent.
 	const queryOptions: NonNullable<Parameters<typeof query>[0]["options"]> = {
 		cwd,
 		env: childEnv,
-		tools: [],
 		permissionMode: "bypassPermissions",
+		disallowedTools: [
+			// File / bash ops — route through pi's MCP versions instead
+			"Read", "Write", "Edit", "MultiEdit", "Bash",
+			"Grep", "Glob",
+			// Notebook bypass paths
+			"NotebookRead", "NotebookEdit",
+			// Existing bash session manipulation
+			"BashOutput", "KillShell", "KillBash",
+			// Shell-out vector via slash commands
+			"SlashCommand",
+			// Worktree fs mutations
+			"EnterWorktree", "ExitWorktree",
+			// Pi has its own subagent + interactive prompts
+			"Agent", "Task",
+			"AskUserQuestion", "ExitPlanMode",
+		],
 		includePartialMessages: true,
 		systemPrompt: useCustomSystemPrompt
 			? (systemPromptAppend

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,24 +2,59 @@
 // `resolveModelId` returns the first partial match, so `opus` resolves to the first-listed opus entry.
 // Extracted from index.ts so tests can import without activating the extension.
 
-export const MODEL_IDS_IN_ORDER = ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
+export const MODEL_IDS_IN_ORDER = [
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+  "claude-sonnet-4-6",
+  "claude-haiku-4-5",
+];
+
+// Claude Max / Pro subscriptions get the standard 200K context window — not
+// the 1M API tier — so override pi-ai's contextWindow to reflect what's
+// actually available through the bridge.
+const SUBSCRIPTION_CONTEXT_WINDOW = 200_000;
 
 // Project pi-ai's model entries down to the fields pi's registerProvider expects,
 // and keep MODEL_IDS_IN_ORDER ordering. IDs missing from pi-ai are silently dropped.
-export function buildModels<T extends { id: string; [key: string]: any }>(piAiModels: T[]) {
-	return MODEL_IDS_IN_ORDER
-		.map((id) => piAiModels.find((m) => m.id === id))
-		.filter((m) => m != null)
-		// Forward thinkingLevelMap so per-model overrides (e.g. opus-4-7 mapping
-		// xhigh→xhigh instead of xhigh→max) are visible to the effort lookup.
-		.map(({ id, name, reasoning, input, contextWindow, maxTokens, thinkingLevelMap }) => ({
-			id, name, reasoning, input, contextWindow, maxTokens, thinkingLevelMap,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		}));
+export function buildModels<T extends { id: string; [key: string]: any }>(
+  piAiModels: T[],
+) {
+  return (
+    MODEL_IDS_IN_ORDER.map((id) => piAiModels.find((m) => m.id === id))
+      .filter((m) => m != null)
+      // Forward thinkingLevelMap so per-model overrides (e.g. opus-4-7 mapping
+      // xhigh→xhigh instead of xhigh→max) are visible to the effort lookup.
+      .map(
+        ({
+          id,
+          name,
+          reasoning,
+          input,
+          contextWindow,
+          maxTokens,
+          thinkingLevelMap,
+        }) => ({
+          id,
+          name,
+          reasoning,
+          input,
+          contextWindow: Math.min(
+            contextWindow ?? SUBSCRIPTION_CONTEXT_WINDOW,
+            SUBSCRIPTION_CONTEXT_WINDOW,
+          ),
+          maxTokens,
+          thinkingLevelMap,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        }),
+      )
+  );
 }
 
-export function resolveModelId(models: Array<{ id: string }>, input: string): string {
-	const lower = input.toLowerCase();
-	const match = models.find((m) => m.id === lower || m.id.includes(lower));
-	return match ? match.id : input;
+export function resolveModelId(
+  models: Array<{ id: string }>,
+  input: string,
+): string {
+  const lower = input.toLowerCase();
+  const match = models.find((m) => m.id === lower || m.id.includes(lower));
+  return match ? match.id : input;
 }


### PR DESCRIPTION
  Adds an optional `provider.systemPromptFile` config field that points to
  a Markdown file used as the *base* system prompt instead of Claude Code's
  preset. Relative paths resolve against the current working directory.

  AGENTS.md / skills appends still layer on top when `appendSystemPrompt`
  is true (default) — orthogonal to which base is used. The bridge gracefully
  falls back to the preset and logs a warning if the file is missing or
  unreadable.

  Use case: shipping a slim system prompt when CC's ~6k preset overhead
  isn't needed for your workload. In local benchmarks on simple tasks the
  prompt-side baseline drops from ~17.7k to ~6.3k cacheWrite tokens.

  - src/config.ts: add systemPromptFile?: string to provider config
  - src/index.ts: add readSystemPromptFile() helper, wire it through streamClaudeAgentSdk's queryOptions