### PR TITLE
Add claude-opus-4-8 model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Add: claude-opus-4-8 model** — Anthropic shipped Opus 4.8, but the installed `@mariozechner/pi-ai` (0.73.x) doesn't define `claude-opus-4-8` yet, so adding the id to `MODEL_IDS_IN_ORDER` alone gets it dropped by `buildModels`' `piAiModels.find` filter. Reintroduced a small `SYNTHETIC_MODELS` fallback that clones the `claude-opus-4-7` entry (identical params: 1M context, 128k max tokens, `xhigh→xhigh` thinking map) under the new id/name. The `opus` shortcut now resolves to 4.8; 4.7/4.6 remain available for explicit pinning. Once pi-ai ships the official definition, drop the synthetic entry and the `find` picks it up directly (per the 0.3.0 pi-ai-bump pattern).
+
 ## 0.4.0 — 2026-05-04
 
 - **Fix: Opus 4.7 + xhigh sent wrong effort to SDK** — pi-ai 0.72 ships per-model `thinkingLevelMap` overrides (e.g. `claude-opus-4-7` declares `xhigh→xhigh`, not `xhigh→max`), but our hardcoded `REASONING_TO_EFFORT` table ignored them. Effort lookup now consults `model.thinkingLevelMap` first, falls back to the table for older pi-ai or unmapped levels. Forwarded `thinkingLevelMap` through `buildModels` projection.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pi install npm:pi-claude-bridge
 
 ## Provider
 
-Use `/model` to select `claude-bridge/claude-opus-4-7`, `claude-bridge/claude-opus-4-6`, `claude-bridge/claude-sonnet-4-6`, or `claude-bridge/claude-haiku-4-5`.
+Use `/model` to select `claude-bridge/claude-opus-4-8`, `claude-bridge/claude-opus-4-7`, `claude-bridge/claude-opus-4-6`, `claude-bridge/claude-sonnet-4-6`, or `claude-bridge/claude-haiku-4-5`.
 
 Behind the scenes, pi's tools are bridged to Claude Code but it should all work like normal in pi. Bash commands get a 120-second default timeout (matching Claude Code's default) since pi's bash has no timeout by default. Skills in pi are copied over to Claude Code's system prompt so should work as they would with any other pi provider.
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,13 +2,28 @@
 // `resolveModelId` returns the first partial match, so `opus` resolves to the first-listed opus entry.
 // Extracted from index.ts so tests can import without activating the extension.
 
-export const MODEL_IDS_IN_ORDER = ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
+export const MODEL_IDS_IN_ORDER = ["claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
+
+// Models newer than the installed pi-ai's registry: clone the named base entry
+// (same params) and override id/name. Remove an entry once pi-ai ships its
+// official definition and the `piAiModels.find` below picks it up directly.
+const SYNTHETIC_MODELS: Record<string, { base: string; name: string }> = {
+	"claude-opus-4-8": { base: "claude-opus-4-7", name: "Claude Opus 4.8" },
+};
 
 // Project pi-ai's model entries down to the fields pi's registerProvider expects,
-// and keep MODEL_IDS_IN_ORDER ordering. IDs missing from pi-ai are silently dropped.
+// and keep MODEL_IDS_IN_ORDER ordering. IDs missing from pi-ai (and without a
+// synthetic fallback) are silently dropped.
 export function buildModels<T extends { id: string; [key: string]: any }>(piAiModels: T[]) {
 	return MODEL_IDS_IN_ORDER
-		.map((id) => piAiModels.find((m) => m.id === id))
+		.map((id) => {
+			const found = piAiModels.find((m) => m.id === id);
+			if (found) return found;
+			const synthetic = SYNTHETIC_MODELS[id];
+			if (!synthetic) return undefined;
+			const base = piAiModels.find((m) => m.id === synthetic.base);
+			return base ? ({ ...base, id, name: synthetic.name } as T) : undefined;
+		})
 		.filter((m) => m != null)
 		// Forward thinkingLevelMap so per-model overrides (e.g. opus-4-7 mapping
 		// xhigh→xhigh instead of xhigh→max) are visible to the effort lookup.

--- a/tests/unit-models.mjs
+++ b/tests/unit-models.mjs
@@ -33,10 +33,23 @@ describe("MODELS projection", () => {
 		assert.deepEqual(models.map((m) => m.id), MODEL_IDS_IN_ORDER);
 	});
 
-	it("silently drops IDs missing from pi-ai (no fallback)", () => {
-		// Only haiku present — opus/sonnet vanish from picker.
+	it("drops IDs with no pi-ai entry and no synthetic base", () => {
+		// Only haiku present — opus/sonnet vanish; opus-4-8's synthetic base
+		// (opus-4-7) is also absent, so it can't be cloned either.
 		const models = buildModels([mockPiAiModel("claude-haiku-4-5")]);
 		assert.deepEqual(models.map((m) => m.id), ["claude-haiku-4-5"]);
+	});
+
+	it("synthesizes claude-opus-4-8 from claude-opus-4-7 when pi-ai lacks it", () => {
+		// pi-ai has 4-7 but not 4-8 (current state): 4-8 is cloned from 4-7.
+		const models = buildModels([mockPiAiModel("claude-opus-4-7")]);
+		const ids = models.map((m) => m.id);
+		assert.ok(ids.includes("claude-opus-4-8"));
+		const v48 = models.find((m) => m.id === "claude-opus-4-8");
+		const v47 = models.find((m) => m.id === "claude-opus-4-7");
+		assert.equal(v48.name, "Claude Opus 4.8");
+		assert.equal(v48.contextWindow, v47.contextWindow);
+		assert.equal(v48.maxTokens, v47.maxTokens);
 	});
 
 	it("zeros out cost regardless of pi-ai pricing", () => {
@@ -50,8 +63,8 @@ describe("MODELS projection", () => {
 describe("resolveModelId", () => {
 	const models = buildModels(MODEL_IDS_IN_ORDER.map(mockPiAiModel));
 
-	it("opus shortcut resolves to claude-opus-4-7 (first opus in order)", () => {
-		assert.equal(resolveModelId(models, "opus"), "claude-opus-4-7");
+	it("opus shortcut resolves to claude-opus-4-8 (first opus in order)", () => {
+		assert.equal(resolveModelId(models, "opus"), "claude-opus-4-8");
 	});
 
 	it("haiku shortcut resolves to claude-haiku-4-5", () => {


### PR DESCRIPTION
Closes #22.

Adds **Claude Opus 4.8** (`claude-opus-4-8`) as a selectable model.

### Why a synthetic fallback
The latest `@mariozechner/pi-ai` (0.73.1) doesn't define `claude-opus-4-8` yet, so adding the id to `MODEL_IDS_IN_ORDER` alone gets it dropped by `buildModels`' `piAiModels.find` filter. This reintroduces a small `SYNTHETIC_MODELS` map that clones the `claude-opus-4-7` entry (identical params — 1M context, 128k max tokens, `xhigh→xhigh` thinking map) under the new id/name.

The `opus` shortcut now resolves to 4.8; 4.7/4.6 remain available for explicit pinning. Once pi-ai ships the official definition, drop the synthetic entry and `piAiModels.find` picks it up directly (the 0.3.0 pi-ai-bump pattern).

### Changes
- `src/models.ts` — add `claude-opus-4-8` to `MODEL_IDS_IN_ORDER` (first), add `SYNTHETIC_MODELS` fallback in `buildModels`
- `tests/unit-models.mjs` — update opus-shortcut assertion to 4.8, add synthesis coverage
- `README.md` / `CHANGELOG.md` — document the model

### Verification
- `npm run typecheck` — clean
- `npm run test:unit` — 83/83 pass