### PR TITLE
Fix spurious "Prompt is too long": enable 1M context via [1m] CLI suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Fix: 1M-context models now actually use the 1M window (issue #24, #17)** — models whose advertised context window exceeds 200K (Opus 4.6/4.7/4.8, Sonnet 4.6) show a `[1m]` suffix in their display name while keeping registered pi model ids stable/bare. The bridge adds `[1m]` only at the Claude Code CLI `--model` boundary, which is what enables its 1M window; without it the CLI stays on the 200K default and long sessions hit a spurious `Prompt is too long` once context crosses ~200K, even though pi's status bar shows headroom. The `context-1m-2025-08-07` beta proposed in #24 does **not** work for this bridge's audience: under Pro/Max subscription (OAuth) auth the CLI discards custom betas (`Custom betas are only available for API key users. Ignoring provided betas.`). The `[1m]` model-id path works under subscription auth. Haiku 4.5 (200K) is unaffected.
+
 ## 0.5.0 — 2026-06-05
 
 - **Add: claude-opus-4-8 model** — migrated pi imports/dev peers from deprecated `@mariozechner/*` packages to `@earendil-works/*` 0.78.x so the official pi-ai registry supplies Opus 4.8. The `opus` shortcut now resolves to 4.8; 4.7/4.6 remain available for explicit pinning.

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { appendFileSync, mkdirSync, realpathSync, statSync } from "fs";
 import { homedir } from "os";
 import { dirname, join } from "path";
 import { PROVIDER_ID, messageContentToText, convertPiMessages } from "./convert.js";
-import { buildModels, resolveModelId as _resolveModelId } from "./models.js";
+import { buildModels, claudeCodeModelId, resolveModel as _resolveModel } from "./models.js";
 import { MCP_SERVER_NAME, MCP_TOOL_PREFIX, extractSkillsBlock } from "./skills.js";
 import { verifyWrittenSession as _verifyWrittenSession } from "./session-verify.js";
 import { extractAllToolResults as _extractAllToolResults, type McpResult } from "./extract-tool-results.js";
@@ -118,8 +118,8 @@ const SDK_TO_PI_TOOL_NAME: Record<string, string> = {
 // MODELS is buildModels(getModels("anthropic")) — projection kept in models.js.
 const MODELS = buildModels(getModels("anthropic"));
 
-function resolveModelId(input: string): string {
-	return _resolveModelId(MODELS, input);
+function resolveModel(input: string) {
+	return _resolveModel(MODELS, input);
 }
 
 // --- Error handling ---
@@ -980,7 +980,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 			?? REASONING_TO_EFFORT[options.reasoning]
 		: undefined;
 
-	const extraArgs: Record<string, string | null> = { model: model.id };
+	const extraArgs: Record<string, string | null> = { model: claudeCodeModelId(model) };
 	if (strictMcpConfigEnabled) extraArgs["strict-mcp-config"] = null;
 	// Opus 4.7 defaults thinking.display to "omitted" (empty thinking text in stream).
 	// Force summarized so thinking_delta events arrive. See anthropics/claude-agent-sdk-python#830.
@@ -1173,7 +1173,10 @@ async function promptAndWait(
 	},
 ): Promise<{ responseText: string; stopReason: string }> {
 	const cwd = process.cwd();
-	const modelId = resolveModelId(options?.model ?? "opus");
+	const requestedModel = options?.model ?? "opus";
+	const model = resolveModel(requestedModel);
+	const modelId = model?.id ?? requestedModel;
+	const cliModel = model ? claudeCodeModelId(model) : modelId;
 
 	// Session resume for shared mode — reuse provider's session if it exists,
 	// otherwise create one from pi's context.
@@ -1208,12 +1211,12 @@ async function promptAndWait(
 
 	const extraArgs: Record<string, string | null> = {
 		"strict-mcp-config": null,
-		model: modelId,
+		model: cliModel,
 	};
 	if (effort) extraArgs["thinking-display"] = "summarized";
 
 	debug("askClaude:",
-		`mode=${mode} model=${modelId} effort=${effort ?? "default"}`,
+		`mode=${mode} model=${modelId} cliModel=${cliModel} effort=${effort ?? "default"}`,
 		`isolated=${options?.isolated ?? false} resume=${resumeSessionId?.slice(0, 8) ?? "none"}`,
 		`skills=${Boolean(skillsBlock)} promptLen=${prompt.length}`);
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,25 +1,45 @@
 // Canonical selection + display order for the model picker.
-// `resolveModelId` returns the first partial match, so `opus` resolves to the first-listed opus entry.
+// `resolveModel` returns the first partial match, so `opus` resolves to the first-listed opus entry.
 // Extracted from index.ts so tests can import without activating the extension.
 
 export const MODEL_IDS_IN_ORDER = ["claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
 
 // Project pi-ai's model entries down to the fields pi's registerProvider expects,
 // and keep MODEL_IDS_IN_ORDER ordering. IDs missing from pi-ai are silently dropped.
+//
+// Models with a >200K advertised window get a visible [1m] suffix in the
+// display name, but keep their registered ids stable/bare. The spawned Claude
+// Code CLI enables its 1M context window only when the model string passed to
+// --model contains [1m], so claudeCodeModelId() adds that suffix at the CLI
+// boundary. Unlike the context-1m-2025-08-07 beta (issue #24), this works under
+// Pro/Max subscription (OAuth) auth, where the CLI ignores custom betas
+// ("Custom betas are only available for API key users.").
 export function buildModels<T extends { id: string; [key: string]: any }>(piAiModels: T[]) {
 	return MODEL_IDS_IN_ORDER
 		.map((id) => piAiModels.find((m) => m.id === id))
 		.filter((m) => m != null)
 		// Forward thinkingLevelMap so per-model overrides (e.g. opus-4-7 mapping
 		// xhigh→xhigh instead of xhigh→max) are visible to the effort lookup.
-		.map(({ id, name, reasoning, input, contextWindow, maxTokens, thinkingLevelMap }) => ({
-			id, name, reasoning, input, contextWindow, maxTokens, thinkingLevelMap,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		}));
+		.map(({ id, name, reasoning, input, contextWindow, maxTokens, thinkingLevelMap }) => {
+			const oneM = hasOneMContext({ contextWindow });
+			return {
+				id,
+				name: oneM && typeof name === "string" && !name.includes("[1m]") ? `${name} [1m]` : name,
+				reasoning, input, contextWindow, maxTokens, thinkingLevelMap,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			};
+		});
 }
 
-export function resolveModelId(models: Array<{ id: string }>, input: string): string {
+export function hasOneMContext(model: { contextWindow?: number | null }): boolean {
+	return (model.contextWindow ?? 0) > 200_000;
+}
+
+export function claudeCodeModelId(model: { id: string; contextWindow?: number | null }): string {
+	return hasOneMContext(model) && !model.id.includes("[1m]") ? `${model.id}[1m]` : model.id;
+}
+
+export function resolveModel<T extends { id: string }>(models: T[], input: string): T | undefined {
 	const lower = input.toLowerCase();
-	const match = models.find((m) => m.id === lower || m.id.includes(lower));
-	return match ? match.id : input;
+	return models.find((m) => m.id === lower || m.id.includes(lower));
 }

--- a/tests/unit-models.mjs
+++ b/tests/unit-models.mjs
@@ -1,11 +1,11 @@
 /**
- * Tests for MODELS construction + resolveModelId.
+ * Tests for MODELS construction + resolveModel.
  * Pins: opus shortcut resolves to whichever opus is first in MODEL_IDS_IN_ORDER,
  * projection strips pi-ai's baseUrl/api/provider/headers, and ordering is preserved.
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { MODEL_IDS_IN_ORDER, buildModels, resolveModelId } from "../src/models.js";
+import { MODEL_IDS_IN_ORDER, buildModels, claudeCodeModelId, resolveModel } from "../src/models.js";
 
 // Simulated pi-ai registry entry — extra fields mimic the ones pi-ai exposes
 // that must not leak into the provider-registered MODELS array.
@@ -45,24 +45,54 @@ describe("MODELS projection", () => {
 			assert.deepEqual(m.cost, { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
 		}
 	});
+
+	it("appends [1m] to display names but keeps ids bare for >200K-context models", () => {
+		const oneM = (id) => ({ ...mockPiAiModel(id), contextWindow: 1000000 });
+		const models = buildModels(MODEL_IDS_IN_ORDER.map(oneM));
+		assert.deepEqual(models.map((m) => m.id), MODEL_IDS_IN_ORDER);
+		for (const m of models) {
+			assert.ok(m.name.endsWith("[1m]"), `${m.name} should end with [1m]`);
+			assert.equal(m.contextWindow, 1000000);
+		}
+	});
+
+	it("leaves <=200K-context display names unsuffixed", () => {
+		// mockPiAiModel pins contextWindow at exactly 200000 (the default window).
+		const models = buildModels(MODEL_IDS_IN_ORDER.map(mockPiAiModel));
+		assert.deepEqual(models.map((m) => m.id), MODEL_IDS_IN_ORDER);
+		assert.ok(models.every((m) => !m.name.endsWith("[1m]")));
+	});
 });
 
-describe("resolveModelId", () => {
+describe("resolveModel", () => {
 	const models = buildModels(MODEL_IDS_IN_ORDER.map(mockPiAiModel));
 
 	it("opus shortcut resolves to claude-opus-4-8 (first opus in order)", () => {
-		assert.equal(resolveModelId(models, "opus"), "claude-opus-4-8");
+		assert.equal(resolveModel(models, "opus")?.id, "claude-opus-4-8");
 	});
 
 	it("haiku shortcut resolves to claude-haiku-4-5", () => {
-		assert.equal(resolveModelId(models, "haiku"), "claude-haiku-4-5");
+		assert.equal(resolveModel(models, "haiku")?.id, "claude-haiku-4-5");
 	});
 
-	it("full ID passes through unchanged", () => {
-		assert.equal(resolveModelId(models, "claude-opus-4-6"), "claude-opus-4-6");
+	it("full ID resolves to itself", () => {
+		assert.equal(resolveModel(models, "claude-opus-4-6")?.id, "claude-opus-4-6");
 	});
 
-	it("falls through to input when no match", () => {
-		assert.equal(resolveModelId(models, "gpt-9"), "gpt-9");
+	it("returns undefined when no match", () => {
+		assert.equal(resolveModel(models, "gpt-9"), undefined);
+	});
+
+	it("returns the matched model object for CLI-arg conversion", () => {
+		const oneM = (id) => ({ ...mockPiAiModel(id), contextWindow: 1000000 });
+		const oneMModels = buildModels(MODEL_IDS_IN_ORDER.map(oneM));
+		const model = resolveModel(oneMModels, "opus");
+		assert.equal(model.id, "claude-opus-4-8");
+		assert.equal(claudeCodeModelId(model), "claude-opus-4-8[1m]");
+	});
+
+	it("claudeCodeModelId leaves 200K models bare", () => {
+		const model = models.find((m) => m.id === "claude-haiku-4-5");
+		assert.equal(claudeCodeModelId(model), "claude-haiku-4-5");
 	});
 });


### PR DESCRIPTION
## Problem

Sessions on Opus 4.6/4.7/4.8 and Sonnet 4.6 hit `Prompt is too long` once accumulated context crosses ~200K tokens, even though pi advertises these models as 1M context and the status bar shows plenty of headroom. Reported in #24 and #17.

## Root cause

The bridge spawns the Claude Code CLI, which only enables its 1M context window when the model string passed to `--model` carries a `[1m]` suffix. With the bare id (`claude-opus-4-8`) the CLI stays on the 200K default, so the API rejects once the prompt exceeds 200K. Because pi owns compaction (`DISABLE_AUTO_COMPACT=1`), there is no CLI-side safety net to catch it.

**Why the `context-1m-2025-08-07` beta proposed in #24 does not work for this bridge.** This package targets Pro/Max *subscription* (OAuth) auth. Under that auth the spawned CLI discards custom betas — captured from its stderr with a `betas: ["context-1m-2025-08-07"]` patch applied:

```
Warning: Custom betas are only available for API key users. Ignoring provided betas.
```

So the beta path silently no-ops for exactly the audience this bridge serves. The `[1m]` model-id suffix is the opt-in that does work under subscription auth.

## Fix

- `buildModels` gives >200K-window models a visible `[1m]` suffix in their **display name** only; registered pi ids stay bare, so selection strings (`claude-bridge/claude-opus-4-8`) are unchanged.
- `claudeCodeModelId()` appends `[1m]` at the `--model` boundary, applied once each at the provider and AskClaude sites.
- `hasOneMContext()` gates on `contextWindow > 200000`, so any future 1M model qualifies automatically and Haiku 4.5 (200K) stays bare. `pi-ai`'s `Model.contextWindow` is a required field, so the provider-path decision is safe at runtime.
- Generalize `resolveModelId` → `resolveModel` (returns the matched model, so the AskClaude site can derive both the bare id for session keying and the CLI id).

## Verification

- `npm run typecheck` and `npm run test:unit` green (86 tests, including new coverage for the suffix behavior).
- Live: a real subscription session at ~518K tokens that previously threw `Prompt is too long` now runs on both the provider (main inference) and AskClaude paths, with no betas warning.

Fixes #24, #17.
