### PR TITLE
Adaptive thinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## UNRELEASED
+
+- **Add: pi's reasoning slider is now authoritative for adaptive models** — on adaptive-thinking models (every bridge model except Haiku 4.5) the bridge now always passes an explicit thinking config: `off` sends `thinking: disabled` plus a deterministic effort (configurable via `provider.effortWhenReasoningOff`, default `"high"`), and any other level sends `thinking: adaptive` plus the mapped effort. Verified live in both directions: previously `off` still produced thinking (CC defaults thinking ON), and `~/.claude/settings.json` `alwaysThinkingEnabled: false` silently suppressed thinking the slider asked for. Fable 5 can't disable thinking (verified live: it ignores `thinking: disabled`; pi-ai marks `off` unsupported and pi hides it from the slider) — an explicit AskClaude `thinking: "off"` on it clamps to `minimal` instead. Haiku 4.5 is unchanged (budget-based thinking, no effort knob).
+- **Change: AskClaude `thinking` defaults to `high` on adaptive models** — omitting `thinking` previously sent no effort and let Claude Code pick its own settings-dependent default. It now resolves to `high` (Anthropic's recommended starting point) so AskClaude behaves the same regardless of CC settings. Unknown model ids keep the old behavior — no effort sent, CC picks.
+
 ## 0.6.1 — 2026-07-01
 
 - **Add: claude-fable-5 and claude-sonnet-5 models** — Anthropic's Claude Fable 5 (released 2026-06-09) and Sonnet 5 (released 2026-06-30) are now selectable via `/model`. Both ship 1M context only (no 200K variant, no `[1m]` entitlement toggle) and force adaptive thinking. The `fable` and `sonnet` shortcuts resolve to these new models.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Use `/model` to select `claude-bridge/claude-fable-5`, `claude-bridge/claude-opu
 
 Behind the scenes, pi's tools are bridged to Claude Code but it should all work like normal in pi. Bash commands get a 120-second default timeout (matching Claude Code's default) since pi's bash has no timeout by default. Skills in pi are copied over to Claude Code's system prompt so should work as they would with any other pi provider.
 
+**Thinking and effort:** pi's `reasoning` slider sets the API `effort` tier and explicitly enables or disables the reasoning phase, so `~/.claude/settings.json` (`alwaysThinkingEnabled`) can't silently override the slider in either direction. The effort sent when thinking is off defaults to `high` and is configurable via `provider.effortWhenReasoningOff`. Exceptions: Fable 5 can't disable thinking (pi hides `off` for it), and Haiku 4.5 uses old-style budget thinking with no effort tiers.
+
+`xhigh` reasoning resolves differently per model: on Opus 4.6 and Sonnet 4.6 (no real `xhigh` tier, top is `max`) it maps to `max`; on Opus 4.7/4.8 it maps to a genuine `xhigh` tier below `max`. Anthropic's `max` overthinks and costs more — pick it deliberately, not as a default.
+
 **1M Context:** Opus 4.7 and Opus 4.8 get 1M context by default. Opus 4.6 only gets 1M if you're on a Max plan or pay for Extra Usage. Sonnet 4.6 only gets 1M if you pay for Extra Usage. You will need to set `provider.plan` and/or `provider.longContextExtraUsage` for 1M context in Opus 4.6/Sonnet 4.6 as described in [Configuration](#configuration).
 
 ## AskClaude Tool
@@ -46,7 +50,7 @@ You could also create skills or add something to AGENTS.md to e.g. "Always call 
 - **`prompt`** — the question or task for Claude Code
 - **`mode`** — `read` (default, read files and search/fetch on web), `none`, or `full` (read+write+bash, disable this mode with `allowFullMode: false` in config)
 - **`model`** — `opus` (default), `sonnet`, `haiku`, or a full model ID
-- **`thinking`** — effort level: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`
+- **`thinking`** — effort level: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`. Omit for `high` on adaptive-thinking models (deterministic); Haiku and unknown models send no effort when omitted. `off` disables the reasoning phase but still sends effort (see `provider.effortWhenReasoningOff`).
 - **`isolated`** — when `true`, Claude gets a clean session with no conversation history (default: `false`)
 
 ## Configuration
@@ -83,6 +87,7 @@ Config: `~/.pi/agent/claude-bridge.json` (global) or the project Pi config direc
 `provider`:
 - `plan` (default `"pro"`) — set to `"max"` for Max (or Team Premium/Enterprise) to enable Opus 4.6 with 1M context.
 - `longContextExtraUsage` — set to `true` to enable 1M models that cost money through Extra Usage. It enables Sonnet 4.6 with 1M on every plan and Opus 4.6 with 1M on Pro. Not needed for Opus 4.7 or 4.8.
+- `effortWhenReasoningOff` (default `"high"`) — effort sent when pi's reasoning level is `off` on an adaptive-thinking model. One of `low`, `medium`, `high`, `xhigh`, `max`.
 - `appendSystemPrompt` — append pi's AGENTS.md and skills (default `true`)
 - `settingSources` — CC filesystem settings to load; only applied when `appendSystemPrompt: false`
 - `strictMcpConfig` — block MCP servers from `~/.claude.json` / `.mcp.json` (default `true`). Cloud MCP (Gmail/Drive via claude.ai OAuth) is always blocked.

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@
 // overriding global. Missing or unparseable files are ignored (error to
 // console.error, empty object returned) so the extension always starts.
 
-import type { SettingSource } from "@anthropic-ai/claude-agent-sdk";
+import type { EffortLevel, SettingSource } from "@anthropic-ai/claude-agent-sdk";
 import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
 import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
@@ -32,6 +32,11 @@ export interface Config {
 		// Anthropic billing). Enables Sonnet 4.6 [1m] on every plan and Opus 4.6
 		// [1m] on Pro.
 		longContextExtraUsage?: boolean;
+		// Effort sent when pi's reasoning level is "off" on an adaptive-thinking
+		// model. The bridge also passes thinking: disabled so ~/.claude/settings.json
+		// (alwaysThinkingEnabled / effortLevel) can't silently re-enable reasoning
+		// (see resolveThinking in models.ts). Defaults to "high".
+		effortWhenReasoningOff?: EffortLevel;
 	};
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { calculateCost, StringEnum, type AssistantMessage, type AssistantMessage
 import * as piAi from "@earendil-works/pi-ai";
 import { getModels } from "@earendil-works/pi-ai/compat";
 import { buildSessionContext, compact, keyHint, type CompactionEntry, type ExtensionAPI, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
-import { createSdkMcpServer, query, type EffortLevel, type SDKMessage, type SDKUserMessage, type SettingSource } from "@anthropic-ai/claude-agent-sdk";
+import { createSdkMcpServer, query, type SDKMessage, type SDKUserMessage, type SettingSource } from "@anthropic-ai/claude-agent-sdk";
 import type { Base64ImageSource, ContentBlockParam, MessageParam } from "@anthropic-ai/sdk/resources";
 import { Type } from "typebox";
 import { Text } from "@earendil-works/pi-tui";
@@ -11,7 +11,7 @@ import { appendFileSync, mkdirSync, realpathSync, statSync } from "fs";
 import { homedir } from "os";
 import { dirname, join } from "path";
 import { PROVIDER_ID, messageContentToText, convertPiMessages } from "./convert.js";
-import { applyLongContext, buildModels, claudeCodeModelId, type LongContextSettings, resolveModel as _resolveModel } from "./models.js";
+import { applyLongContext, buildModels, claudeCodeModelId, isAdaptiveModel, type LongContextSettings, resolveModel as _resolveModel, resolveThinking } from "./models.js";
 import { MCP_SERVER_NAME, MCP_TOOL_PREFIX, extractSkillsBlock } from "./skills.js";
 import { verifyWrittenSession as _verifyWrittenSession } from "./session-verify.js";
 import { extractAllToolResults as _extractAllToolResults, type McpResult } from "./extract-tool-results.js";
@@ -761,13 +761,6 @@ function logServedContextWindow(label: string, message: SDKMessage, model: Model
 	}
 }
 
-// --- Effort level mapping ---
-// Pi reasoning levels → CC SDK effort levels
-
-const REASONING_TO_EFFORT: Record<string, EffortLevel> = {
-	minimal: "low", low: "low", medium: "medium", high: "high", xhigh: "max",
-};
-
 // --- Provider helpers: misc ---
 
 function mapStopReason(reason: string | undefined): "stop" | "length" | "toolUse" {
@@ -1216,22 +1209,21 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	const strictMcpConfigEnabled = providerSettings.strictMcpConfig !== false;
 	const claudeExecutable = providerSettings.pathToClaudeCodeExecutable;
 
-	// Prefer the model's own thinkingLevelMap when present (pi-ai 0.72+ ships
-	// per-model overrides — e.g. opus-4-7 wants xhigh→xhigh, not xhigh→max).
-	// Fall back to our generic table for older pi-ai or unmapped levels.
-	const effort = options?.reasoning
-		? ((model as any).thinkingLevelMap?.[options.reasoning] as EffortLevel | undefined)
-			?? REASONING_TO_EFFORT[options.reasoning]
-		: undefined;
+	const { effort, thinking } = resolveThinking(
+		model.id,
+		options?.reasoning,
+		providerSettings.effortWhenReasoningOff ?? "high",
+		(model as any).thinkingLevelMap,
+	);
 
 	// cliModel is the actual id sent to Claude Code (may carry [1m]); model.id is the
 	// pi-registered id. Log cliModel so debug lines reflect what CC actually received.
 	const cliModel = claudeCodeModelId(model, longContextSettings);
 	const extraArgs: Record<string, string | null> = { model: cliModel };
 	if (strictMcpConfigEnabled) extraArgs["strict-mcp-config"] = null;
-	// Opus 4.7 defaults thinking.display to "omitted" (empty thinking text in stream).
-	// Force summarized so thinking_delta events arrive. See anthropics/claude-agent-sdk-python#830.
-	if (effort) extraArgs["thinking-display"] = "summarized";
+	// Non-adaptive models with a level (Haiku) get no typed thinking config;
+	// keep forcing summarized display for them as before.
+	if (effort && !thinking) extraArgs["thinking-display"] = "summarized";
 
 	// Suppress claude.ai cloud MCP servers (Figma/Canva/etc. auto-discovered via OAuth
 	// when the user is logged into Anthropic). These are a separate code path from
@@ -1256,6 +1248,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		},
 		extraArgs,
 		...(effort ? { effort } : {}),
+		...(thinking ? { thinking } : {}),
 		...(settingSources ? { settingSources } : {}),
 		...(mcpServers ? { mcpServers } : {}),
 		...(resumeSessionId ? { resume: resumeSessionId } : {}),
@@ -1265,7 +1258,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 
 	debug("provider: fresh query",
 		`model=${cliModel} msgs=${context.messages.length} tools=${mcpTools.length}`,
-		`resume=${resumeSessionId?.slice(0, 8) ?? "none"} effort=${effort ?? "default"}`,
+		`resume=${resumeSessionId?.slice(0, 8) ?? "none"} thinking=${thinking?.type ?? "default"} effort=${effort ?? "default"}`,
 		`appendSys=${appendSystemPrompt} strictMcp=${strictMcpConfigEnabled}`,
 		`prompt=${promptText.slice(0, 60)}${promptBlocks ? " [+images]" : ""}`);
 
@@ -1465,9 +1458,16 @@ async function promptAndWait(
 	const skillsBlock = options?.appendSkills !== false && options?.systemPrompt
 		? extractSkillsBlock(options.systemPrompt) : undefined;
 
-	// Effort
-	const effort = options?.thinking && options.thinking !== "off"
-		? REASONING_TO_EFFORT[options.thinking] : undefined;
+	// Omitted thinking defaults to "high" on adaptive models so AskClaude behaves
+	// the same regardless of CC settings; non-adaptive/unknown models keep the old
+	// behavior — send nothing, let CC pick — since they may not support effort.
+	const reasoning = options?.thinking ?? (isAdaptiveModel(modelId) ? "high" : undefined);
+	const { effort, thinking } = resolveThinking(
+		modelId,
+		reasoning,
+		providerSettings.effortWhenReasoningOff ?? "high",
+		(model as any)?.thinkingLevelMap,
+	);
 
 	const claudeExecutable = providerSettings.pathToClaudeCodeExecutable;
 
@@ -1475,10 +1475,12 @@ async function promptAndWait(
 		"strict-mcp-config": null,
 		model: cliModel,
 	};
-	if (effort) extraArgs["thinking-display"] = "summarized";
+	// Non-adaptive models with a level (Haiku, unknown ids) get no typed thinking
+	// config; keep forcing summarized display for them as before.
+	if (effort && !thinking) extraArgs["thinking-display"] = "summarized";
 
 	debug("askClaude:",
-		`mode=${mode} model=${modelId} cliModel=${cliModel} effort=${effort ?? "default"}`,
+		`mode=${mode} model=${modelId} cliModel=${cliModel} thinking=${thinking?.type ?? "default"} effort=${effort ?? "default"}`,
 		`isolated=${options?.isolated ?? false} resume=${resumeSessionId?.slice(0, 8) ?? "none"}`,
 		`skills=${Boolean(skillsBlock)} promptLen=${prompt.length}`);
 
@@ -1490,6 +1492,7 @@ async function promptAndWait(
 			permissionMode: "bypassPermissions",
 			...(disallowedTools.length ? { disallowedTools } : {}),
 			...(effort ? { effort } : {}),
+			...(thinking ? { thinking } : {}),
 			systemPrompt: skillsBlock
 				? { type: "preset", preset: "claude_code", append: skillsBlock }
 				: undefined,
@@ -1718,7 +1721,7 @@ export default function (pi: ExtensionAPI) {
 			prompt: Type.String({ description: "The question or task for Claude Code. By default Claude sees the full conversation history. Don't research up front, let Claude explore." }),
 			mode: Type.Optional(StringEnum(modeValues, { description: modeDesc })),
 			model: Type.Optional(Type.String({ description: 'Claude model (e.g. "opus", "sonnet", "haiku", or full ID). Defaults to "opus".' })),
-			thinking: Type.Optional(StringEnum(["off", "minimal", "low", "medium", "high", "xhigh"] as const, { description: "Thinking effort level. Omit to use Claude Code's default." })),
+			thinking: Type.Optional(StringEnum(["off", "minimal", "low", "medium", "high", "xhigh"] as const, { description: "Reasoning effort. Omit for a sensible default (high). Use lower for faster/cheaper answers, higher for harder problems." })),
 			isolated: Type.Optional(Type.Boolean({ description: "When true, Claude sees only this prompt (clean session). When false (default), Claude sees the full conversation history." })),
 		});
 		pi.registerTool<typeof askClaudeParams>({

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,6 +2,8 @@
 // `resolveModel` returns the first partial match, so `opus` resolves to the first-listed opus entry.
 // Extracted from index.ts so tests can import without activating the extension.
 
+import type { EffortLevel, ThinkingConfig } from "@anthropic-ai/claude-agent-sdk";
+
 export const MODEL_IDS_IN_ORDER = ["claude-fable-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-5", "claude-sonnet-4-6", "claude-haiku-4-5"];
 
 // Project pi-ai's model entries down to the fields pi's registerProvider expects,
@@ -89,4 +91,71 @@ export function applyLongContext<T extends { id: string; name: string; contextWi
 		const name = contextWindow > TWO_HUNDRED_K_CONTEXT && !/\b1M\b/i.test(m.name) ? `${m.name} 1M` : m.name;
 		return contextWindow === m.contextWindow && name === m.name ? m : { ...m, contextWindow, name };
 	});
+}
+
+// --- Adaptive thinking + effort resolution ---
+//
+// On adaptive-thinking models (all 4.6+ Claude models) `thinking` is a separate
+// on/off axis from `effort`: thinking=disabled skips the reasoning phase
+// entirely, effort still governs output thoroughness. Every bridge model is
+// adaptive except Haiku 4.5 (budget-based thinking, no effort knob). Unknown
+// ids (arbitrary AskClaude model params) are treated as non-adaptive so we
+// never send flags a model might not support.
+const BUDGET_THINKING_MODEL_IDS = new Set(["claude-haiku-4-5"]);
+
+export function isAdaptiveModel(modelId: string): boolean {
+	return MODEL_IDS_IN_ORDER.includes(modelId) && !BUDGET_THINKING_MODEL_IDS.has(modelId);
+}
+
+// Fallback effort map for levels a model's thinkingLevelMap doesn't override.
+// pi-ai ships only the xhigh override per model (e.g. opus-4-7: {xhigh:"xhigh"},
+// opus-4-6: {xhigh:"max"}); low/medium/high fall through here.
+const REASONING_TO_EFFORT: Record<string, EffortLevel> = {
+	minimal: "low", low: "low", medium: "medium", high: "high", xhigh: "max",
+};
+
+export interface ThinkingResolution {
+	/** Effort to pass to the SDK, or undefined to send none (CC picks). */
+	effort?: EffortLevel;
+	/** SDK thinking option. Always set for adaptive models so pi's slider is
+	 * authoritative: `~/.claude/settings.json` (`alwaysThinkingEnabled`) can
+	 * neither re-enable reasoning when off nor disable it when on (both verified
+	 * live — without an explicit flag, settings win in each direction). */
+	thinking?: ThinkingConfig;
+}
+
+const ADAPTIVE_ON: ThinkingConfig = {
+	type: "adaptive",
+	// Opus 4.7 defaults thinking.display to "omitted" (empty thinking text in
+	// stream). Force summarized so thinking_delta events arrive.
+	// See anthropics/claude-agent-sdk-python#830.
+	display: "summarized",
+};
+
+// Resolve pi's reasoning level into SDK thinking/effort options for one model.
+// pi sends `reasoning: undefined` when its thinking slider is off (see
+// pi-mono agent.ts); AskClaude passes the literal "off". Both mean off here.
+//   - adaptive + off   → thinking disabled, effort = effortWhenOff — deterministic
+//                        instead of falling back to CC's settings-dependent default.
+//                        If pi-ai marks off unsupported (thinkingLevelMap.off === null)
+//                        clamp to minimal like pi's own slider does — fable-5 ignores
+//                        thinking:disabled and thinks anyway (verified live).
+//   - adaptive + level → thinking adaptive, effort from the model's thinkingLevelMap
+//                        or the fallback table
+//   - non-adaptive     → legacy: effort from table, no thinking flag; off sends nothing
+export function resolveThinking(
+	modelId: string,
+	reasoning: string | undefined,
+	effortWhenOff: EffortLevel,
+	thinkingLevelMap?: Record<string, string | null>,
+): ThinkingResolution {
+	let level = reasoning ?? "off";
+	if (level === "off") {
+		if (!isAdaptiveModel(modelId)) return {};
+		if (thinkingLevelMap?.off !== null) return { effort: effortWhenOff, thinking: { type: "disabled" } };
+		level = "minimal";
+	}
+	const mapped = thinkingLevelMap?.[level] as EffortLevel | undefined;
+	const effort = mapped ?? REASONING_TO_EFFORT[level];
+	return isAdaptiveModel(modelId) ? { effort, thinking: ADAPTIVE_ON } : { effort };
 }

--- a/tests/int-thinking-off.mjs
+++ b/tests/int-thinking-off.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// End-to-end check that the bridge's thinking options make pi's slider
+// authoritative over ~/.claude/settings.json in BOTH directions:
+//   - reasoning=off suppresses thinking even when settings force it on
+//     (alwaysThinkingEnabled: true)
+//   - reasoning=high produces thinking even when settings disable it
+//     (alwaysThinkingEnabled: false)
+// Without explicit thinking flags, settings win in each direction (verified
+// live while developing this feature) — these tests pin the fix.
+//
+// Calls the Claude Agent SDK `query()` directly with the bridge's option
+// shape (effort + thinking from resolveThinking) plus adversarial inline
+// `--settings`, then inspects the streamed assistant content for `thinking`
+// blocks. This is the only layer that proves CC honors the flags — the bridge
+// log only shows what we passed in, not what ran.
+//
+// off-direction is deterministic (disabled => no thinking blocks). The
+// on-direction uses a reasoning-heavy prompt; a model can in principle skip
+// thinking on a trivial prompt, but long multiplication reliably triggers it.
+//
+// Requires: ANTHROPIC_API_KEY or CC logged in.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { resolveThinking } from "../src/models.js";
+
+const CWD = process.cwd();
+const MODEL = "claude-opus-4-7";
+const REASONING_PROMPT = "Compute 247 × 389 by hand using long multiplication, showing each partial product. Then verify the result a second way (for example 247 × 400 − 247 × 11) and confirm both match.";
+const TIMEOUT = 120_000;
+
+function optionsFor(reasoning, settings) {
+	const { effort, thinking } = resolveThinking(MODEL, reasoning, "high", { xhigh: "xhigh" });
+	return {
+		cwd: CWD,
+		env: { ...process.env, DISABLE_AUTO_COMPACT: "1", ENABLE_CLAUDEAI_MCP_SERVERS: "0" },
+		permissionMode: "bypassPermissions",
+		model: MODEL,
+		systemPrompt: { type: "preset", preset: "claude_code" },
+		extraArgs: { "strict-mcp-config": null },
+		...(effort ? { effort } : {}),
+		...(thinking ? { thinking } : {}),
+		...(settings ? { settings: JSON.stringify(settings) } : {}),
+	};
+}
+
+async function countThinkingBlocks(reasoning, settings) {
+	let thinkingBlocks = 0;
+	let text = "";
+	const q = query({ prompt: REASONING_PROMPT, options: optionsFor(reasoning, settings) });
+	for await (const m of q) {
+		if (m.type !== "assistant") continue;
+		for (const block of m.message?.content ?? []) {
+			if (block.type === "thinking") thinkingBlocks++;
+			else if (block.type === "text") text += block.text;
+		}
+	}
+	return { thinkingBlocks, text: text.trim() };
+}
+
+test("reasoning=off emits no thinking blocks despite alwaysThinkingEnabled:true", { timeout: TIMEOUT }, async () => {
+	const { thinkingBlocks, text } = await countThinkingBlocks("off", { alwaysThinkingEnabled: true });
+	assert.equal(thinkingBlocks, 0, `expected no thinking blocks with reasoning=off, got ${thinkingBlocks}`);
+	assert.ok(text.length > 0, "expected a text response");
+});
+
+test("reasoning=high emits thinking blocks despite alwaysThinkingEnabled:false", { timeout: TIMEOUT }, async () => {
+	const { thinkingBlocks, text } = await countThinkingBlocks("high", { alwaysThinkingEnabled: false });
+	assert.ok(thinkingBlocks > 0, `expected thinking blocks with reasoning=high, got ${thinkingBlocks} (text: ${text.slice(0, 80)})`);
+});

--- a/tests/unit-models.mjs
+++ b/tests/unit-models.mjs
@@ -5,7 +5,7 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { MODEL_IDS_IN_ORDER, applyLongContext, buildModels, claudeCodeModelId, resolveClaudeCodeRuntimeModel, resolveModel } from "../src/models.js";
+import { MODEL_IDS_IN_ORDER, applyLongContext, buildModels, claudeCodeModelId, isAdaptiveModel, resolveClaudeCodeRuntimeModel, resolveModel, resolveThinking } from "../src/models.js";
 
 const PRO = { plan: "pro", longContextExtraUsage: false };
 const MAX = { plan: "max", longContextExtraUsage: false };
@@ -166,5 +166,64 @@ describe("resolveModel", () => {
 		const model = resolveModel(oneMModels, "opus");
 		assert.equal(model.id, "claude-opus-4-8");
 		assert.equal(claudeCodeModelId(model, PRO), "claude-opus-4-8[1m]");
+	});
+});
+
+describe("isAdaptiveModel", () => {
+	it("every bridge model except Haiku is adaptive", () => {
+		for (const id of MODEL_IDS_IN_ORDER) {
+			assert.equal(isAdaptiveModel(id), id !== "claude-haiku-4-5", id);
+		}
+	});
+
+	it("unknown ids are not adaptive (arbitrary AskClaude model params)", () => {
+		assert.equal(isAdaptiveModel("gpt-9"), false);
+		assert.equal(isAdaptiveModel("claude-opus-4-7-20251115"), false);
+	});
+});
+
+describe("resolveThinking", () => {
+	const r = (modelId, reasoning, map) => resolveThinking(modelId, reasoning, "high", map);
+	const ADAPTIVE_ON = { type: "adaptive", display: "summarized" };
+
+	it("adaptive + undefined (pi slider off) → thinking disabled with effortWhenOff", () => {
+		assert.deepEqual(r("claude-opus-4-7", undefined), { effort: "high", thinking: { type: "disabled" } });
+	});
+
+	it('adaptive + literal "off" (AskClaude) → same as undefined', () => {
+		assert.deepEqual(r("claude-sonnet-5", "off"), { effort: "high", thinking: { type: "disabled" } });
+	});
+
+	it("respects a custom effortWhenOff", () => {
+		assert.deepEqual(resolveThinking("claude-opus-4-7", "off", "max"), { effort: "max", thinking: { type: "disabled" } });
+	});
+
+	it("off unsupported per pi-ai map (fable-5) → clamps to minimal, thinking stays adaptive", () => {
+		assert.deepEqual(r("claude-fable-5", "off", { off: null, xhigh: "xhigh" }), { effort: "low", thinking: ADAPTIVE_ON });
+	});
+
+	it("xhigh prefers the model thinkingLevelMap (opus-4-7 → xhigh, opus-4-6 → max)", () => {
+		assert.deepEqual(r("claude-opus-4-7", "xhigh", { xhigh: "xhigh" }), { effort: "xhigh", thinking: ADAPTIVE_ON });
+		assert.deepEqual(r("claude-opus-4-6", "xhigh", { xhigh: "max" }), { effort: "max", thinking: ADAPTIVE_ON });
+	});
+
+	it("xhigh with no map falls back to the table (sonnet-4-6 → max)", () => {
+		assert.deepEqual(r("claude-sonnet-4-6", "xhigh"), { effort: "max", thinking: ADAPTIVE_ON });
+	});
+
+	it("minimal/low/medium/high fall through to the table, thinking explicitly adaptive", () => {
+		assert.deepEqual(r("claude-opus-4-7", "minimal"), { effort: "low", thinking: ADAPTIVE_ON });
+		assert.deepEqual(r("claude-opus-4-7", "high"), { effort: "high", thinking: ADAPTIVE_ON });
+	});
+
+	it("haiku keeps legacy behavior: level → table effort, off/undefined → nothing", () => {
+		assert.deepEqual(r("claude-haiku-4-5", "high"), { effort: "high" });
+		assert.deepEqual(r("claude-haiku-4-5", "off"), {});
+		assert.deepEqual(r("claude-haiku-4-5", undefined), {});
+	});
+
+	it("unknown model → legacy behavior, never sends a thinking flag", () => {
+		assert.deepEqual(r("gpt-9", "off"), {});
+		assert.deepEqual(r("gpt-9", "high"), { effort: "high" });
 	});
 });


### PR DESCRIPTION
Based on https://github.com/elidickinson/pi-claude-bridge/pull/14 — rebuilt on 0.6.1 (sonnet-5/fable-5, pi 0.80 APIs).

- **pi's reasoning slider is authoritative (provider + AskClaude)**: adaptive models always get an explicit SDK `thinking` config — `{type: disabled}` when the slider is off (with deterministic effort, configurable via `provider.effortWhenReasoningOff`, default `high`), `{type: adaptive, display: summarized}` otherwise. Verified live in both directions: without explicit flags, slider-off still produced thinking (CC defaults ON), and `alwaysThinkingEnabled: false` in `~/.claude/settings.json` silently suppressed thinking the slider asked for.
- **Adaptive = every bridge model except Haiku 4.5** (budget thinking, no effort knob), derived from `MODEL_IDS_IN_ORDER` so future models are covered automatically. Unknown AskClaude model ids keep legacy behavior (no flags sent).
- **fable-5**: ignores `thinking: disabled` (verified live — thinks anyway). pi-ai marks `off` unsupported (`thinkingLevelMap.off === null`) and pi hides it from the slider; an explicit AskClaude `thinking: "off"` clamps to `minimal` like pi's own slider does.
- **AskClaude default**: omitted `thinking` resolves to `high` on adaptive models (deterministic, avoids xhigh→max on 4.6 models); Haiku/unknown ids send nothing — old behavior preserved.
- **Simplified**: two exported helpers (`isAdaptiveModel`, `resolveThinking`) instead of five; SDK's typed `thinking` option replaces the untyped `--thinking` / `--thinking-display` extraArgs (except the Haiku display case).
- **Int test** pins the adversarial settings cases: reasoning=off vs `alwaysThinkingEnabled: true` → 0 thinking blocks, reasoning=high vs `alwaysThinkingEnabled: false` → thinking blocks (Opus 4.7, live API, inline `--settings` so the real config is untouched).