### PR TITLE
Add claude-sonnet-5 model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- **Add: claude-sonnet-5 model** — Anthropic's Claude Sonnet 5 (released 2026-06-30) is now selectable via `/model claude-bridge/claude-sonnet-5`. The `sonnet` shortcut now resolves to Sonnet 5; Sonnet 4.6 remains available for explicit pinning. Per Anthropic, Sonnet 5 ships 1M context only (no 200K variant, no `[1m]` entitlement toggle), forces adaptive thinking, and rejects non-default `temperature`/`top_p`/`top_k` (returns 400). pi-ai's catalog supplies the metadata; runtime policy matches the measured Agent SDK behavior for the other 1M-only models (Opus 4.7/4.8).
+
 ## 0.6.0 — 2026-06-29
 
 - **Fix: `/compact` hang (issue #18)** — the bridge now owns compaction for claude-bridge models, running split-turn summaries as isolated Claude Code subprocesses instead of routing them through the live provider stream. File ops (`<read-files>`/`<modified-files>`) carry forward across compactions. If compaction fails it is cancelled with a notification rather than falling back to the buggy native path.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pi install npm:pi-claude-bridge
 
 ## Provider
 
-Use `/model` to select `claude-bridge/claude-opus-4-8`, `claude-bridge/claude-opus-4-7`, `claude-bridge/claude-opus-4-6`, `claude-bridge/claude-sonnet-4-6`, or `claude-bridge/claude-haiku-4-5`.
+Use `/model` to select `claude-bridge/claude-opus-4-8`, `claude-bridge/claude-opus-4-7`, `claude-bridge/claude-opus-4-6`, `claude-bridge/claude-sonnet-5`, `claude-bridge/claude-sonnet-4-6`, or `claude-bridge/claude-haiku-4-5`.
 
 Behind the scenes, pi's tools are bridged to Claude Code but it should all work like normal in pi. Bash commands get a 120-second default timeout (matching Claude Code's default) since pi's bash has no timeout by default. Skills in pi are copied over to Claude Code's system prompt so should work as they would with any other pi provider.
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,7 +2,7 @@
 // `resolveModel` returns the first partial match, so `opus` resolves to the first-listed opus entry.
 // Extracted from index.ts so tests can import without activating the extension.
 
-export const MODEL_IDS_IN_ORDER = ["claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
+export const MODEL_IDS_IN_ORDER = ["claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-5", "claude-sonnet-4-6", "claude-haiku-4-5"];
 
 // Project pi-ai's model entries down to the fields pi's registerProvider expects,
 // and keep MODEL_IDS_IN_ORDER ordering. IDs missing from pi-ai are silently dropped.
@@ -50,6 +50,9 @@ export function resolveClaudeCodeRuntimeModel(modelId: string, settings: LongCon
 				contextWindow: useOneM ? ONE_M_CONTEXT : TWO_HUNDRED_K_CONTEXT,
 			};
 		}
+		case "claude-sonnet-5":
+			// Sonnet 5 ships 1M-only; no [1m] entitlement toggle, no 200K variant.
+			return { cliModelId: "claude-sonnet-5", contextWindow: ONE_M_CONTEXT };
 		case "claude-sonnet-4-6":
 			return {
 				cliModelId: settings.longContextExtraUsage ? "claude-sonnet-4-6[1m]" : "claude-sonnet-4-6",


### PR DESCRIPTION
## What

Adds Claude Sonnet 5 to the bridge's model picker. After this PR, `/model claude-bridge/claude-sonnet-5` is selectable, and the bare `sonnet` shortcut resolves to Sonnet 5 (Sonnet 4.6 stays available for explicit pinning).

## Why

Anthropic released Claude Sonnet 5 on 2026-06-30. It is a drop-in upgrade to Sonnet 4.6 and is now the default Sonnet-tier model on Anthropic's Free and Pro tiers. The bridge should expose it.

## How

- `src/models.ts`: insert `claude-sonnet-5` into `MODEL_IDS_IN_ORDER` before `claude-sonnet-4-6` (preserves the first-partial-match shortcut behavior), and add a `case` in `resolveClaudeCodeRuntimeModel` that returns the 1M context window unconditionally. Sonnet 5 has no 200K variant and no `[1m]` entitlement toggle, so the case mirrors the 1M-only Opus 4.7/4.8 cases.
- `README.md`: add the new model ID to the `/model` picker list.
- `CHANGELOG.md`: add an `UNRELEASED` entry under the `Add` tag, per the repo's `AGENTS.md` convention.

Two things worth flagging for review:

1. **Sonnet 5 forces adaptive thinking and rejects non-default sampling parameters.** pi-ai's catalog entry already sets `forceAdaptiveThinking: true` and the bridge forwards `thinkingLevelMap`, so the thinking part should just work. If `src/convert.ts` forwards `temperature`/`top_p`/`top_k` set to non-default values, requests to Sonnet 5 will return 400 (same constraint Anthropic introduced on Opus 4.7). I did not change `convert.ts` in this PR. If the bridge currently passes those fields through, a follow-up PR may be needed to strip them when the model is Sonnet 5.
2. **The runtime context-window policy for Sonnet 5 was not empirically measured against the live Agent SDK.** I extrapolated from the 1M-only Opus cases and from Anthropic's "1M is both default and max" doc. If measured behavior differs, adjust the `case` in `resolveClaudeCodeRuntimeModel` (the same place Opus 4.7/4.8 were measured and corrected per `diag/CONTEXT-SIZE.md`).

## Testing

- [x] `npm run typecheck` (tsc --noEmit) clean
- [x] `npm run test:unit` 96/96 pass
