### PR TITLE
Add Claude subscription usage meter (footer + /claude-usage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Add: Claude subscription usage meter** — an always-on footer statusline (e.g. `Claude 5h 44% (Res. 13:50) · 7d 23% (Res. Mon)`, percent used with per-window reset hints) plus a `/claude-usage` command for the full breakdown (5-hour + 7-day windows, reset times, metered extra usage). Data comes from the same `api.anthropic.com/api/oauth/usage` endpoint Claude Code's own `/usage` screen uses — read via the existing Claude Code OAuth token (macOS Keychain or `~/.claude/.credentials.json`), nothing sent elsewhere. The footer also refreshes for free from the `rate_limit_event` metadata the bridge already receives while you work. Toggle the footer live with `/claude-usage on`/`off`; configure via `usageMeter.enabled` / `usageMeter.refreshMinutes`.
+
 ## 0.6.1 — 2026-07-01
 
 - **Add: claude-fable-5 and claude-sonnet-5 models** — Anthropic's Claude Fable 5 (released 2026-06-09) and Sonnet 5 (released 2026-06-30) are now selectable via `/model`. Both ship 1M context only (no 200K variant, no `[1m]` entitlement toggle) and force adaptive thinking. The `fable` and `sonnet` shortcuts resolve to these new models.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## UNRELEASED
 
 - **Add: Claude subscription usage meter** — an always-on footer statusline (e.g. `Claude 5h 44% (Res. 13:50) · 7d 23% (Res. Mon)`, percent used with per-window reset hints) plus a `/claude-usage` command for the full breakdown (5-hour + 7-day windows, reset times, metered extra usage). Data comes from the same `api.anthropic.com/api/oauth/usage` endpoint Claude Code's own `/usage` screen uses — read via the existing Claude Code OAuth token (macOS Keychain or `~/.claude/.credentials.json`), nothing sent elsewhere. The footer also refreshes for free from the `rate_limit_event` metadata the bridge already receives while you work. Toggle the footer live with `/claude-usage on`/`off`; configure via `usageMeter.enabled` / `usageMeter.refreshMinutes`.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ You could also create skills or add something to AGENTS.md to e.g. "Always call 
 - **`thinking`** — effort level: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`
 - **`isolated`** — when `true`, Claude gets a clean session with no conversation history (default: `false`)
 
+## Usage Meter
+
+Shows how much of your Claude subscription quota is left, using the same `api.anthropic.com/api/oauth/usage` endpoint as Claude Code's own `/usage` screen (read via your existing Claude Code OAuth token; nothing is sent anywhere else).
+
+- **Footer statusline** — an always-on meter like `Claude 5h 19% (Res. 12:50) · 7d 21% (Res. Sat)` (percentages are *used*; `Res.` is when each window resets — clock time for the 5-hour window, weekday for the 7-day window). It refreshes on session start, on a timer, and for free from the rate-limit metadata Claude returns as you work.
+- **`/claude-usage` command** — prints the full breakdown on demand: the 5-hour session window, the 7-day window, per-window reset times, and metered extra usage when enabled.
+- **`/claude-usage on` / `off`** — toggle the footer meter live for the current session (tab-completes `on`/`off`). The persistent default is the `usageMeter.enabled` config key below; the command overrides it until the next restart. A bare `/claude-usage` still prints the panel even when the footer is hidden.
+
+The token is read from the macOS Keychain (`Claude Code-credentials`) or `~/.claude/.credentials.json` on other platforms. If no token is found the meter stays silent.
+
 ## Configuration
 
 Config: `~/.pi/agent/claude-bridge.json` (global) or the project Pi config directory, usually `.pi/claude-bridge.json` (project; merged over global).
@@ -66,6 +76,10 @@ Config: `~/.pi/agent/claude-bridge.json` (global) or the project Pi config direc
     "longContextExtraUsage": false,
     "strictMcpConfig": true,
     "pathToClaudeCodeExecutable": "/home/you/.nix-profile/bin/claude"
+  },
+  "usageMeter": {
+    "enabled": true,
+    "refreshMinutes": 5
   }
 }
 ```
@@ -88,6 +102,10 @@ Config: `~/.pi/agent/claude-bridge.json` (global) or the project Pi config direc
 - `strictMcpConfig` — block MCP servers from `~/.claude.json` / `.mcp.json` (default `true`). Cloud MCP (Gmail/Drive via claude.ai OAuth) is always blocked.
 - `pathToClaudeCodeExecutable` — path to the `claude` binary. Useful if your OS/filesystem has the SDK's bundled musl/glibc binaries in a place where they can't run. For example, with Nix you can set the binary to e.g. `"/home/you/.nix-profile/bin/claude"`.
 
+
+`usageMeter`:
+- `enabled` — show the always-on footer meter (default `true`). The `/claude-usage` command works regardless of this setting.
+- `refreshMinutes` — how often to refresh the active snapshot (default `5`).
 
 **Extension providers and models.json:** pi's `modelOverrides` in `~/.pi/agent/models.json` do not currently apply to extension-registered providers (like claude-bridge). Overriding `contextWindow` or other fields requires editing `src/models.ts` directly.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,13 @@ export interface Config {
 		// [1m] on Pro.
 		longContextExtraUsage?: boolean;
 	};
+	/** Claude subscription usage meter (footer statusline + /claude-usage). */
+	usageMeter?: {
+		/** Show the always-on footer meter (default true). The /claude-usage command works regardless. */
+		enabled?: boolean;
+		/** How often to refresh the active snapshot, in minutes (default 5). */
+		refreshMinutes?: number;
+	};
 }
 
 export function tryParseJson(path: string): Partial<Config> {
@@ -51,5 +58,6 @@ export function loadConfig(cwd: string): Config {
 	return {
 		askClaude: { ...global.askClaude, ...project.askClaude },
 		provider: { ...global.provider, ...project.provider },
+		usageMeter: { ...global.usageMeter, ...project.usageMeter },
 	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { loadConfig, type Config } from "./config.js";
 import { extractAgentsAppend } from "./agents-md.js";
 import { jsonSchemaToZodShape } from "./typebox-to-zod.js";
 import { buildActionSummary, type ToolCallState } from "./askclaude-ui.js";
+import { fetchUsage, formatStatus, formatPanel, applyRateLimitInfo, type UsageSnapshot } from "./usage.js";
 
 // Compat (#2): use factory if available (pi-ai ≥0.66), else fall back to constructor (gsd-pi etc.)
 const _piAi = piAi as any;
@@ -659,6 +660,40 @@ function mapToolArgs(
 
 // Global (not query state):
 let piUI: ExtensionUIContext | null = null;
+
+// --- Usage meter state ---
+let usageSnapshot: UsageSnapshot | null = null;
+let usageTimer: ReturnType<typeof setInterval> | null = null;
+let usageMeterEnabled = true;
+
+function renderUsageStatus() {
+	if (!usageMeterEnabled) return;
+	piUI?.setStatus("claude-usage", usageSnapshot ? formatStatus(usageSnapshot) : undefined);
+}
+
+async function refreshUsage(): Promise<UsageSnapshot | null> {
+	const snap = await fetchUsage();
+	if (snap) {
+		usageSnapshot = snap;
+		renderUsageStatus();
+	}
+	return snap ?? usageSnapshot;
+}
+
+function stopUsageTimer() {
+	if (usageTimer) {
+		clearInterval(usageTimer);
+		usageTimer = null;
+	}
+}
+
+function startUsageMeter(refreshMinutes: number) {
+	if (!usageMeterEnabled) return;
+	void refreshUsage();
+	stopUsageTimer();
+	usageTimer = setInterval(() => void refreshUsage(), Math.max(1, refreshMinutes) * 60_000);
+	usageTimer.unref?.();
+}
 const activeQueryContexts = new Set<QueryContext>();
 
 function contextForToolResults(results: McpResult[]): QueryContext | undefined {
@@ -1055,6 +1090,10 @@ async function consumeQuery(
 					piUI?.notify(`Claude rate limited (${info.rateLimitType ?? "unknown"}) — resets at ${resetsAt}`, "warning");
 				} else if (info?.status === "allowed_warning") {
 					piUI?.notify(`Claude rate limit warning: ${Math.round(info.utilization ?? 0)}% used (${info.rateLimitType ?? ""})`, "warning");
+				}
+				if (info) {
+					usageSnapshot = applyRateLimitInfo(usageSnapshot, info);
+					renderUsageStatus();
 				}
 				break;
 			}
@@ -1601,6 +1640,9 @@ export default function (pi: ExtensionAPI) {
 		plan: providerSettings.plan ?? "pro",
 		longContextExtraUsage: providerSettings.longContextExtraUsage ?? false,
 	};
+	const usageConf = config.usageMeter ?? {};
+	usageMeterEnabled = usageConf.enabled !== false;
+	const usageRefreshMinutes = usageConf.refreshMinutes ?? 5;
 	const registeredModels = applyLongContext(MODELS, longContextSettings);
 
 	// Reset shared session on pi session lifecycle events
@@ -1622,8 +1664,13 @@ export default function (pi: ExtensionAPI) {
 		if (event.reason === "new" || event.reason === "resume" || event.reason === "fork") {
 			clearSession(`session_start:${event.reason}`);
 		}
+		if (usageSnapshot) renderUsageStatus();
+		startUsageMeter(usageRefreshMinutes);
 	});
-	pi.on("session_shutdown", () => clearSession("session_shutdown"));
+	pi.on("session_shutdown", () => {
+		stopUsageTimer();
+		clearSession("session_shutdown");
+	});
 
 	pi.on("session_before_compact", async (event, ctx) => {
 		if (ctx.model?.baseUrl !== "claude-bridge") return undefined;
@@ -1829,4 +1876,40 @@ export default function (pi: ExtensionAPI) {
 			},
 		});
 	}
+
+	// --- /claude-usage command ---
+	// No argument: print the full usage panel. `on` / `off` / `toggle`: flip the
+	// always-on footer meter for this session (the persistent default is the
+	// `usageMeter.enabled` config key).
+	pi.registerCommand("claude-usage", {
+		description: "Show Claude subscription usage, or toggle the footer meter: /claude-usage [on|off]",
+		getArgumentCompletions: (prefix) => {
+			const p = prefix.trim().toLowerCase();
+			return [
+				{ value: "on", label: "on", description: "Show the always-on footer meter" },
+				{ value: "off", label: "off", description: "Hide the footer meter" },
+			].filter((i) => i.value.startsWith(p));
+		},
+		handler: async (args, ctx) => {
+			const arg = args.trim().toLowerCase();
+			if (arg === "on" || arg === "off" || arg === "toggle") {
+				usageMeterEnabled = arg === "toggle" ? !usageMeterEnabled : arg === "on";
+				if (usageMeterEnabled) {
+					startUsageMeter(usageRefreshMinutes);
+					ctx.ui.notify("Claude usage meter enabled.", "info");
+				} else {
+					stopUsageTimer();
+					ctx.ui.setStatus("claude-usage", undefined);
+					ctx.ui.notify("Claude usage meter hidden. Run /claude-usage on to restore, or /claude-usage for a one-off report.", "info");
+				}
+				return;
+			}
+			const snap = await refreshUsage();
+			if (!snap) {
+				ctx.ui.notify("Claude usage unavailable: no OAuth token found, or the usage request failed.", "warning");
+				return;
+			}
+			ctx.ui.notify(formatPanel(snap), "info");
+		},
+	});
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -672,8 +672,8 @@ function renderUsageStatus() {
 	piUI?.setStatus("claude-usage", status || undefined);
 }
 
-async function refreshUsage(): Promise<UsageSnapshot | null> {
-	const snap = await fetchUsage();
+async function refreshUsage(options: { force?: boolean } = {}): Promise<UsageSnapshot | null> {
+	const snap = await fetchUsage(options);
 	if (snap) {
 		usageSnapshot = snap;
 		renderUsageStatus();
@@ -1906,7 +1906,7 @@ export default function (pi: ExtensionAPI) {
 				}
 				return;
 			}
-			const snap = await refreshUsage();
+			const snap = await refreshUsage({ force: true });
 			if (!snap) {
 				ctx.ui.notify("Claude usage unavailable: no OAuth token found, or the usage request failed.", "warning");
 				return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -668,7 +668,8 @@ let usageMeterEnabled = true;
 
 function renderUsageStatus() {
 	if (!usageMeterEnabled) return;
-	piUI?.setStatus("claude-usage", usageSnapshot ? formatStatus(usageSnapshot) : undefined);
+	const status = usageSnapshot ? formatStatus(usageSnapshot) : "";
+	piUI?.setStatus("claude-usage", status || undefined);
 }
 
 async function refreshUsage(): Promise<UsageSnapshot | null> {
@@ -1882,12 +1883,13 @@ export default function (pi: ExtensionAPI) {
 	// always-on footer meter for this session (the persistent default is the
 	// `usageMeter.enabled` config key).
 	pi.registerCommand("claude-usage", {
-		description: "Show Claude subscription usage, or toggle the footer meter: /claude-usage [on|off]",
+		description: "Show Claude subscription usage, or toggle the footer meter: /claude-usage [on|off|toggle]",
 		getArgumentCompletions: (prefix) => {
 			const p = prefix.trim().toLowerCase();
 			return [
 				{ value: "on", label: "on", description: "Show the always-on footer meter" },
 				{ value: "off", label: "off", description: "Hide the footer meter" },
+				{ value: "toggle", label: "toggle", description: "Toggle the footer meter" },
 			].filter((i) => i.value.startsWith(p));
 		},
 		handler: async (args, ctx) => {

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -25,6 +25,10 @@ const USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
 const OAUTH_BETA_HEADER = "oauth-2025-04-20";
 const KEYCHAIN_SERVICE = "Claude Code-credentials";
 const FETCH_TIMEOUT_MS = 10_000;
+const RATE_LIMIT_BACKOFF_MS = 15 * 60_000;
+const AUTH_FAILURE_BACKOFF_MS = 5 * 60_000;
+
+let usageFetchBackoffUntil = 0;
 
 /** A single quota window as shown in the meter. */
 export interface UsageWindow {
@@ -155,7 +159,8 @@ function toWindow(key: string, raw: RawWindow | null | undefined): UsageWindow |
 }
 
 /** Fetch and normalise the live usage snapshot. Returns null on any failure. */
-export async function fetchUsage(): Promise<UsageSnapshot | null> {
+export async function fetchUsage(options: { force?: boolean } = {}): Promise<UsageSnapshot | null> {
+	if (!options.force && Date.now() < usageFetchBackoffUntil) return null;
 	const token = await getOAuthToken();
 	if (!token) return null;
 
@@ -170,7 +175,12 @@ export async function fetchUsage(): Promise<UsageSnapshot | null> {
 			},
 			signal: controller.signal,
 		});
-		if (!res.ok) return null;
+		if (!res.ok) {
+			if (res.status === 429) usageFetchBackoffUntil = Date.now() + RATE_LIMIT_BACKOFF_MS;
+			else if (res.status === 401 || res.status === 403) usageFetchBackoffUntil = Date.now() + AUTH_FAILURE_BACKOFF_MS;
+			return null;
+		}
+		usageFetchBackoffUntil = 0;
 		data = (await res.json()) as Record<string, unknown>;
 	} catch {
 		return null;

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,0 +1,262 @@
+// Claude subscription usage meter.
+//
+// Two data sources, both keyed on the same underlying quota:
+//   1. Active  — GET https://api.anthropic.com/api/oauth/usage with the Claude
+//      Code OAuth token (the same endpoint Claude Code's own /usage screen and
+//      `caut` query). Full breakdown (5-hour session, 7-day window, extra
+//      usage). Used on startup, on a timer, and for the /claude-usage command.
+//   2. Passive — the bridge already receives `rate_limit_event` SDK messages
+//      ({ status, rateLimitType, utilization, resetsAt }) during every query.
+//      Feeding those in keeps the footer meter fresh for free while you work,
+//      with no extra network call.
+//
+// `utilization` is percent USED (e.g. 13 => 13% used); "how much is left" is
+// therefore 100 - utilization.
+
+import { execFile } from "child_process";
+import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+const USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
+const OAUTH_BETA_HEADER = "oauth-2025-04-20";
+const KEYCHAIN_SERVICE = "Claude Code-credentials";
+const FETCH_TIMEOUT_MS = 10_000;
+
+/** A single quota window as shown in the meter. */
+export interface UsageWindow {
+	/** Stable key matching the API field / rate_limit_event type (e.g. "five_hour"). */
+	key: string;
+	/** Short human label for the footer/panel (e.g. "5h", "7d"). */
+	label: string;
+	/** Percent used, 0-100. */
+	utilization: number;
+	/** Percent remaining, 0-100. */
+	remaining: number;
+	/** When this window resets, if known. */
+	resetsAt?: Date;
+}
+
+export interface UsageSnapshot {
+	windows: UsageWindow[];
+	/** Extra-usage (metered overage) summary line, when enabled. */
+	extraUsage?: string;
+	fetchedAt: Date;
+}
+
+/** rate_limit_event payload the bridge already receives from the Agent SDK. */
+export interface RateLimitInfo {
+	status?: string;
+	rateLimitType?: string;
+	utilization?: number;
+	resetsAt?: string | number;
+}
+
+// Windows we surface, in display order. Anything else in the response is ignored.
+const WINDOW_LABELS: Record<string, string> = {
+	five_hour: "5h",
+	seven_day: "7d",
+	seven_day_opus: "7d Opus",
+	seven_day_sonnet: "7d Sonnet",
+};
+
+function clampPct(n: number): number {
+	if (!Number.isFinite(n)) return 0;
+	return Math.max(0, Math.min(100, n));
+}
+
+function parseResetsAt(v: unknown): Date | undefined {
+	if (typeof v === "number") return new Date(v > 1e12 ? v : v * 1000);
+	if (typeof v === "string") {
+		const d = new Date(v);
+		return Number.isNaN(d.getTime()) ? undefined : d;
+	}
+	return undefined;
+}
+
+/** Human "resets in Xh Ym" / "resets in Nd" from now. */
+export function formatReset(resetsAt: Date | undefined, now = new Date()): string {
+	if (!resetsAt) return "";
+	let secs = Math.round((resetsAt.getTime() - now.getTime()) / 1000);
+	if (secs <= 0) return "resetting";
+	const d = Math.floor(secs / 86400);
+	secs -= d * 86400;
+	const h = Math.floor(secs / 3600);
+	secs -= h * 3600;
+	const m = Math.floor(secs / 60);
+	if (d > 0) return `resets in ${d}d ${h}h`;
+	if (h > 0) return `resets in ${h}h ${m}m`;
+	return `resets in ${m}m`;
+}
+
+/**
+ * Read the Claude Code OAuth access token.
+ *
+ * macOS: the token lives in the login Keychain under the generic-password
+ * service "Claude Code-credentials". Elsewhere Claude Code writes
+ * ~/.claude/.credentials.json. Both hold the same JSON shape:
+ * `{ "claudeAiOauth": { "accessToken": "...", ... } }`.
+ */
+export async function getOAuthToken(): Promise<string | null> {
+	// macOS Keychain first.
+	if (process.platform === "darwin") {
+		try {
+			const { stdout } = await execFileAsync("security", [
+				"find-generic-password",
+				"-w",
+				"-s",
+				KEYCHAIN_SERVICE,
+			]);
+			const tok = extractAccessToken(stdout);
+			if (tok) return tok;
+		} catch {
+			// Fall through to the file-based credential store.
+		}
+	}
+	const credPath = join(homedir(), ".claude", ".credentials.json");
+	if (existsSync(credPath)) {
+		try {
+			return extractAccessToken(readFileSync(credPath, "utf-8"));
+		} catch {
+			return null;
+		}
+	}
+	return null;
+}
+
+function extractAccessToken(raw: string): string | null {
+	try {
+		const json = JSON.parse(raw.trim());
+		const tok = json?.claudeAiOauth?.accessToken;
+		return typeof tok === "string" && tok.length > 0 ? tok : null;
+	} catch {
+		return null;
+	}
+}
+
+interface RawWindow {
+	utilization?: number | null;
+	resets_at?: string | null;
+}
+
+function toWindow(key: string, raw: RawWindow | null | undefined): UsageWindow | null {
+	if (!raw || typeof raw.utilization !== "number") return null;
+	const utilization = clampPct(raw.utilization);
+	return {
+		key,
+		label: WINDOW_LABELS[key] ?? key,
+		utilization,
+		remaining: clampPct(100 - utilization),
+		resetsAt: parseResetsAt(raw.resets_at),
+	};
+}
+
+/** Fetch and normalise the live usage snapshot. Returns null on any failure. */
+export async function fetchUsage(): Promise<UsageSnapshot | null> {
+	const token = await getOAuthToken();
+	if (!token) return null;
+
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+	let data: Record<string, unknown>;
+	try {
+		const res = await fetch(USAGE_URL, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"anthropic-beta": OAUTH_BETA_HEADER,
+			},
+			signal: controller.signal,
+		});
+		if (!res.ok) return null;
+		data = (await res.json()) as Record<string, unknown>;
+	} catch {
+		return null;
+	} finally {
+		clearTimeout(timer);
+	}
+
+	const windows: UsageWindow[] = [];
+	for (const key of Object.keys(WINDOW_LABELS)) {
+		const w = toWindow(key, data[key] as RawWindow | null | undefined);
+		if (w) windows.push(w);
+	}
+	if (windows.length === 0) return null;
+
+	let extraUsage: string | undefined;
+	const eu = data.extra_usage as { is_enabled?: boolean; utilization?: number } | undefined;
+	if (eu?.is_enabled) {
+		extraUsage = `extra usage ${Math.round(clampPct(eu.utilization ?? 0))}% used`;
+	}
+
+	return { windows, extraUsage, fetchedAt: new Date() };
+}
+
+/**
+ * Overlay a passive rate_limit_event onto an existing snapshot, returning an
+ * updated copy. If the event's window isn't already tracked it is appended.
+ */
+export function applyRateLimitInfo(
+	snapshot: UsageSnapshot | null,
+	info: RateLimitInfo,
+): UsageSnapshot | null {
+	if (typeof info.utilization !== "number" || !info.rateLimitType) return snapshot;
+	const key = info.rateLimitType;
+	const utilization = clampPct(info.utilization);
+	const next: UsageWindow = {
+		key,
+		label: WINDOW_LABELS[key] ?? key,
+		utilization,
+		remaining: clampPct(100 - utilization),
+		resetsAt: parseResetsAt(info.resetsAt),
+	};
+	const windows = snapshot ? [...snapshot.windows] : [];
+	const idx = windows.findIndex((w) => w.key === key);
+	if (idx >= 0) windows[idx] = { ...next, resetsAt: next.resetsAt ?? windows[idx].resetsAt };
+	else windows.push(next);
+	return { windows, extraUsage: snapshot?.extraUsage, fetchedAt: new Date() };
+}
+
+/** Local clock time HH:MM (for the 5-hour reset). */
+export function formatResetClock(date: Date | undefined): string {
+	if (!date) return "";
+	return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+}
+
+/** Local short weekday, e.g. "Sat" (for the 7-day reset). */
+export function formatResetDay(date: Date | undefined): string {
+	if (!date) return "";
+	return date.toLocaleDateString(undefined, { weekday: "short" });
+}
+
+/**
+ * Compact one-line footer, percent USED, with a reset hint per window:
+ * the 5-hour window shows its reset clock time, the 7-day window its reset day.
+ * e.g. "Claude 5h 19% (Res. 12:50) · 7d 21% (Res. Sat)".
+ */
+export function formatStatus(snapshot: UsageSnapshot): string {
+	const parts = snapshot.windows
+		.filter((w) => w.key === "five_hour" || w.key === "seven_day")
+		.map((w) => {
+			const reset = w.key === "five_hour" ? formatResetClock(w.resetsAt) : formatResetDay(w.resetsAt);
+			const rseg = reset ? ` (Res. ${reset})` : "";
+			return `${w.label} ${Math.round(w.utilization)}%${rseg}`;
+		});
+	if (parts.length === 0) return "";
+	return `Claude ${parts.join(" · ")}`;
+}
+
+/** Multi-line panel for the /claude-usage command. */
+export function formatPanel(snapshot: UsageSnapshot, now = new Date()): string {
+	const lines: string[] = ["Claude subscription usage (remaining):"];
+	for (const w of snapshot.windows) {
+		const reset = formatReset(w.resetsAt, now);
+		const used = `${Math.round(w.utilization)}% used`;
+		const tail = reset ? `${used}, ${reset}` : used;
+		lines.push(`  ${w.label.padEnd(10)} ${String(Math.round(w.remaining)).padStart(3)}% left   (${tail})`);
+	}
+	if (snapshot.extraUsage) lines.push(`  ${snapshot.extraUsage}`);
+	return lines.join("\n");
+}

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -225,10 +225,12 @@ export function formatResetClock(date: Date | undefined): string {
 	return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
 }
 
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
 /** Local short weekday, e.g. "Sat" (for the 7-day reset). */
 export function formatResetDay(date: Date | undefined): string {
 	if (!date) return "";
-	return date.toLocaleDateString(undefined, { weekday: "short" });
+	return WEEKDAYS[date.getDay()];
 }
 
 /**

--- a/tests/unit-config.mjs
+++ b/tests/unit-config.mjs
@@ -33,6 +33,7 @@ describe("loadConfig", () => {
 			assert.deepEqual(loadConfig(cwd), {
 				provider: { plan: "max" },
 				askClaude: { enabled: false },
+				usageMeter: {},
 			});
 		} finally {
 			rmSync(cwd, { recursive: true, force: true });
@@ -58,6 +59,7 @@ describe("loadConfig", () => {
 			assert.deepEqual(loadConfig(cwd), {
 				provider: { plan: "max", strictMcpConfig: true },
 				askClaude: { enabled: false, defaultMode: "read" },
+				usageMeter: {},
 			});
 		} finally {
 			rmSync(cwd, { recursive: true, force: true });

--- a/tests/unit-usage.mjs
+++ b/tests/unit-usage.mjs
@@ -1,0 +1,100 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+	applyRateLimitInfo,
+	formatPanel,
+	formatReset,
+	formatResetClock,
+	formatResetDay,
+	formatStatus,
+} from "../src/usage.js";
+
+function snap(windows, extraUsage) {
+	return { windows, extraUsage, fetchedAt: new Date() };
+}
+
+describe("formatReset", () => {
+	const now = new Date("2026-07-03T09:00:00Z");
+	it("shows minutes under an hour", () => {
+		assert.equal(formatReset(new Date("2026-07-03T09:40:00Z"), now), "resets in 40m");
+	});
+	it("shows hours and minutes under a day", () => {
+		assert.equal(formatReset(new Date("2026-07-03T12:30:00Z"), now), "resets in 3h 30m");
+	});
+	it("shows days and hours beyond a day", () => {
+		assert.equal(formatReset(new Date("2026-07-05T11:00:00Z"), now), "resets in 2d 2h");
+	});
+	it("handles past/undefined", () => {
+		assert.equal(formatReset(new Date("2026-07-03T08:00:00Z"), now), "resetting");
+		assert.equal(formatReset(undefined, now), "");
+	});
+});
+
+describe("formatResetClock / formatResetDay", () => {
+	// Local-time constructor so formatting is timezone-independent.
+	const d = new Date(2026, 6, 3, 9, 5); // 2026-07-03 09:05 local (a Friday)
+	it("clock is zero-padded HH:MM", () => assert.equal(formatResetClock(d), "09:05"));
+	it("day is a short weekday", () => assert.match(formatResetDay(d), /^[A-Za-z]{3}/));
+	it("empty for undefined", () => {
+		assert.equal(formatResetClock(undefined), "");
+		assert.equal(formatResetDay(undefined), "");
+	});
+});
+
+describe("formatStatus", () => {
+	it("shows percent used with per-window reset hints, session + weekly only", () => {
+		const s = snap([
+			{ key: "five_hour", label: "5h", utilization: 19, remaining: 81, resetsAt: new Date(2026, 6, 3, 12, 50) },
+			{ key: "seven_day", label: "7d", utilization: 21, remaining: 79, resetsAt: new Date(2026, 6, 6, 0, 0) },
+			{ key: "seven_day_opus", label: "7d Opus", utilization: 5, remaining: 95 },
+		]);
+		assert.match(formatStatus(s), /^Claude 5h 19% \(Res\. 12:50\) · 7d 21% \(Res\. [A-Za-z]{3}\)$/);
+	});
+	it("omits the reset hint when unknown", () => {
+		const s = snap([{ key: "five_hour", label: "5h", utilization: 19, remaining: 81 }]);
+		assert.equal(formatStatus(s), "Claude 5h 19%");
+	});
+});
+
+describe("formatPanel", () => {
+	const now = new Date("2026-07-03T09:00:00Z");
+	it("renders each window with used% and reset, plus extra usage", () => {
+		const s = snap(
+			[{ key: "five_hour", label: "5h", utilization: 13, remaining: 87, resetsAt: new Date("2026-07-03T12:00:00Z") }],
+			"extra usage 4% used",
+		);
+		const out = formatPanel(s, now);
+		assert.match(out, /Claude subscription usage/);
+		assert.match(out, /5h\s+87% left\s+\(13% used, resets in 3h 0m\)/);
+		assert.match(out, /extra usage 4% used/);
+	});
+});
+
+describe("applyRateLimitInfo", () => {
+	it("creates a snapshot from a passive event when none exists", () => {
+		const s = applyRateLimitInfo(null, { rateLimitType: "five_hour", utilization: 42 });
+		assert.equal(s.windows.length, 1);
+		assert.equal(s.windows[0].key, "five_hour");
+		assert.equal(s.windows[0].remaining, 58);
+	});
+	it("updates the matching window in place, preserving prior reset if event lacks one", () => {
+		const base = snap([
+			{ key: "five_hour", label: "5h", utilization: 13, remaining: 87, resetsAt: new Date("2026-07-03T12:00:00Z") },
+			{ key: "seven_day", label: "7d", utilization: 20, remaining: 80 },
+		]);
+		const s = applyRateLimitInfo(base, { rateLimitType: "five_hour", utilization: 90 });
+		const w = s.windows.find((x) => x.key === "five_hour");
+		assert.equal(w.remaining, 10);
+		assert.equal(w.resetsAt.toISOString(), "2026-07-03T12:00:00.000Z");
+		assert.equal(s.windows.length, 2);
+	});
+	it("clamps utilization into 0-100", () => {
+		const s = applyRateLimitInfo(null, { rateLimitType: "seven_day", utilization: 130 });
+		assert.equal(s.windows[0].utilization, 100);
+		assert.equal(s.windows[0].remaining, 0);
+	});
+	it("ignores events with no type or non-numeric utilization", () => {
+		assert.equal(applyRateLimitInfo(null, { utilization: 10 }), null);
+		assert.equal(applyRateLimitInfo(null, { rateLimitType: "five_hour" }), null);
+	});
+});

--- a/tests/unit-usage.mjs
+++ b/tests/unit-usage.mjs
@@ -34,7 +34,7 @@ describe("formatResetClock / formatResetDay", () => {
 	// Local-time constructor so formatting is timezone-independent.
 	const d = new Date(2026, 6, 3, 9, 5); // 2026-07-03 09:05 local (a Friday)
 	it("clock is zero-padded HH:MM", () => assert.equal(formatResetClock(d), "09:05"));
-	it("day is a short weekday", () => assert.match(formatResetDay(d), /^[A-Za-z]{3}/));
+	it("day is a deterministic short weekday", () => assert.equal(formatResetDay(d), "Fri"));
 	it("empty for undefined", () => {
 		assert.equal(formatResetClock(undefined), "");
 		assert.equal(formatResetDay(undefined), "");
@@ -48,7 +48,7 @@ describe("formatStatus", () => {
 			{ key: "seven_day", label: "7d", utilization: 21, remaining: 79, resetsAt: new Date(2026, 6, 6, 0, 0) },
 			{ key: "seven_day_opus", label: "7d Opus", utilization: 5, remaining: 95 },
 		]);
-		assert.match(formatStatus(s), /^Claude 5h 19% \(Res\. 12:50\) · 7d 21% \(Res\. [A-Za-z]{3}\)$/);
+		assert.equal(formatStatus(s), "Claude 5h 19% (Res. 12:50) · 7d 21% (Res. Mon)");
 	});
 	it("omits the reset hint when unknown", () => {
 		const s = snap([{ key: "five_hour", label: "5h", utilization: 19, remaining: 81 }]);


### PR DESCRIPTION
## What

Adds a **Claude subscription usage meter** so you can see how much of your quota is left without leaving pi.

- **Footer statusline** (always on): e.g. `Claude 5h 44% (Res. 13:50) · 7d 23% (Res. Mon)` — percent **used**, with a per-window reset hint (clock time for the 5-hour window, weekday for the 7-day window). Refreshes on session start, on a timer, and **for free** from the `rate_limit_event` metadata the bridge already receives while you work.
- **`/claude-usage` command**: full breakdown on demand (5-hour + 7-day windows, used %, reset times, metered extra usage when enabled).
- **`/claude-usage on` / `off`**: toggle the footer live for the session (tab-completes); a bare `/claude-usage` still prints the panel even when the footer is hidden.

## How

Uses the same `api.anthropic.com/api/oauth/usage` endpoint Claude Code's own `/usage` screen queries, read via the **existing Claude Code OAuth token** (macOS Keychain `Claude Code-credentials`, `~/.claude/.credentials.json` fallback). Nothing is sent anywhere but Anthropic. If no token is found the meter stays silent.

## Config

```json
{
  "usageMeter": {
    "enabled": true,
    "refreshMinutes": 5
  }
}
```

- `enabled` — show the always-on footer (default `true`); the `/claude-usage` command works regardless.
- `refreshMinutes` — active-snapshot refresh interval (default `5`).

## Files

- `src/usage.ts` (new) — token read, fetch/parse, formatters, passive `rate_limit_event` merge (pure, unit-tested)
- `src/index.ts` — lifecycle wiring (`session_start`/`session_shutdown`), passive footer update in the existing `rate_limit_event` handler, `/claude-usage` command
- `src/config.ts` — `usageMeter` block
- `tests/unit-usage.mjs` (new), `tests/unit-config.mjs` (updated) — `npm run test:unit` green (110 tests)
- `README.md`, `CHANGELOG.md`

## Notes

- No new runtime dependencies (Node builtins + global `fetch`).
- `npm run typecheck` shows only the single pre-existing diamond-dependency error on the provider registration (identical on `main`), unrelated to this change.
