### PR TITLE
Add /usage command and quota footer from streamed rate-limit events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- **Add: `/usage` command and quota footer** — the bridge records the subscription rate-limit windows the Claude Agent SDK streams each turn and shows the 5-hour utilization in the footer. `/usage` prints a bar for each window that has streamed in, with reset times, plus an Extra Usage in-use flag. Only windows the SDK actually emits are shown; windows that do not apply to the account are not referenced. No credentials are read. Exact credit spend and per-model limits are not in the stream, so `/usage` points at Claude Code's own `/usage` for those.
+
 ## 0.6.2 — 2026-07-06
 
 - **Fix: Sonnet 5 and Fable 5 with 1M context** — bare model IDs (`claude-sonnet-5`, `claude-fable-5`) are 200K context. Must pass `[1m]` suffix for both, similar to Opus 4.8.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ You could also create skills or add something to AGENTS.md to e.g. "Always call 
 - **`thinking`** — effort level: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`
 - **`isolated`** — when `true`, Claude gets a clean session with no conversation history (default: `false`)
 
+## Usage stats
+
+The Claude Agent SDK reports a rate-limit sample each turn. The bridge shows the current 5-hour utilization in pi's footer (e.g. `CC 5h 34%`, with a `⚠extra` flag when Extra Usage is active) and adds a `/usage` command that prints a bar for each rolling window it has observed, with reset times, plus whether Extra Usage credits are currently in use.
+
+No credentials are read: this uses only the rate-limit events the SDK already streams. Each event covers one window, so `/usage` fills in over successive turns and shows only the windows that apply to your account. Exact credit spend and per-model limits (such as Fable) are not in the stream. For those, run `claude` and use its own `/usage`.
+
 ## Configuration
 
 Config: `~/.pi/agent/claude-bridge.json` (global) or the project Pi config directory, usually `.pi/claude-bridge.json` (project; merged over global).

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { calculateCost, StringEnum, type AssistantMessage, type AssistantMessage
 import * as piAi from "@earendil-works/pi-ai";
 import { getModels } from "@earendil-works/pi-ai/compat";
 import { buildSessionContext, compact, keyHint, type CompactionEntry, type ExtensionAPI, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
-import { createSdkMcpServer, query, type EffortLevel, type SDKMessage, type SDKUserMessage, type SettingSource } from "@anthropic-ai/claude-agent-sdk";
+import { createSdkMcpServer, query, type EffortLevel, type SDKMessage, type SDKRateLimitInfo, type SDKUserMessage, type SettingSource } from "@anthropic-ai/claude-agent-sdk";
 import type { Base64ImageSource, ContentBlockParam, MessageParam } from "@anthropic-ai/sdk/resources";
 import { Type } from "typebox";
 import { Text } from "@earendil-works/pi-tui";
@@ -20,6 +20,7 @@ import { loadConfig, type Config } from "./config.js";
 import { extractAgentsAppend } from "./agents-md.js";
 import { jsonSchemaToZodShape } from "./typebox-to-zod.js";
 import { buildActionSummary, type ToolCallState } from "./askclaude-ui.js";
+import { formatQuotaStatus, formatUsageReport, type UsageWindows } from "./usage.js";
 
 // Compat (#2): use factory if available (pi-ai ≥0.66), else fall back to constructor (gsd-pi etc.)
 const _piAi = piAi as any;
@@ -661,6 +662,14 @@ function mapToolArgs(
 let piUI: ExtensionUIContext | null = null;
 const activeQueryContexts = new Set<QueryContext>();
 
+// Latest rate-limit sample per window; fills in over turns since each event covers one.
+const usageWindows: UsageWindows = new Map();
+
+function recordUsage(info: SDKRateLimitInfo): void {
+	if (info.rateLimitType) usageWindows.set(info.rateLimitType, { ...info, capturedAt: Date.now() });
+	piUI?.setStatus("claude-quota", formatQuotaStatus(usageWindows));
+}
+
 function contextForToolResults(results: McpResult[]): QueryContext | undefined {
 	for (const result of results) {
 		const id = result.toolCallId;
@@ -1048,8 +1057,9 @@ async function consumeQuery(
 			case "user":
 				break; // SDK echo of user prompt — not needed
 			case "rate_limit_event": {
-				const info = (message as any).rate_limit_info;
+				const info = (message as any).rate_limit_info as SDKRateLimitInfo;
 				debug("consumeQuery: rate_limit_event", JSON.stringify(info).slice(0, 300));
+				recordUsage(info);
 				if (info?.status === "rejected") {
 					const resetsAt = info.resetsAt ? new Date(info.resetsAt).toLocaleTimeString() : "unknown";
 					piUI?.notify(`Claude rate limited (${info.rateLimitType ?? "unknown"}) — resets at ${resetsAt}`, "warning");
@@ -1624,6 +1634,13 @@ export default function (pi: ExtensionAPI) {
 		}
 	});
 	pi.on("session_shutdown", () => clearSession("session_shutdown"));
+
+	pi.registerCommand("usage", {
+		description: "Show Claude Code subscription quota usage seen by the bridge",
+		handler: async (_args, ctx) => {
+			ctx.ui.notify(formatUsageReport(usageWindows), "info");
+		},
+	});
 
 	pi.on("session_before_compact", async (event, ctx) => {
 		if (ctx.model?.baseUrl !== "claude-bridge") return undefined;

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,0 +1,75 @@
+// Pure quota formatters, split from index.ts so tests can import them without
+// activating the extension. Rendered only from streamed rate_limit_events, so
+// windows the account never hits are simply absent, not blanked.
+
+import type { SDKRateLimitInfo } from "@anthropic-ai/claude-agent-sdk";
+
+export type UsageSample = SDKRateLimitInfo & { capturedAt: number };
+export type UsageWindows = Map<string, UsageSample>;
+
+const WINDOW_LABELS: Record<string, string> = {
+	five_hour: "5-hour",
+	seven_day: "weekly",
+	seven_day_opus: "weekly Opus",
+	seven_day_sonnet: "weekly Sonnet",
+};
+const WINDOW_ORDER = ["five_hour", "seven_day", "seven_day_opus", "seven_day_sonnet"];
+
+const BAR_WIDTH = 20;
+
+function windowLabel(key: string): string {
+	return WINDOW_LABELS[key] ?? key;
+}
+
+// "overage" is a status flag, not a quota window, so it gets no bar.
+function quotaWindowKeys(windows: UsageWindows): string[] {
+	return [...windows.keys()]
+		.filter((k) => k !== "overage")
+		.sort((a, b) => {
+			const ai = WINDOW_ORDER.indexOf(a);
+			const bi = WINDOW_ORDER.indexOf(b);
+			return (ai === -1 ? 99 : ai) - (bi === -1 ? 99 : bi);
+		});
+}
+
+export function formatResetTime(ts?: number): string {
+	if (!ts) return "unknown";
+	return new Date(ts).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+export function anyExtraUsageActive(windows: UsageWindows): boolean {
+	return [...windows.values()].some((w) => w.isUsingOverage);
+}
+
+export function formatQuotaStatus(windows: UsageWindows): string | undefined {
+	const five = windows.get("five_hour");
+	if (!five) return undefined;
+	let s = `CC 5h ${Math.round(five.utilization ?? 0)}%`;
+	if (anyExtraUsageActive(windows)) s += " \u26A0extra";
+	return s;
+}
+
+export function usageBar(pct: number, width = BAR_WIDTH): string {
+	const filled = Math.max(0, Math.min(width, Math.round((pct / 100) * width)));
+	return "\u2593".repeat(filled) + "\u2591".repeat(width - filled);
+}
+
+export function formatUsageReport(windows: UsageWindows): string {
+	const keys = quotaWindowKeys(windows);
+	if (keys.length === 0) {
+		return "Claude usage: no data yet \u2014 send a message through the bridge first.";
+	}
+	const labelWidth = Math.max(...keys.map((k) => windowLabel(k).length));
+	const lines = ["Plan quota", ""];
+	for (const key of keys) {
+		const w = windows.get(key)!;
+		const pct = Math.round(w.utilization ?? 0);
+		const label = windowLabel(key).padEnd(labelWidth);
+		lines.push(`  ${label}  ${usageBar(pct)}  ${String(pct).padStart(3)}%  resets ${formatResetTime(w.resetsAt)}`);
+		lines.push("");
+	}
+	lines.push(`  Extra Usage: ${anyExtraUsageActive(windows) ? "in use" : "not in use"}`);
+	// Spend amount and per-model limits are not in the stream; only Claude Code has them.
+	lines.push("  For exact credit spend and per-model limits: run `claude` then /usage");
+	return lines.join("\n");
+}

--- a/tests/unit-usage.mjs
+++ b/tests/unit-usage.mjs
@@ -1,0 +1,77 @@
+/**
+ * Tests for subscription quota formatting. Verifies the footer status and the
+ * /usage report render only the windows the SDK actually streamed, and that
+ * absent windows are never referenced.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatQuotaStatus, formatUsageReport, anyExtraUsageActive, usageBar } from "../src/usage.js";
+
+const sample = (fields) => ({ status: "allowed", capturedAt: Date.now(), ...fields });
+
+describe("usageBar", () => {
+	it("fills proportionally and stays fixed width", () => {
+		assert.equal(usageBar(0, 10), "░░░░░░░░░░");
+		assert.equal(usageBar(50, 10), "▓▓▓▓▓░░░░░");
+		assert.equal(usageBar(100, 10), "▓▓▓▓▓▓▓▓▓▓");
+	});
+	it("clamps out-of-range values", () => {
+		assert.equal(usageBar(150, 10), "▓▓▓▓▓▓▓▓▓▓");
+		assert.equal(usageBar(-5, 10), "░░░░░░░░░░");
+	});
+});
+
+describe("formatQuotaStatus", () => {
+	it("returns undefined with no five-hour sample", () => {
+		assert.equal(formatQuotaStatus(new Map()), undefined);
+		const weeklyOnly = new Map([["seven_day", sample({ rateLimitType: "seven_day", utilization: 10 })]]);
+		assert.equal(formatQuotaStatus(weeklyOnly), undefined);
+	});
+
+	it("renders the five-hour utilization", () => {
+		const windows = new Map([["five_hour", sample({ rateLimitType: "five_hour", utilization: 33.6 })]]);
+		assert.equal(formatQuotaStatus(windows), "CC 5h 34%");
+	});
+
+	it("flags active extra usage", () => {
+		const windows = new Map([
+			["five_hour", sample({ rateLimitType: "five_hour", utilization: 80, isUsingOverage: true })],
+		]);
+		assert.ok(formatQuotaStatus(windows).includes("extra"));
+	});
+});
+
+describe("formatUsageReport", () => {
+	it("reports no data for an empty map", () => {
+		assert.match(formatUsageReport(new Map()), /no data yet/);
+	});
+
+	it("renders only windows that streamed in, in canonical order", () => {
+		const windows = new Map([
+			["seven_day", sample({ rateLimitType: "seven_day", utilization: 12, resetsAt: 1785542400000 })],
+			["five_hour", sample({ rateLimitType: "five_hour", utilization: 50, resetsAt: 1783632000000 })],
+		]);
+		const report = formatUsageReport(windows);
+		const fiveIdx = report.indexOf("5-hour");
+		const weekIdx = report.indexOf("weekly");
+		assert.ok(fiveIdx !== -1 && weekIdx !== -1, "both windows present");
+		assert.ok(fiveIdx < weekIdx, "five-hour listed before weekly");
+		assert.match(report, /5-hour  ▓+░+   50%  resets/);
+	});
+
+	it("does not reference windows that never streamed in", () => {
+		const windows = new Map([["five_hour", sample({ rateLimitType: "five_hour", utilization: 7 })]]);
+		const report = formatUsageReport(windows);
+		assert.ok(report.includes("5-hour"), "shows the window it has");
+		assert.ok(!report.includes("weekly"), "no phantom weekly bar");
+		assert.ok(!/not seen|unavailable/.test(report), "no placeholder text for absent windows");
+	});
+
+	it("reports extra usage in use when any window is on overage", () => {
+		const windows = new Map([
+			["five_hour", sample({ rateLimitType: "five_hour", utilization: 100, isUsingOverage: true })],
+		]);
+		assert.ok(anyExtraUsageActive(windows));
+		assert.match(formatUsageReport(windows), /Extra Usage: in use/);
+	});
+});


### PR DESCRIPTION
## What this adds

A `/usage` command and a persistent footer that surface the Claude subscription quota the bridge already receives, so you can see how much of your plan you have used without leaving pi.

- **Footer:** shows the current 5-hour utilization, e.g. `CC 5h 34%`, with a `⚠extra` flag when Extra Usage credits are in use.
- **`/usage`:** prints a bar for each rolling window that has streamed in (5-hour, weekly, and any per-model weekly windows the account has), each with its reset time, plus an "Extra Usage: in use / not in use" line.

## How it works

The Claude Agent SDK already emits a `rate_limit_event` on every turn. The bridge now records the latest sample per window and renders it. No credentials are read and no extra network calls are made. This stays within the extension's existing boundary of never touching auth state.

Each event carries one window, so the report fills in over successive turns and shows only the windows that actually apply to the account. Windows that do not apply are never referenced, so there are no phantom bars.

## Known limitation

The exact credit spend amount and per-model limits (for example a Fable weekly limit) are not present in the streamed events. `/usage` points the user to Claude Code's own `/usage` for those. A future opt-in mode could read them from the usage endpoint, but that would require handling credentials, so it is intentionally left out here.

## Testing

- New unit tests in `tests/unit-usage.mjs` cover bar rendering, footer status, window ordering, the no-phantom-window behavior, and the Extra Usage flag.
- Full unit suite passes (108 tests). `typecheck` shows only the pre-existing diamond-dependency error unrelated to this change.
