### PR TITLE
Add Claude Opus 5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## UNRELEASED
+
+- **Add: Claude Opus 5 model** — register `claude-opus-5` with its 1M Claude Code runtime ID and make the `opus` shortcut select it. A temporary local catalog fallback keeps the model available until pi-ai publishes matching metadata.
+- **Bump: aligned Pi development packages** — update pi-ai, pi-coding-agent, and pi-tui to 0.80.10-compatible ranges so typechecking uses one event-stream type.
+
 ## 0.6.2 — 2026-07-06
 
 - **Fix: Sonnet 5 and Fable 5 with 1M context** — bare model IDs (`claude-sonnet-5`, `claude-fable-5`) are 200K context. Must pass `[1m]` suffix for both, similar to Opus 4.8.

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ pi install npm:pi-claude-bridge
 
 ## Provider
 
-Use `/model` to select `claude-bridge/claude-fable-5`, `claude-bridge/claude-opus-4-8`, `claude-bridge/claude-opus-4-7`, `claude-bridge/claude-opus-4-6`, `claude-bridge/claude-sonnet-5`, `claude-bridge/claude-sonnet-4-6`, or `claude-bridge/claude-haiku-4-5`.
+Use `/model` to select `claude-bridge/claude-fable-5`, `claude-bridge/claude-opus-5`, `claude-bridge/claude-opus-4-8`, `claude-bridge/claude-opus-4-7`, `claude-bridge/claude-opus-4-6`, `claude-bridge/claude-sonnet-5`, `claude-bridge/claude-sonnet-4-6`, or `claude-bridge/claude-haiku-4-5`.
 
 Behind the scenes, pi's tools are bridged to Claude Code but it should all work like normal in pi. Bash commands get a 120-second default timeout (matching Claude Code's default) since pi's bash has no timeout by default. Skills in pi are copied over to Claude Code's system prompt so should work as they would with any other pi provider.
 
-**1M Context:** Opus 4.7 and Opus 4.8 get 1M context by default. Opus 4.6 only gets 1M if you're on a Max plan or pay for Extra Usage. Sonnet 4.6 only gets 1M if you pay for Extra Usage. You will need to set `provider.plan` and/or `provider.longContextExtraUsage` for 1M context in Opus 4.6/Sonnet 4.6 as described in [Configuration](#configuration).
+**1M Context:** Opus 5, Opus 4.7, and Opus 4.8 get 1M context by default. Opus 4.6 only gets 1M if you're on a Max plan or pay for Extra Usage. Sonnet 4.6 only gets 1M if you pay for Extra Usage. You will need to set `provider.plan` and/or `provider.longContextExtraUsage` for 1M context in Opus 4.6/Sonnet 4.6 as described in [Configuration](#configuration).
 
 ## AskClaude Tool
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-claude-bridge",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-claude-bridge",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.141",
@@ -16,9 +16,9 @@
         "typebox": "^1.3.0"
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "^0.80.3",
-        "@earendil-works/pi-coding-agent": "^0.80.2",
-        "@earendil-works/pi-tui": "^0.80.2",
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-coding-agent": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
         "@types/node": "^24.13.2",
         "tsx": "^4.22.4",
         "typescript": "^6.0.3"
@@ -701,9 +701,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
-      "integrity": "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
+      "integrity": "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -755,16 +755,16 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.2.tgz",
-      "integrity": "sha512-m9v7OUit0s9LklWfh61ca/XY5INjUzjtYtNZwy3cNvyjOLk3IpBgghP8aAp0iH35rLaiRwuuWiJ8t88ODMWY+A==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
+      "integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.2",
-        "@earendil-works/pi-ai": "^0.80.2",
-        "@earendil-works/pi-tui": "^0.80.2",
+        "@earendil-works/pi-agent-core": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1254,12 +1254,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.2.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.2",
+        "@earendil-works/pi-ai": "^0.80.10",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1269,8 +1269,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.2.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1287,15 +1287,15 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.2.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2728,9 +2728,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.2.tgz",
-      "integrity": "sha512-OvOAMIbXiC9OSse17YMiXIsI9AS5XM/ZV8N/k+UzdlRpPILDQYmLElevgGW92kkXR8qHBClIdzhCjuzlBGvphA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
+      "integrity": "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "@earendil-works/pi-tui": ">=0.80.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.80.3",
-    "@earendil-works/pi-coding-agent": "^0.80.2",
-    "@earendil-works/pi-tui": "^0.80.2",
+    "@earendil-works/pi-ai": "^0.80.10",
+    "@earendil-works/pi-coding-agent": "^0.80.10",
+    "@earendil-works/pi-tui": "^0.80.10",
     "@types/node": "^24.13.2",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3"

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,23 +2,46 @@
 // `resolveModel` returns the first partial match, so `opus` resolves to the first-listed opus entry.
 // Extracted from index.ts so tests can import without activating the extension.
 
-export const MODEL_IDS_IN_ORDER = ["claude-fable-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-5", "claude-sonnet-4-6", "claude-haiku-4-5"];
+export const MODEL_IDS_IN_ORDER = ["claude-fable-5", "claude-opus-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-5", "claude-sonnet-4-6", "claude-haiku-4-5"];
+
+// Claude Code can expose a new subscription model before pi-ai publishes its
+// provider catalog entry. Keep the bridge usable during that gap, but prefer
+// pi-ai metadata automatically as soon as it becomes available.
+const BRIDGE_MODEL_FALLBACKS: Record<string, {
+	id: string;
+	name: string;
+	reasoning: boolean;
+	input: string[];
+	contextWindow: number;
+	maxTokens: number;
+	thinkingLevelMap?: Record<string, string>;
+}> = {
+	"claude-opus-5": {
+		id: "claude-opus-5",
+		name: "Claude Opus 5",
+		reasoning: true,
+		input: ["text", "image"],
+		contextWindow: 1_000_000,
+		maxTokens: 128_000,
+	},
+};
 
 // Workaround for missing thinkingLevelMap in pi-ai (earendil-works/pi#6371).
-// Sonnet 5 and Sonnet 4.6 have no map, so getSupportedThinkingLevels hides
-// xhigh (it's opt-in). Both models' top effort tier is "max" with no real
-// xhigh (verified via CC supportedModels API), so xhigh→max matches opus-4-6.
+// Opus 5 is not in pi-ai yet; Sonnet 5 and Sonnet 4.6 have no map there.
+// Without an explicit mapping getSupportedThinkingLevels hides xhigh. Opus 5
+// supports xhigh directly; both Sonnet models map their top tier to max.
 const DEFAULT_THINKING_LEVEL_MAPS: Record<string, Record<string, string>> = {
+	"claude-opus-5": { xhigh: "xhigh" },
 	"claude-sonnet-5": { xhigh: "max" },
 	"claude-sonnet-4-6": { xhigh: "max" },
 };
 
 // Project pi-ai's model entries down to the fields pi's registerProvider expects,
-// and keep MODEL_IDS_IN_ORDER ordering. IDs missing from pi-ai are silently dropped.
+// and keep MODEL_IDS_IN_ORDER ordering. Unknown IDs without a bridge fallback are dropped.
 // Context-dependent display labels are applied after plan/long-context config is known.
 export function buildModels<T extends { id: string; [key: string]: any }>(piAiModels: T[]) {
 	return MODEL_IDS_IN_ORDER
-		.map((id) => piAiModels.find((m) => m.id === id))
+		.map((id) => piAiModels.find((m) => m.id === id) ?? BRIDGE_MODEL_FALLBACKS[id])
 		.filter((m) => m != null)
 		// Forward thinkingLevelMap so per-model overrides (e.g. opus-4-7 mapping
 		// xhigh→xhigh instead of xhigh→max) are visible to the effort lookup.
@@ -49,6 +72,8 @@ const ONE_M_CONTEXT = 1_000_000;
 // not, and [1m] entitlement differs by model. See diag/CONTEXT-SIZE.md.
 export function resolveClaudeCodeRuntimeModel(modelId: string, settings: LongContextSettings): ClaudeCodeRuntimeModel {
 	switch (modelId) {
+		case "claude-opus-5":
+			return { cliModelId: "claude-opus-5[1m]", contextWindow: ONE_M_CONTEXT };
 		case "claude-opus-4-8":
 			return { cliModelId: "claude-opus-4-8[1m]", contextWindow: ONE_M_CONTEXT };
 		case "claude-opus-4-7":

--- a/tests/unit-models.mjs
+++ b/tests/unit-models.mjs
@@ -41,10 +41,25 @@ describe("MODELS projection", () => {
 		assert.deepEqual(models.map((m) => m.id), MODEL_IDS_IN_ORDER);
 	});
 
-	it("silently drops IDs missing from pi-ai (no fallback)", () => {
-		// Only haiku present — opus/sonnet vanish from picker.
+	it("supplies Opus 5 while pi-ai has not published its catalog entry", () => {
 		const models = buildModels([mockPiAiModel("claude-haiku-4-5")]);
-		assert.deepEqual(models.map((m) => m.id), ["claude-haiku-4-5"]);
+		assert.deepEqual(find(models, "claude-opus-5"), {
+			id: "claude-opus-5",
+			name: "Claude Opus 5",
+			reasoning: true,
+			input: ["text", "image"],
+			contextWindow: 1000000,
+			maxTokens: 128000,
+			thinkingLevelMap: { xhigh: "xhigh" },
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		});
+	});
+
+	it("prefers pi-ai metadata when Opus 5 becomes available there", () => {
+		const upstream = { ...mockPiAiModel("claude-opus-5"), name: "Upstream Opus 5", maxTokens: 64000 };
+		const models = buildModels([upstream]);
+		assert.equal(find(models, "claude-opus-5")?.name, "Upstream Opus 5");
+		assert.equal(find(models, "claude-opus-5")?.maxTokens, 64000);
 	});
 
 	it("zeros out cost regardless of pi-ai pricing", () => {
@@ -80,6 +95,7 @@ describe("MODELS projection", () => {
 
 describe("Claude Code runtime model policy", () => {
 	it("uses measured Pro defaults", () => {
+		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-opus-5", PRO), { cliModelId: "claude-opus-5[1m]", contextWindow: 1000000 });
 		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-opus-4-8", PRO), { cliModelId: "claude-opus-4-8[1m]", contextWindow: 1000000 });
 		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-opus-4-7", PRO), { cliModelId: "claude-opus-4-7", contextWindow: 1000000 });
 		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-opus-4-6", PRO), { cliModelId: "claude-opus-4-6", contextWindow: 200000 });
@@ -109,6 +125,7 @@ describe("claudeCodeModelId", () => {
 	const models = buildModels(MODEL_IDS_IN_ORDER.map(oneM));
 
 	it("returns the measured SDK request id", () => {
+		assert.equal(claudeCodeModelId(find(models, "claude-opus-5"), PRO), "claude-opus-5[1m]");
 		assert.equal(claudeCodeModelId(find(models, "claude-opus-4-8"), PRO), "claude-opus-4-8[1m]");
 		assert.equal(claudeCodeModelId(find(models, "claude-opus-4-7"), PRO), "claude-opus-4-7");
 		assert.equal(claudeCodeModelId(find(models, "claude-opus-4-6"), PRO), "claude-opus-4-6");
@@ -124,6 +141,7 @@ describe("applyLongContext", () => {
 
 	it("registers measured Pro defaults", () => {
 		const registered = applyLongContext(models, PRO);
+		assert.equal(find(registered, "claude-opus-5").contextWindow, 1000000);
 		assert.equal(find(registered, "claude-opus-4-8").contextWindow, 1000000);
 		assert.equal(find(registered, "claude-opus-4-7").contextWindow, 1000000);
 		assert.equal(find(registered, "claude-opus-4-6").contextWindow, 200000);
@@ -148,6 +166,7 @@ describe("applyLongContext", () => {
 
 	it("labels exactly the registered 1M models", () => {
 		const pro = applyLongContext(models, PRO);
+		assert.equal(find(pro, "claude-opus-5").name, "claude-opus-5 1M");
 		assert.equal(find(pro, "claude-opus-4-8").name, "claude-opus-4-8 1M");
 		assert.equal(find(pro, "claude-opus-4-7").name, "claude-opus-4-7 1M");
 		assert.equal(find(pro, "claude-opus-4-6").name, "claude-opus-4-6");
@@ -162,8 +181,8 @@ describe("applyLongContext", () => {
 describe("resolveModel", () => {
 	const models = buildModels(MODEL_IDS_IN_ORDER.map(mockPiAiModel));
 
-	it("opus shortcut resolves to claude-opus-4-8 (first opus in order)", () => {
-		assert.equal(resolveModel(models, "opus")?.id, "claude-opus-4-8");
+	it("opus shortcut resolves to claude-opus-5 (first opus in order)", () => {
+		assert.equal(resolveModel(models, "opus")?.id, "claude-opus-5");
 	});
 
 	it("haiku shortcut resolves to claude-haiku-4-5", () => {
@@ -181,7 +200,7 @@ describe("resolveModel", () => {
 	it("returns the matched model object for CLI-arg conversion", () => {
 		const oneMModels = buildModels(MODEL_IDS_IN_ORDER.map(oneM));
 		const model = resolveModel(oneMModels, "opus");
-		assert.equal(model.id, "claude-opus-4-8");
-		assert.equal(claudeCodeModelId(model, PRO), "claude-opus-4-8[1m]");
+		assert.equal(model.id, "claude-opus-5");
+		assert.equal(claudeCodeModelId(model, PRO), "claude-opus-5[1m]");
 	});
 });


### PR DESCRIPTION
## Summary

- Add Claude Opus 5 to the bridge model picker
- Make the `opus` shortcut select Opus 5
- Route requests through `claude-opus-5[1m]`
- Provide temporary model metadata until pi-ai adds Opus 5
- Prefer pi-ai metadata automatically when it becomes available
- Align Pi development packages so typechecking uses compatible types

## Testing

- `npm run test:unit`, 100 tests passed
- `npm run typecheck`
- `npm pack --dry-run`
- Verified model registration through `pi --list-models`
- Completed a live bridge request with `claude-bridge/claude-opus-5`

## Notes

The temporary fallback can be removed after the minimum supported pi-ai version includes Opus 5.