### PR TITLE
Make Claude Code permission mode configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## UNRELEASED
+
+- **Add: configurable Claude Code permission modes** — provider and AskClaude sessions now have independent `provider.permissionMode` and `askClaude.permissionMode` overrides, while preserving the existing `bypassPermissions` default.
+- **Fix: compaction stream typecheck** — cast across the duplicated `pi-ai` dev dependency boundary, matching provider registration.
+
 ## 0.6.2 — 2026-07-06
 
 - **Fix: Sonnet 5 and Fable 5 with 1M context** — bare model IDs (`claude-sonnet-5`, `claude-fable-5`) are 200K context. Must pass `[1m]` suffix for both, similar to Opus 4.8.

--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ Config: `~/.pi/agent/claude-bridge.json` (global) or the project Pi config direc
     "enabled": true,
     "allowFullMode": true,
     "defaultIsolated": false,
+    "permissionMode": "auto",
     "description": "Custom tool description override"
   },
   "provider": {
+    "permissionMode": "auto",
     "plan": "max",
     "longContextExtraUsage": false,
     "strictMcpConfig": true,
@@ -79,8 +81,10 @@ Config: `~/.pi/agent/claude-bridge.json` (global) or the project Pi config direc
 - `defaultIsolated` — start each call in a fresh session (default `false`)
 - `allowFullMode` — allow `mode: "full"`; set `false` to lock it out
 - `appendSkills` — forward pi's skills block into the system prompt (default `true`)
+- `permissionMode` — Claude Code permission mode (default `"bypassPermissions"`). This is independent of the `read` / `full` / `none` capability mode.
 
 `provider`:
+- `permissionMode` — Claude Code permission mode for provider tool calls (default `"bypassPermissions"`)
 - `plan` (default `"pro"`) — set to `"max"` for Max (or Team Premium/Enterprise) to enable Opus 4.6 with 1M context.
 - `longContextExtraUsage` — set to `true` to enable 1M models that cost money through Extra Usage. It enables Sonnet 4.6 with 1M on every plan and Opus 4.6 with 1M on Pro. Not needed for Opus 4.7 or 4.8.
 - `appendSystemPrompt` — append pi's AGENTS.md and skills (default `true`)

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,11 +3,19 @@
 // overriding global. Missing or unparseable files are ignored (error to
 // console.error, empty object returned) so the extension always starts.
 
-import type { SettingSource } from "@anthropic-ai/claude-agent-sdk";
+import type { PermissionMode, SettingSource } from "@anthropic-ai/claude-agent-sdk";
 import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
 import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
+
+export type BridgePermissionMode = Exclude<PermissionMode, "plan">;
+
+export const DEFAULT_PERMISSION_MODE: BridgePermissionMode = "bypassPermissions";
+
+export function resolvePermissionMode(mode?: BridgePermissionMode): BridgePermissionMode {
+	return mode ?? DEFAULT_PERMISSION_MODE;
+}
 
 export interface Config {
 	askClaude?: {
@@ -19,6 +27,7 @@ export interface Config {
 		defaultIsolated?: boolean;
 		allowFullMode?: boolean;
 		appendSkills?: boolean;
+		permissionMode?: BridgePermissionMode;
 	};
 	/** Low-level Claude Agent SDK plumbing. Most users won't need these. */
 	provider?: {
@@ -26,6 +35,7 @@ export interface Config {
 		settingSources?: SettingSource[];
 		strictMcpConfig?: boolean;
 		pathToClaudeCodeExecutable?: string;
+		permissionMode?: BridgePermissionMode;
 		// Subscription plan tier. Setting to "max" enables Opus 4.6 at 1M context
 		plan?: "pro" | "max";
 		// Set to true to opt into metered 1M context usage ("extra usage" in

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { MCP_SERVER_NAME, MCP_TOOL_PREFIX, extractSkillsBlock } from "./skills.j
 import { verifyWrittenSession as _verifyWrittenSession } from "./session-verify.js";
 import { extractAllToolResults as _extractAllToolResults, type McpResult } from "./extract-tool-results.js";
 import { QueryContext, ctx } from "./query-state.js";
-import { loadConfig, type Config } from "./config.js";
+import { loadConfig, resolvePermissionMode, type BridgePermissionMode, type Config } from "./config.js";
 import { extractAgentsAppend } from "./agents-md.js";
 import { jsonSchemaToZodShape } from "./typebox-to-zod.js";
 import { buildActionSummary, type ToolCallState } from "./askclaude-ui.js";
@@ -136,6 +136,14 @@ function errorMessage(err: unknown): string {
 		try { return JSON.stringify(err); } catch {}
 	}
 	return String(err);
+}
+
+function permissionOptions(configuredMode?: BridgePermissionMode) {
+	const permissionMode = resolvePermissionMode(configuredMode);
+	return {
+		permissionMode,
+		...(permissionMode === "bypassPermissions" ? { allowDangerouslySkipPermissions: true } : {}),
+	};
 }
 
 // AskClaude mode presets — controls which CC tools are blocked per mode.
@@ -1248,7 +1256,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		cwd,
 		env: childEnv,
 		tools: [],
-		permissionMode: "bypassPermissions",
+		...permissionOptions(providerSettings.permissionMode),
 		includePartialMessages: true,
 		systemPrompt: {
 			type: "preset", preset: "claude_code",
@@ -1266,6 +1274,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	debug("provider: fresh query",
 		`model=${cliModel} msgs=${context.messages.length} tools=${mcpTools.length}`,
 		`resume=${resumeSessionId?.slice(0, 8) ?? "none"} effort=${effort ?? "default"}`,
+		`permission=${resolvePermissionMode(providerSettings.permissionMode)}`,
 		`appendSys=${appendSystemPrompt} strictMcp=${strictMcpConfigEnabled}`,
 		`prompt=${promptText.slice(0, 60)}${promptBlocks ? " [+images]" : ""}`);
 
@@ -1479,6 +1488,7 @@ async function promptAndWait(
 
 	debug("askClaude:",
 		`mode=${mode} model=${modelId} cliModel=${cliModel} effort=${effort ?? "default"}`,
+		`permission=${resolvePermissionMode(askClaudePermissionMode)}`,
 		`isolated=${options?.isolated ?? false} resume=${resumeSessionId?.slice(0, 8) ?? "none"}`,
 		`skills=${Boolean(skillsBlock)} promptLen=${prompt.length}`);
 
@@ -1487,7 +1497,7 @@ async function promptAndWait(
 		options: {
 			cwd,
 			env: { ...process.env, ENABLE_CLAUDEAI_MCP_SERVERS: "0", DISABLE_AUTO_COMPACT: "1" },
-			permissionMode: "bypassPermissions",
+			...permissionOptions(askClaudePermissionMode),
 			...(disallowedTools.length ? { disallowedTools } : {}),
 			...(effort ? { effort } : {}),
 			systemPrompt: skillsBlock
@@ -1588,6 +1598,7 @@ const PREVIEW_MAX_CHARS = 1000;
 const PREVIEW_MAX_LINES = 6;
 
 let askClaudeToolName = "AskClaude";
+let askClaudePermissionMode: BridgePermissionMode | undefined;
 
 export default function (pi: ExtensionAPI) {
 	// Disable non-essential Claude Code traffic (update checks, MCP registry, telemetry)
@@ -1642,7 +1653,8 @@ export default function (pi: ExtensionAPI) {
 				event.customInstructions,
 				event.signal,
 				undefined,
-				isolatedStreamFn,
+				// Cast: pi-ai is duplicated through the pi-coding-agent dev dependency.
+				isolatedStreamFn as any,
 				undefined,
 			);
 			debug(`session_before_compact: takeover complete summaryLen=${compaction.summary.length}`);
@@ -1704,6 +1716,7 @@ export default function (pi: ExtensionAPI) {
 	// --- AskClaude tool ---
 
 	const askConf = config.askClaude;
+	askClaudePermissionMode = askConf?.permissionMode;
 	const allowFull = askConf?.allowFullMode !== false;
 	const defaultMode = askConf?.defaultMode ?? "read";
 	const defaultIsolated = askConf?.defaultIsolated ?? false;

--- a/tests/unit-config.mjs
+++ b/tests/unit-config.mjs
@@ -4,7 +4,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
-import { loadConfig } from "../src/config.js";
+import { loadConfig, resolvePermissionMode } from "../src/config.js";
 
 function withTempHome(fn) {
 	const oldHome = process.env.HOME;
@@ -19,6 +19,16 @@ function withTempHome(fn) {
 	}
 }
 
+describe("resolvePermissionMode", () => {
+	it("preserves the existing bypassPermissions default", () => {
+		assert.equal(resolvePermissionMode(), "bypassPermissions");
+	});
+
+	it("preserves an explicit mode", () => {
+		assert.equal(resolvePermissionMode("bypassPermissions"), "bypassPermissions");
+	});
+});
+
 describe("loadConfig", () => {
 	it("loads project config from Pi's configured project directory", () => withTempHome(() => {
 		const cwd = mkdtempSync(join(tmpdir(), "claude-bridge-project-"));
@@ -26,13 +36,13 @@ describe("loadConfig", () => {
 			const configDir = join(cwd, CONFIG_DIR_NAME);
 			mkdirSync(configDir, { recursive: true });
 			writeFileSync(join(configDir, "claude-bridge.json"), JSON.stringify({
-				provider: { plan: "max" },
-				askClaude: { enabled: false },
+				provider: { plan: "max", permissionMode: "auto" },
+				askClaude: { enabled: false, permissionMode: "auto" },
 			}));
 
 			assert.deepEqual(loadConfig(cwd), {
-				provider: { plan: "max" },
-				askClaude: { enabled: false },
+				provider: { plan: "max", permissionMode: "auto" },
+				askClaude: { enabled: false, permissionMode: "auto" },
 			});
 		} finally {
 			rmSync(cwd, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- expose independent `provider.permissionMode` and `askClaude.permissionMode` settings
- preserve `bypassPermissions` as the compatibility default
- set the SDK safety acknowledgement when bypass mode is selected
- document that permission mode is separate from AskClaude capability mode

## Validation
- `npm run typecheck`
- `npm run test:unit` (101 passing)
- live provider smoke test with `permissionMode: "auto"` and an MCP-bridged Pi `read` tool

The compaction stream cast fixes an existing `pi-ai` diamond-dependency typecheck error exposed by the current lockfile.