### PR TITLE
Fix images in trailing user messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { calculateCost, StringEnum, type AssistantMessage, type AssistantMessageEventStream, type Context, type Model, type SimpleStreamOptions, type Tool } from "@earendil-works/pi-ai";
+import { calculateCost, StringEnum, type AssistantMessage, type AssistantMessageEventStream, type Context, type ImageContent, type Model, type SimpleStreamOptions, type TextContent, type Tool, type UserMessage } from "@earendil-works/pi-ai";
 import * as piAi from "@earendil-works/pi-ai";
 import { getModels } from "@earendil-works/pi-ai/compat";
 import { buildSessionContext, compact, keyHint, type CompactionEntry, type ExtensionAPI, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
@@ -240,38 +240,45 @@ function extractUserPrompt(messages: Context["messages"]): string | null {
 	return messageContentToText(last.content) || "";
 }
 
-/** Extract the last user message as ContentBlockParam[] (preserving images).
+/** Extract the trailing user turn as ContentBlockParam[] (preserving images).
  *  Returns null if no images — caller should fall back to string prompt. */
 function extractUserPromptBlocks(messages: Context["messages"]): ContentBlockParam[] | null {
-	const last = messages[messages.length - 1];
-	if (!last || last.role !== "user") return null;
-	if (typeof last.content === "string") {
-		debug(`extractUserPromptBlocks: content is string (length=${last.content.length})`);
-		return null;
+	const userTail: UserMessage[] = [];
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i];
+		if (!message || message.role !== "user") break;
+		userTail.unshift(message);
 	}
-	if (!Array.isArray(last.content)) {
-		debug(`extractUserPromptBlocks: content is ${typeof last.content}`);
-		return null;
-	}
-	debug(`extractUserPromptBlocks: ${last.content.length} blocks, types=${last.content.map((b: any) => b.type).join(",")}`);
+	if (userTail.length === 0) return null;
+
 	let hasImage = false;
 	const blocks: ContentBlockParam[] = [];
-	for (const block of last.content) {
-		if (block.type === "text" && block.text) {
-			blocks.push({ type: "text", text: block.text });
-		} else if (block.type === "image") {
-			debug(`image block: mimeType=${(block as any).mimeType}, data length=${((block as any).data ?? "").length}, keys=${Object.keys(block).join(",")}`);
-			if (!(block as any).data || !(block as any).mimeType) {
-				debug(`image block missing data or mimeType, skipping`);
-				continue;
+	for (const message of userTail) {
+		const content: (TextContent | ImageContent)[] = typeof message.content === "string"
+			? [{ type: "text", text: message.content }]
+			: message.content;
+		for (const block of content) {
+			if (block.type === "text" && block.text) {
+				blocks.push({ type: "text", text: block.text });
+			} else if (block.type === "image") {
+				debug(`image block: mimeType=${block.mimeType}, data length=${block.data.length}, keys=${Object.keys(block).join(",")}`);
+				if (!block.data || !block.mimeType) {
+					debug(`image block missing data or mimeType, skipping`);
+					continue;
+				}
+				hasImage = true;
+				blocks.push({
+					type: "image",
+					source: {
+						type: "base64",
+						media_type: block.mimeType as Base64ImageSource["media_type"],
+						data: block.data,
+					},
+				});
 			}
-			hasImage = true;
-			blocks.push({
-				type: "image",
-				source: { type: "base64", media_type: block.mimeType as Base64ImageSource["media_type"], data: block.data },
-			});
 		}
 	}
+	debug(`extractUserPromptBlocks: ${userTail.length} trailing user messages, ${blocks.length} blocks`);
 	return hasImage ? blocks : null;
 }
 
@@ -606,6 +613,7 @@ export const __test = {
 		return sharedSession;
 	},
 	syncSharedSession,
+	extractUserPromptBlocks,
 };
 
 // --- Provider helpers: tool name mapping ---

--- a/tests/unit-prompt-blocks.mjs
+++ b/tests/unit-prompt-blocks.mjs
@@ -1,0 +1,32 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { __test } = await import("../src/index.js");
+
+describe("extractUserPromptBlocks", () => {
+	it("keeps images and text from the trailing run of user messages", () => {
+		const blocks = __test.extractUserPromptBlocks([
+			{ role: "user", content: [
+				{ type: "text", text: "describe this" },
+				{ type: "image", mimeType: "image/png", data: "aW1hZ2U=" },
+			] },
+			{ role: "user", content: "(attachment preview: [#image 1])" },
+		]);
+
+		assert.deepEqual(blocks, [
+			{ type: "text", text: "describe this" },
+			{ type: "image", source: { type: "base64", media_type: "image/png", data: "aW1hZ2U=" } },
+			{ type: "text", text: "(attachment preview: [#image 1])" },
+		]);
+	});
+
+	it("does not reach past the current user turn", () => {
+		const blocks = __test.extractUserPromptBlocks([
+			{ role: "user", content: [{ type: "image", mimeType: "image/png", data: "b2xk" }] },
+			{ role: "assistant", content: [{ type: "text", text: "done" }] },
+			{ role: "user", content: "next turn" },
+		]);
+
+		assert.equal(blocks, null);
+	});
+});


### PR DESCRIPTION
Fixes #34.

`extractUserPromptBlocks()` only inspected the final message. When an extension appended a display or preview user message after the real image-bearing message, the image moved into the text-only history path and never reached Claude.

This change scans the trailing run of user messages as one current turn. It preserves text and image order, and stops at the first assistant or tool-result boundary so an earlier turn's images are not resent.

Tests cover an image displaced by a trailing preview message and the prior-turn boundary.

Checks:

- `npm run test:unit`: 101 passed
- focused prompt-block test: 2 passed
- `npm run typecheck`: the branch has no new type errors, but the command still exits on the existing duplicate `pi-ai` `AssistantMessageEventStream` type in `src/index.ts`. The same error is present on an unchanged `main` checkout.

## Environment

- `pi-claude-bridge@0.6.2`
- `@earendil-works/pi-coding-agent@0.82.1`
- Claude Code `2.1.170`
- Claude Agent SDK `0.2.141`
- Node.js `22.22.2`
- Ubuntu 24.04 on WSL2
- `pi-paster@0.1.4` (`f0b33fe`), which appends the trailing attachment-preview user message
