### PR TITLE
Add claude-opus-5 model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- **Add: claude-opus-5 model** — Anthropic's Claude Opus 5 is now selectable via `/model`, and the `opus` shortcut resolves to it (newest Opus, as with the 4.8 bump). Like Opus 4.8, the bare `claude-opus-5` id serves 200K, so the bridge requests `claude-opus-5[1m]` for 1M context. Measured 2026-07-26 via the Agent SDK (subscription OAuth): bare `claude-opus-5` → 200K, `claude-opus-5[1m]` → 1M, served with no credit gate. pi-ai supplies the metadata (`thinkingLevelMap` present, so no workaround needed).
+
 ## 0.6.2 — 2026-07-06
 
 - **Fix: Sonnet 5 and Fable 5 with 1M context** — bare model IDs (`claude-sonnet-5`, `claude-fable-5`) are 200K context. Must pass `[1m]` suffix for both, similar to Opus 4.8.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pi install npm:pi-claude-bridge
 
 ## Provider
 
-Use `/model` to select `claude-bridge/claude-fable-5`, `claude-bridge/claude-opus-4-8`, `claude-bridge/claude-opus-4-7`, `claude-bridge/claude-opus-4-6`, `claude-bridge/claude-sonnet-5`, `claude-bridge/claude-sonnet-4-6`, or `claude-bridge/claude-haiku-4-5`.
+Use `/model` to select `claude-bridge/claude-fable-5`, `claude-bridge/claude-opus-5`, `claude-bridge/claude-opus-4-8`, `claude-bridge/claude-opus-4-7`, `claude-bridge/claude-opus-4-6`, `claude-bridge/claude-sonnet-5`, `claude-bridge/claude-sonnet-4-6`, or `claude-bridge/claude-haiku-4-5`.
 
 Behind the scenes, pi's tools are bridged to Claude Code but it should all work like normal in pi. Bash commands get a 120-second default timeout (matching Claude Code's default) since pi's bash has no timeout by default. Skills in pi are copied over to Claude Code's system prompt so should work as they would with any other pi provider.
 
@@ -82,7 +82,7 @@ Config: `~/.pi/agent/claude-bridge.json` (global) or the project Pi config direc
 
 `provider`:
 - `plan` (default `"pro"`) — set to `"max"` for Max (or Team Premium/Enterprise) to enable Opus 4.6 with 1M context.
-- `longContextExtraUsage` — set to `true` to enable 1M models that cost money through Extra Usage. It enables Sonnet 4.6 with 1M on every plan and Opus 4.6 with 1M on Pro. Not needed for Opus 4.7 or 4.8.
+- `longContextExtraUsage` — set to `true` to enable 1M models that cost money through Extra Usage. It enables Sonnet 4.6 with 1M on every plan and Opus 4.6 with 1M on Pro. Not needed for Opus 4.7, 4.8, or 5.
 - `appendSystemPrompt` — append pi's AGENTS.md and skills (default `true`)
 - `settingSources` — CC filesystem settings to load; only applied when `appendSystemPrompt: false`
 - `strictMcpConfig` — block MCP servers from `~/.claude.json` / `.mcp.json` (default `true`). Cloud MCP (Gmail/Drive via claude.ai OAuth) is always blocked.

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,7 +2,7 @@
 // `resolveModel` returns the first partial match, so `opus` resolves to the first-listed opus entry.
 // Extracted from index.ts so tests can import without activating the extension.
 
-export const MODEL_IDS_IN_ORDER = ["claude-fable-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-5", "claude-sonnet-4-6", "claude-haiku-4-5"];
+export const MODEL_IDS_IN_ORDER = ["claude-fable-5", "claude-opus-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-5", "claude-sonnet-4-6", "claude-haiku-4-5"];
 
 // Workaround for missing thinkingLevelMap in pi-ai (earendil-works/pi#6371).
 // Sonnet 5 and Sonnet 4.6 have no map, so getSupportedThinkingLevels hides
@@ -49,6 +49,8 @@ const ONE_M_CONTEXT = 1_000_000;
 // not, and [1m] entitlement differs by model. See diag/CONTEXT-SIZE.md.
 export function resolveClaudeCodeRuntimeModel(modelId: string, settings: LongContextSettings): ClaudeCodeRuntimeModel {
 	switch (modelId) {
+		case "claude-opus-5":
+			return { cliModelId: "claude-opus-5[1m]", contextWindow: ONE_M_CONTEXT };
 		case "claude-opus-4-8":
 			return { cliModelId: "claude-opus-4-8[1m]", contextWindow: ONE_M_CONTEXT };
 		case "claude-opus-4-7":

--- a/tests/unit-models.mjs
+++ b/tests/unit-models.mjs
@@ -80,6 +80,7 @@ describe("MODELS projection", () => {
 
 describe("Claude Code runtime model policy", () => {
 	it("uses measured Pro defaults", () => {
+		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-opus-5", PRO), { cliModelId: "claude-opus-5[1m]", contextWindow: 1000000 });
 		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-opus-4-8", PRO), { cliModelId: "claude-opus-4-8[1m]", contextWindow: 1000000 });
 		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-opus-4-7", PRO), { cliModelId: "claude-opus-4-7", contextWindow: 1000000 });
 		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-opus-4-6", PRO), { cliModelId: "claude-opus-4-6", contextWindow: 200000 });
@@ -88,6 +89,7 @@ describe("Claude Code runtime model policy", () => {
 	});
 
 	it("plan max only changes Opus 4.6", () => {
+		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-opus-5", MAX), { cliModelId: "claude-opus-5[1m]", contextWindow: 1000000 });
 		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-opus-4-8", MAX), { cliModelId: "claude-opus-4-8[1m]", contextWindow: 1000000 });
 		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-opus-4-7", MAX), { cliModelId: "claude-opus-4-7", contextWindow: 1000000 });
 		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-opus-4-6", MAX), { cliModelId: "claude-opus-4-6[1m]", contextWindow: 1000000 });
@@ -148,6 +150,7 @@ describe("applyLongContext", () => {
 
 	it("labels exactly the registered 1M models", () => {
 		const pro = applyLongContext(models, PRO);
+		assert.equal(find(pro, "claude-opus-5").name, "claude-opus-5 1M");
 		assert.equal(find(pro, "claude-opus-4-8").name, "claude-opus-4-8 1M");
 		assert.equal(find(pro, "claude-opus-4-7").name, "claude-opus-4-7 1M");
 		assert.equal(find(pro, "claude-opus-4-6").name, "claude-opus-4-6");
@@ -162,8 +165,8 @@ describe("applyLongContext", () => {
 describe("resolveModel", () => {
 	const models = buildModels(MODEL_IDS_IN_ORDER.map(mockPiAiModel));
 
-	it("opus shortcut resolves to claude-opus-4-8 (first opus in order)", () => {
-		assert.equal(resolveModel(models, "opus")?.id, "claude-opus-4-8");
+	it("opus shortcut resolves to claude-opus-5 (first opus in order)", () => {
+		assert.equal(resolveModel(models, "opus")?.id, "claude-opus-5");
 	});
 
 	it("haiku shortcut resolves to claude-haiku-4-5", () => {
@@ -181,7 +184,7 @@ describe("resolveModel", () => {
 	it("returns the matched model object for CLI-arg conversion", () => {
 		const oneMModels = buildModels(MODEL_IDS_IN_ORDER.map(oneM));
 		const model = resolveModel(oneMModels, "opus");
-		assert.equal(model.id, "claude-opus-4-8");
-		assert.equal(claudeCodeModelId(model, PRO), "claude-opus-4-8[1m]");
+		assert.equal(model.id, "claude-opus-5");
+		assert.equal(claudeCodeModelId(model, PRO), "claude-opus-5[1m]");
 	});
 });


### PR DESCRIPTION
## What

Adds **Claude Opus 5** to the claude-bridge model picker. It is already in pi-ai's Anthropic catalog but was dropped because `MODEL_IDS_IN_ORDER` did not list it.

## Runtime mapping (measured)

Opus 5 behaves exactly like Opus 4.8, so it needs the `[1m]` suffix for 1M (the bare id serves 200K). Measured on 2026-07-26 with the `diag/context-size.mjs` method — Agent SDK `query()`, subscription OAuth (no `ANTHROPIC_API_KEY`), one trivial turn per id, reading `result.modelUsage[*].contextWindow`:

| requested id | served |
|----------------------|--------|
| `claude-opus-5`      | 200K   |
| `claude-opus-5[1m]`  | 1M     |

Both returned `subtype: success`, `is_error: false`, with no `429` / credit gate — the same shape as `claude-opus-4-8[1m]`. So the runtime case mirrors Opus 4.8 (unconditional `[1m]` to 1M). pi-ai ships a `thinkingLevelMap` for it (`{xhigh, max}`), so no `DEFAULT_THINKING_LEVEL_MAPS` workaround is needed.

## Changes

- `src/models.ts` — add `claude-opus-5` to `MODEL_IDS_IN_ORDER` (first opus, so the `opus` shortcut resolves to it, matching the earlier 4.8 bump) and a runtime case returning `claude-opus-5[1m]` / 1M.
- `tests/unit-models.mjs` — opus-5 assertions (runtime policy PRO + MAX, the 1M label, and the `opus` shortcut now pinned to opus-5).
- `README.md` — list `claude-opus-5`; note `longContextExtraUsage` is not needed for it.
- `CHANGELOG.md` — `UNRELEASED` entry.

## Tests

`npm run test:unit` (tests/unit-models.mjs): **22/22 pass**. These edits add no new `tsc` errors.

> Note: the `opus` shortcut now resolves to Opus 5 instead of 4.8 (newest opus first, consistent with how 0.5.0 moved it to 4.8). Happy to pin opus-5 lower in the list instead if you would prefer to keep `opus` on 4.8.
