### PR TITLE
Stop stalled Claude SDK streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Set `CLAUDE_BRIDGE_DEBUG=1` to enable debug output:
 
 When filing a bug about a session-resume failure (e.g. "No conversation found"), the most useful attachments are the `syncResult:` lines from the bridge log plus the matching `cc-cli-logs/` file for the failing query.
 
+The bridge stops an SDK query that produces no events for 120 seconds after streaming has started. The first event gets a longer 300-second minimum because large contexts can have a slow prefill. The timer stands down while a pi tool call is pending. Set `CLAUDE_BRIDGE_IDLE_TIMEOUT_MS` or `CLAUDE_BRIDGE_FIRST_TOKEN_TIMEOUT_MS` to override the defaults; set both to `0` to disable the watchdog.
+
 ## Maintenance
 
 After a Claude Code release, review `MODE_DISALLOWED_TOOLS` in `src/index.ts` — it gates which CC tools the AskClaude subagent may invoke per mode (`read` / `full` / `none`). Add new agentic tools (PlanMode, Task spawning, etc.) to the appropriate mode lists if they shouldn't be available to subagents.

--- a/src/index.ts
+++ b/src/index.ts
@@ -606,6 +606,7 @@ export const __test = {
 		return sharedSession;
 	},
 	syncSharedSession,
+	consumeQuery,
 };
 
 // --- Provider helpers: tool name mapping ---
@@ -1016,52 +1017,102 @@ async function consumeQuery(
 	queryCtx: QueryContext,
 ): Promise<{ capturedSessionId?: string }> {
 	let capturedSessionId: string | undefined;
-
-	for await (const message of sdkQuery) {
-		if (wasAborted()) break;
-		if (!queryCtx.currentPiStream || !queryCtx.turnOutput) continue;
-
-		switch (message.type) {
-			case "stream_event":
-				processStreamEvent(message, customToolNameToPi, model, queryCtx);
-				break;
-			case "assistant":
-				processAssistantMessage(message, model, customToolNameToPi, queryCtx);
-				break;
-			case "result":
-				logServedContextWindow("result", message, model);
-				if (!queryCtx.turnSawStreamEvent && message.subtype === "success") {
-					ensureTurnStarted(queryCtx);
-					const text = message.result || "";
-					queryCtx.turnBlocks.push({ type: "text", text });
-					const idx = queryCtx.turnBlocks.length - 1;
-					queryCtx.currentPiStream?.push({ type: "text_start", contentIndex: idx, partial: queryCtx.turnOutput });
-					queryCtx.currentPiStream?.push({ type: "text_delta", contentIndex: idx, delta: text, partial: queryCtx.turnOutput });
-					queryCtx.currentPiStream?.push({ type: "text_end", contentIndex: idx, content: text, partial: queryCtx.turnOutput });
-				}
-				break;
-			case "system":
-				if ((message as any).subtype === "init" && (message as any).session_id) {
-					capturedSessionId = (message as any).session_id;
-				}
-				break;
-			case "user":
-				break; // SDK echo of user prompt — not needed
-			case "rate_limit_event": {
-				const info = (message as any).rate_limit_info;
-				debug("consumeQuery: rate_limit_event", JSON.stringify(info).slice(0, 300));
-				if (info?.status === "rejected") {
-					const resetsAt = info.resetsAt ? new Date(info.resetsAt).toLocaleTimeString() : "unknown";
-					piUI?.notify(`Claude rate limited (${info.rateLimitType ?? "unknown"}) — resets at ${resetsAt}`, "warning");
-				} else if (info?.status === "allowed_warning") {
-					piUI?.notify(`Claude rate limit warning: ${Math.round(info.utilization ?? 0)}% used (${info.rateLimitType ?? ""})`, "warning");
-				}
-				break;
+	const idleMsValue = Number(process.env.CLAUDE_BRIDGE_IDLE_TIMEOUT_MS ?? 120_000);
+	const idleMs = Number.isFinite(idleMsValue) && idleMsValue >= 0 ? idleMsValue : 120_000;
+	const firstTokenDefault = idleMs > 0 ? Math.max(300_000, idleMs * 3) : 0;
+	const firstTokenMsValue = Number(process.env.CLAUDE_BRIDGE_FIRST_TOKEN_TIMEOUT_MS ?? firstTokenDefault);
+	const firstTokenMs = Number.isFinite(firstTokenMsValue) && firstTokenMsValue >= 0 ? firstTokenMsValue : firstTokenDefault;
+	let idleTimer: ReturnType<typeof setTimeout> | undefined;
+	let streamPhase: "first-token" | "stream" = "first-token";
+	let stalledPhase: "first-token" | "stream" = "first-token";
+	let stalledBudgetMs = 0;
+	let idleTimedOut = false;
+	const clearIdleTimer = () => {
+		if (idleTimer !== undefined) clearTimeout(idleTimer);
+		idleTimer = undefined;
+	};
+	const armIdleTimer = () => {
+		clearIdleTimer();
+		const budgetMs = streamPhase === "stream" ? idleMs : firstTokenMs;
+		if (!(budgetMs > 0)) return;
+		idleTimer = setTimeout(() => {
+			idleTimer = undefined;
+			if (queryCtx.pendingToolCalls.size > 0) {
+				armIdleTimer();
+				return;
 			}
-			default:
-				debug("consumeQuery: unhandled SDK message type", message.type);
-				break;
+			idleTimedOut = true;
+			stalledPhase = streamPhase;
+			stalledBudgetMs = budgetMs;
+			piUI?.notify(`Claude stream idle for ${Math.round(budgetMs / 1000)}s; stopping stalled request`, "warning");
+			void sdkQuery.interrupt().catch(() => {});
+			try { sdkQuery.close(); } catch {}
+		}, budgetMs);
+	};
+	armIdleTimer();
+
+	try {
+		for await (const message of sdkQuery) {
+			if (wasAborted()) break;
+			if (message.type === "stream_event") {
+				streamPhase = "stream";
+			} else if (message.type === "assistant" && message.message.content.some((block) => block.type === "tool_use")) {
+				streamPhase = "first-token";
+			} else if (message.type === "result") {
+				streamPhase = "first-token";
+			}
+			armIdleTimer();
+			if (!queryCtx.currentPiStream || !queryCtx.turnOutput) continue;
+
+			switch (message.type) {
+				case "stream_event":
+					processStreamEvent(message, customToolNameToPi, model, queryCtx);
+					break;
+				case "assistant":
+					processAssistantMessage(message, model, customToolNameToPi, queryCtx);
+					break;
+				case "result":
+					logServedContextWindow("result", message, model);
+					if (!queryCtx.turnSawStreamEvent && message.subtype === "success") {
+						ensureTurnStarted(queryCtx);
+						const text = message.result || "";
+						queryCtx.turnBlocks.push({ type: "text", text });
+						const idx = queryCtx.turnBlocks.length - 1;
+						queryCtx.currentPiStream?.push({ type: "text_start", contentIndex: idx, partial: queryCtx.turnOutput });
+						queryCtx.currentPiStream?.push({ type: "text_delta", contentIndex: idx, delta: text, partial: queryCtx.turnOutput });
+						queryCtx.currentPiStream?.push({ type: "text_end", contentIndex: idx, content: text, partial: queryCtx.turnOutput });
+					}
+					break;
+				case "system":
+					if ((message as any).subtype === "init" && (message as any).session_id) {
+						capturedSessionId = (message as any).session_id;
+					}
+					break;
+				case "user":
+					break; // SDK echo of user prompt — not needed
+				case "rate_limit_event": {
+					const info = (message as any).rate_limit_info;
+					debug("consumeQuery: rate_limit_event", JSON.stringify(info).slice(0, 300));
+					if (info?.status === "rejected") {
+						const resetsAt = info.resetsAt ? new Date(info.resetsAt).toLocaleTimeString() : "unknown";
+						piUI?.notify(`Claude rate limited (${info.rateLimitType ?? "unknown"}) — resets at ${resetsAt}`, "warning");
+					} else if (info?.status === "allowed_warning") {
+						piUI?.notify(`Claude rate limit warning: ${Math.round(info.utilization ?? 0)}% used (${info.rateLimitType ?? ""})`, "warning");
+					}
+					break;
+				}
+				default:
+					debug("consumeQuery: unhandled SDK message type", message.type);
+					break;
+			}
 		}
+	} catch (error) {
+		if (!idleTimedOut || wasAborted()) throw error;
+	} finally {
+		clearIdleTimer();
+	}
+	if (idleTimedOut && !wasAborted()) {
+		throw new Error(`Claude SDK stream stalled: no ${stalledPhase} activity for ${stalledBudgetMs}ms`);
 	}
 
 	// DEBUG: trace when consumeQuery exits

--- a/tests/unit-stream-idle-watchdog.mjs
+++ b/tests/unit-stream-idle-watchdog.mjs
@@ -1,0 +1,62 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { QueryContext } from "../src/query-state.js";
+
+const { __test } = await import("../src/index.js");
+
+function halfOpenQuery() {
+	let finish;
+	return {
+		interruptCount: 0,
+		closeCount: 0,
+		[Symbol.asyncIterator]() { return this; },
+		next() { return new Promise((resolve) => { finish = resolve; }); },
+		interrupt() { this.interruptCount++; return Promise.resolve(); },
+		close() { this.closeCount++; finish?.({ done: true }); },
+	};
+}
+
+async function withShortTimeouts(run) {
+	const previousIdle = process.env.CLAUDE_BRIDGE_IDLE_TIMEOUT_MS;
+	const previousFirst = process.env.CLAUDE_BRIDGE_FIRST_TOKEN_TIMEOUT_MS;
+	process.env.CLAUDE_BRIDGE_IDLE_TIMEOUT_MS = "10";
+	process.env.CLAUDE_BRIDGE_FIRST_TOKEN_TIMEOUT_MS = "10";
+	try {
+		await run();
+	} finally {
+		if (previousIdle === undefined) delete process.env.CLAUDE_BRIDGE_IDLE_TIMEOUT_MS;
+		else process.env.CLAUDE_BRIDGE_IDLE_TIMEOUT_MS = previousIdle;
+		if (previousFirst === undefined) delete process.env.CLAUDE_BRIDGE_FIRST_TOKEN_TIMEOUT_MS;
+		else process.env.CLAUDE_BRIDGE_FIRST_TOKEN_TIMEOUT_MS = previousFirst;
+	}
+}
+
+describe("stream idle watchdog", () => {
+	it("interrupts a half-open SDK query and returns a provider error", async () => {
+		await withShortTimeouts(async () => {
+			const query = halfOpenQuery();
+			await assert.rejects(
+				__test.consumeQuery(query, new Map(), {}, () => false, new QueryContext()),
+				/Claude SDK stream stalled: no first-token activity for 10ms/,
+			);
+			assert.equal(query.interruptCount, 1);
+			assert.equal(query.closeCount, 1);
+		});
+	});
+
+	it("does not interrupt while a pi tool call is pending", async () => {
+		await withShortTimeouts(async () => {
+			const query = halfOpenQuery();
+			const context = new QueryContext();
+			context.pendingToolCalls.set("tool-1", {});
+			const result = __test.consumeQuery(query, new Map(), {}, () => false, context);
+
+			await new Promise((resolve) => setTimeout(resolve, 35));
+			assert.equal(query.interruptCount, 0);
+			context.pendingToolCalls.clear();
+
+			await assert.rejects(result, /Claude SDK stream stalled/);
+			assert.equal(query.interruptCount, 1);
+		});
+	});
+});


### PR DESCRIPTION
Fixes #35.

The Claude Agent SDK can leave its async iterator open without producing another event or throwing. `consumeQuery()` then waits forever, so pi remains on `Working...` and the normal provider error path never runs.

This adds a bounded watchdog around the SDK stream:

- 120-second idle timeout after streaming starts
- 300-second minimum before the first token, since large-context prefill can be slower
- no timeout while a pi tool call is pending
- `interrupt()` and `close()` when the timer expires, followed by a normal provider error

The defaults can be changed with `CLAUDE_BRIDGE_IDLE_TIMEOUT_MS` and `CLAUDE_BRIDGE_FIRST_TOKEN_TIMEOUT_MS`. Setting both to `0` disables the watchdog.

The unit checks use a fake SDK iterator that never resolves. They verify that the bridge interrupts and closes it, then returns a bounded `stream stalled` error, while leaving the query alone as long as a pi tool call remains pending.

## Environment

- `pi-claude-bridge@0.6.2`
- `@earendil-works/pi-coding-agent@0.82.1`
- Claude Code `2.1.170`
- Claude Agent SDK `0.2.141`
- Node.js `22.22.2`
- Claude Max plan
- Ubuntu 24.04 on WSL2

## Checks

- `npm run test:unit`: 101 passed
- focused watchdog test: 2 passed
- `npm run typecheck`: the branch has no new type errors, but the command still exits on the existing duplicate `pi-ai` `AssistantMessageEventStream` type in `src/index.ts`. The same error is present on unchanged `main`.