### PR TITLE
Fix images dropped when image isn't on final user message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- **Fix: images dropped when not on the final user message (issue #34)** — `extractUserPromptBlocks` only scanned the last message, so an image followed by a trailing text preview lost the image. Now scans the full trailing run of user messages and hoists all image blocks.
+- **Fix: crash on data-less image blocks** — the debug log read `block.data.length` before the guard that skips data-less images, so one malformed block threw out of the fresh-query path on every retry.
+
 ## 0.6.3 — 2026-07-26
 
 - **Add: claude-opus-5 model** — Claude Opus 5 is selectable via `/model` and the `opus` shortcut now points to it.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { calculateCost, StringEnum, type AssistantMessage, type AssistantMessageEventStream, type Context, type Model, type SimpleStreamOptions, type Tool } from "@earendil-works/pi-ai";
+import { calculateCost, StringEnum, type AssistantMessage, type AssistantMessageEventStream, type Context, type ImageContent, type Model, type SimpleStreamOptions, type TextContent, type Tool, type UserMessage } from "@earendil-works/pi-ai";
 import * as piAi from "@earendil-works/pi-ai";
 import { getModels } from "@earendil-works/pi-ai/compat";
 import { buildSessionContext, compact, keyHint, type CompactionEntry, type ExtensionAPI, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
@@ -240,38 +240,45 @@ function extractUserPrompt(messages: Context["messages"]): string | null {
 	return messageContentToText(last.content) || "";
 }
 
-/** Extract the last user message as ContentBlockParam[] (preserving images).
+/** Extract the trailing user turn as ContentBlockParam[] (preserving images).
  *  Returns null if no images — caller should fall back to string prompt. */
 function extractUserPromptBlocks(messages: Context["messages"]): ContentBlockParam[] | null {
-	const last = messages[messages.length - 1];
-	if (!last || last.role !== "user") return null;
-	if (typeof last.content === "string") {
-		debug(`extractUserPromptBlocks: content is string (length=${last.content.length})`);
-		return null;
+	const userTail: UserMessage[] = [];
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i];
+		if (!message || message.role !== "user") break;
+		userTail.unshift(message);
 	}
-	if (!Array.isArray(last.content)) {
-		debug(`extractUserPromptBlocks: content is ${typeof last.content}`);
-		return null;
-	}
-	debug(`extractUserPromptBlocks: ${last.content.length} blocks, types=${last.content.map((b: any) => b.type).join(",")}`);
+	if (userTail.length === 0) return null;
+
 	let hasImage = false;
 	const blocks: ContentBlockParam[] = [];
-	for (const block of last.content) {
-		if (block.type === "text" && block.text) {
-			blocks.push({ type: "text", text: block.text });
-		} else if (block.type === "image") {
-			debug(`image block: mimeType=${(block as any).mimeType}, data length=${((block as any).data ?? "").length}, keys=${Object.keys(block).join(",")}`);
-			if (!(block as any).data || !(block as any).mimeType) {
-				debug(`image block missing data or mimeType, skipping`);
-				continue;
+	for (const message of userTail) {
+		const content: (TextContent | ImageContent)[] = typeof message.content === "string"
+			? [{ type: "text", text: message.content }]
+			: message.content;
+		for (const block of content) {
+			if (block.type === "text" && block.text) {
+				blocks.push({ type: "text", text: block.text });
+			} else if (block.type === "image") {
+				debug(`image block: mimeType=${block.mimeType}, data length=${block.data.length}, keys=${Object.keys(block).join(",")}`);
+				if (!block.data || !block.mimeType) {
+					debug(`image block missing data or mimeType, skipping`);
+					continue;
+				}
+				hasImage = true;
+				blocks.push({
+					type: "image",
+					source: {
+						type: "base64",
+						media_type: block.mimeType as Base64ImageSource["media_type"],
+						data: block.data,
+					},
+				});
 			}
-			hasImage = true;
-			blocks.push({
-				type: "image",
-				source: { type: "base64", media_type: block.mimeType as Base64ImageSource["media_type"], data: block.data },
-			});
 		}
 	}
+	debug(`extractUserPromptBlocks: ${userTail.length} trailing user messages, ${blocks.length} blocks`);
 	return hasImage ? blocks : null;
 }
 
@@ -606,6 +613,7 @@ export const __test = {
 		return sharedSession;
 	},
 	syncSharedSession,
+	extractUserPromptBlocks,
 };
 
 // --- Provider helpers: tool name mapping ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,6 +271,14 @@ function extractUserPromptBlocks(messages: Context["messages"]): ContentBlockPar
 		const content: (TextContent | ImageContent)[] = typeof message.content === "string"
 			? [{ type: "text", text: message.content }]
 			: message.content;
+		// Off-type content violates UserMessage's contract, so fail rather than
+		// degrade — but name the shape, since the cause is almost always another
+		// extension appending a malformed message, not this file.
+		if (!Array.isArray(content)) {
+			throw new Error(
+				`extractUserPromptBlocks: user message content must be a string or block array, got ${typeof content} — likely a malformed message from another extension`,
+			);
+		}
 		for (const block of content) {
 			if (block.type === "text" && block.text) {
 				blocks.push({ type: "text", text: block.text });

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,28 +232,37 @@ function extractAllToolResults(context: Context): McpResult[] {
 	return results;
 }
 
-/** Extract the last user message from context as a prompt string. Returns null if last message is not a user message. */
-function extractUserPrompt(messages: Context["messages"]): string | null {
-	const last = messages[messages.length - 1];
-	if (!last || last.role !== "user") return null;
-	if (typeof last.content === "string") return last.content;
-	return messageContentToText(last.content) || "";
+/** Index of the first message of the current user turn — the trailing run of
+ *  user messages that has not been written into the Claude Code session yet.
+ *  Equals messages.length when the last message is not a user message.
+ *
+ *  Single source of truth for the history/prompt split: everything before this
+ *  index is replayed as session history, everything from it onward becomes the
+ *  prompt. Deriving both halves from one index is what keeps a message from
+ *  landing in both — an extension appending a display-only user message after
+ *  the real one (see issue #34) makes the turn longer than one message. */
+function turnStart(messages: Context["messages"]): number {
+	let i = messages.length;
+	while (i > 0 && messages[i - 1].role === "user") i--;
+	return i;
 }
 
-/** Extract the trailing user turn as ContentBlockParam[] (preserving images).
+/** Extract the current user turn as a prompt string. Returns null if the last message is not a user message. */
+function extractUserPrompt(messages: Context["messages"]): string | null {
+	const turn = messages.slice(turnStart(messages)) as UserMessage[];
+	if (turn.length === 0) return null;
+	return turn.map((m) => (typeof m.content === "string" ? m.content : messageContentToText(m.content))).join("\n");
+}
+
+/** Extract the current user turn as ContentBlockParam[] (preserving images).
  *  Returns null if no images — caller should fall back to string prompt. */
 function extractUserPromptBlocks(messages: Context["messages"]): ContentBlockParam[] | null {
-	const userTail: UserMessage[] = [];
-	for (let i = messages.length - 1; i >= 0; i--) {
-		const message = messages[i];
-		if (!message || message.role !== "user") break;
-		userTail.unshift(message);
-	}
-	if (userTail.length === 0) return null;
+	const turn = messages.slice(turnStart(messages)) as UserMessage[];
+	if (turn.length === 0) return null;
 
 	let hasImage = false;
 	const blocks: ContentBlockParam[] = [];
-	for (const message of userTail) {
+	for (const message of turn) {
 		const content: (TextContent | ImageContent)[] = typeof message.content === "string"
 			? [{ type: "text", text: message.content }]
 			: message.content;
@@ -278,7 +287,7 @@ function extractUserPromptBlocks(messages: Context["messages"]): ContentBlockPar
 			}
 		}
 	}
-	debug(`extractUserPromptBlocks: ${userTail.length} trailing user messages, ${blocks.length} blocks`);
+	debug(`extractUserPromptBlocks: ${turn.length} msgs in turn, ${blocks.length} blocks, types=${blocks.map((b) => b.type).join(",")}`);
 	return hasImage ? blocks : null;
 }
 
@@ -529,7 +538,7 @@ function syncSharedSession(
 	customToolNameToSdk?: Map<string, string>,
 	modelId?: string,
 ): SyncResult {
-	const priorMessages = messages.slice(0, -1); // everything before the new user prompt
+	const priorMessages = messages.slice(0, turnStart(messages)); // everything before the current user turn
 
 	// REUSE path
 	//

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,7 +251,12 @@ function turnStart(messages: Context["messages"]): number {
 function extractUserPrompt(messages: Context["messages"]): string | null {
 	const turn = messages.slice(turnStart(messages)) as UserMessage[];
 	if (turn.length === 0) return null;
-	return turn.map((m) => (typeof m.content === "string" ? m.content : messageContentToText(m.content))).join("\n");
+	// Drop empties before joining so an all-empty turn still yields "" and trips
+	// the caller's empty-prompt guard rather than sending bare newlines.
+	return turn
+		.map((m) => (typeof m.content === "string" ? m.content : messageContentToText(m.content)))
+		.filter((text) => text)
+		.join("\n");
 }
 
 /** Extract the current user turn as ContentBlockParam[] (preserving images).
@@ -270,11 +275,14 @@ function extractUserPromptBlocks(messages: Context["messages"]): ContentBlockPar
 			if (block.type === "text" && block.text) {
 				blocks.push({ type: "text", text: block.text });
 			} else if (block.type === "image") {
-				debug(`image block: mimeType=${block.mimeType}, data length=${block.data.length}, keys=${Object.keys(block).join(",")}`);
+				// Guard before logging: data-less image blocks do occur, and reading
+				// .length off the missing field in the debug template would throw
+				// before this check ever runs (template args evaluate unconditionally).
 				if (!block.data || !block.mimeType) {
-					debug(`image block missing data or mimeType, skipping`);
+					debug(`image block missing data or mimeType, skipping: keys=${Object.keys(block).join(",")}`);
 					continue;
 				}
+				debug(`image block: mimeType=${block.mimeType}, data length=${block.data.length}`);
 				hasImage = true;
 				blocks.push({
 					type: "image",

--- a/tests/unit-prompt-blocks.mjs
+++ b/tests/unit-prompt-blocks.mjs
@@ -1,0 +1,32 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { __test } = await import("../src/index.js");
+
+describe("extractUserPromptBlocks", () => {
+	it("keeps images and text from the trailing run of user messages", () => {
+		const blocks = __test.extractUserPromptBlocks([
+			{ role: "user", content: [
+				{ type: "text", text: "describe this" },
+				{ type: "image", mimeType: "image/png", data: "aW1hZ2U=" },
+			] },
+			{ role: "user", content: "(attachment preview: [#image 1])" },
+		]);
+
+		assert.deepEqual(blocks, [
+			{ type: "text", text: "describe this" },
+			{ type: "image", source: { type: "base64", media_type: "image/png", data: "aW1hZ2U=" } },
+			{ type: "text", text: "(attachment preview: [#image 1])" },
+		]);
+	});
+
+	it("does not reach past the current user turn", () => {
+		const blocks = __test.extractUserPromptBlocks([
+			{ role: "user", content: [{ type: "image", mimeType: "image/png", data: "b2xk" }] },
+			{ role: "assistant", content: [{ type: "text", text: "done" }] },
+			{ role: "user", content: "next turn" },
+		]);
+
+		assert.equal(blocks, null);
+	});
+});

--- a/tests/unit-prompt-blocks.mjs
+++ b/tests/unit-prompt-blocks.mjs
@@ -52,6 +52,15 @@ describe("extractUserPromptBlocks", () => {
 			{ type: "image", source: { type: "base64", media_type: "image/png", data: "aW1hZ2U=" } },
 		]);
 	});
+
+	// Off-type content is a contract violation, so it should fail loudly — and
+	// name the shape, since the culprit is usually another extension.
+	it("throws a legible error on off-type content", () => {
+		assert.throws(
+			() => __test.extractUserPromptBlocks([{ role: "user", content: undefined }]),
+			/content must be a string or block array, got undefined/,
+		);
+	});
 });
 
 after(() => rmSync(debugDir, { recursive: true, force: true }));

--- a/tests/unit-prompt-blocks.mjs
+++ b/tests/unit-prompt-blocks.mjs
@@ -1,5 +1,11 @@
-import { describe, it } from "node:test";
+import { describe, it, after, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const debugDir = mkdtempSync(join(tmpdir(), "prompt-blocks-debug-"));
+process.env.CLAUDE_BRIDGE_DEBUG_PATH = join(debugDir, "claude-bridge.log");
 
 const { __test } = await import("../src/index.js");
 
@@ -28,5 +34,52 @@ describe("extractUserPromptBlocks", () => {
 		]);
 
 		assert.equal(blocks, null);
+	});
+
+});
+
+after(() => rmSync(debugDir, { recursive: true, force: true }));
+
+describe("history/prompt split", () => {
+	afterEach(() => __test.resetSharedSession());
+
+	// The turn boundary is computed once and both halves derive from it, so a
+	// message can never be replayed as history *and* resent as the prompt.
+	it("does not replay the current turn as session history", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "turn-split-"));
+		const claudeDir = mkdtempSync(join(tmpdir(), "turn-split-cfg-"));
+		const prevConfigDir = process.env.CLAUDE_CONFIG_DIR;
+		process.env.CLAUDE_CONFIG_DIR = claudeDir;
+		try {
+			const messages = [
+				{ role: "user", content: "earlier question", timestamp: 1 },
+				{ role: "assistant", content: [{ type: "text", text: "earlier answer" }], timestamp: 2 },
+				// The current turn: real image-bearing message plus an extension's
+				// trailing display-only message (issue #34).
+				{ role: "user", content: [
+					{ type: "text", text: "describe this" },
+					{ type: "image", mimeType: "image/png", data: "aW1hZ2U=" },
+				], timestamp: 3 },
+				{ role: "user", content: "(attachment preview: [#image 1])", timestamp: 4 },
+			];
+
+			const { sessionId } = __test.syncSharedSession(messages, cwd);
+			// readdir rather than fs.globSync — the latter is Node 22+, and engines allows 20.
+			const projectsDir = join(claudeDir, "projects");
+			const [projectDir] = readdirSync(projectsDir);
+			assert.ok(projectDir, "syncSharedSession should have written a session file");
+			const history = readFileSync(join(projectsDir, projectDir, `${sessionId}.jsonl`), "utf8");
+			const prompt = JSON.stringify(__test.extractUserPromptBlocks(messages));
+
+			assert.match(prompt, /describe this/, "the image-bearing message belongs in the prompt");
+			assert.doesNotMatch(history, /describe this/, "and must not also be replayed as history");
+			assert.match(history, /earlier question/, "genuinely prior turns still become history");
+		} finally {
+			// Assigning undefined would set the literal string "undefined".
+			if (prevConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+			else process.env.CLAUDE_CONFIG_DIR = prevConfigDir;
+			rmSync(cwd, { recursive: true, force: true });
+			rmSync(claudeDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/tests/unit-prompt-blocks.mjs
+++ b/tests/unit-prompt-blocks.mjs
@@ -36,6 +36,22 @@ describe("extractUserPromptBlocks", () => {
 		assert.equal(blocks, null);
 	});
 
+	// Data-less image blocks occur in the wild; the skip guard has to run before
+	// the debug line that reads .length off the missing field.
+	it("skips malformed image blocks instead of throwing", () => {
+		const blocks = __test.extractUserPromptBlocks([
+			{ role: "user", content: [
+				{ type: "text", text: "look" },
+				{ type: "image", mimeType: "image/png" },
+				{ type: "image", mimeType: "image/png", data: "aW1hZ2U=" },
+			] },
+		]);
+
+		assert.deepEqual(blocks, [
+			{ type: "text", text: "look" },
+			{ type: "image", source: { type: "base64", media_type: "image/png", data: "aW1hZ2U=" } },
+		]);
+	});
 });
 
 after(() => rmSync(debugDir, { recursive: true, force: true }));


### PR DESCRIPTION
Closes #34 (and supersedes #45)

extractUserPromptBlocks() only inspected the final message. When an extension appended a display or preview user message after the real image-bearing message, the image moved into the text-only history path and never reached Claude.

Also fixes an unrelated crash on the same path: the debug template read block.data.length before the guard that skips data-less image blocks, making the guard unreachable.

#45's fix alone was incomplete: syncSharedSession still sliced at messages.slice(0, -1), so the real message was replayed as session history and resent as the prompt, and the extra unsent message defeated trailingAssistantOnly, forcing a full session teardown + reimport on every image paste. Both halves now derive from one turnStart() index