### PR TITLE
Test harness hygiene: isolate the debug log, fail fast on unwritable ~/.claude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Fix: images dropped when not on the final user message (issue #34)** — `extractUserPromptBlocks` only scanned the last message, so an image followed by a trailing text preview lost the image. Now scans the full trailing run of user messages and hoists all image blocks.
 - **Fix: crash on data-less image blocks** — the debug log read `block.data.length` before the guard that skips data-less images, so one malformed block threw out of the fresh-query path on every retry.
+- **Tests: harness hygiene** — the unit suite redirects `CLAUDE_BRIDGE_DEBUG_PATH` via a preloaded `tests/lib/setup.mjs` instead of per-file boilerplate, so no test can write to the real bridge log; the integration harness now probes `~/.claude` for writability at startup and fails fast instead of surfacing a confusing `No conversation found with session ID` on the next resume.
 
 ## 0.6.3 — 2026-07-26
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Config: `~/.pi/agent/claude-bridge.json` (global) or the project Pi config direc
 
 `npm test` for the full suite, which adds integration tests that hit APIs (`tests/int-*.{sh,mjs}`: smoke, multi-turn, cache, session-resume, session-rebuild, tool-message). Set `CLAUDE_BRIDGE_TESTING_ALT_MODEL` in `.env.test` for the alt-provider smoke test (e.g. `openrouter/z-ai/glm-4.7-flash`).
 
+Integration tests spawn real `pi` and Claude Code subprocesses, so they need write access to `~/.claude` for CC's session state — a sandbox that blocks it makes the next turn's `--resume` fail with `No conversation found with session ID`. The RPC harness probes for this at startup and fails fast.
+
 ## Debugging
 
 Set `CLAUDE_BRIDGE_DEBUG=1` to enable debug output:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "assets"
   ],
   "scripts": {
-    "test:unit": "node --import tsx --test tests/unit-*.mjs",
+    "test:unit": "node --import tsx --import ./tests/lib/setup.mjs --test tests/unit-*.mjs",
     "test": "set -a && [ -f .env.test ] && . .env.test; set +a && npm run test:unit && tests/int-smoke.sh && tests/int-multi-turn.sh && tests/int-cache.sh && node --import tsx --test tests/int-*.mjs",
     "test:usage": "tests/usage-test.sh",
     "typecheck": "tsc --noEmit"

--- a/tests/lib/rpc-harness.mjs
+++ b/tests/lib/rpc-harness.mjs
@@ -3,7 +3,8 @@
  * Provides spawn, send, event waiting, and text collection utilities.
  */
 import { spawn } from "node:child_process";
-import { createWriteStream, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { createWriteStream, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { StringDecoder } from "node:string_decoder";
@@ -14,6 +15,20 @@ const DIR = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 // (`node --import tsx --test tests/int-foo.mjs`) and not just via `npm test`.
 const ENV_FILE = resolve(DIR, ".env.test");
 if (existsSync(ENV_FILE)) process.loadEnvFile(ENV_FILE);
+
+// Claude Code persists session state under ~/.claude. A sandbox that blocks
+// those writes lets the first query succeed and then fails the next turn's
+// --resume with "No conversation found with session ID", which reads like a
+// bridge bug. Surface the real cause up front.
+const PROBE = resolve(homedir(), ".claude", ".int-test-write-probe");
+try {
+	writeFileSync(PROBE, "");
+	rmSync(PROBE);
+} catch (err) {
+	throw new Error(
+		`Integration tests need write access to ~/.claude for Claude Code session state (got ${err.code}). Re-run outside the sandbox.`,
+	);
+}
 
 /**
  * Create an RPC harness for pi integration tests.

--- a/tests/lib/setup.mjs
+++ b/tests/lib/setup.mjs
@@ -1,0 +1,20 @@
+/**
+ * Unit-suite preload: redirect the bridge's debug log to a throwaway directory.
+ *
+ * src/index.ts resolves DEBUG_LOG_PATH into a module-level const at import time
+ * (and mkdirs it when CLAUDE_BRIDGE_DEBUG=1), so the override has to be in place
+ * before any test imports the module. Doing that per test file is easy to forget,
+ * and forgetting is invisible: the suite still passes everywhere except on a
+ * developer machine with CLAUDE_BRIDGE_DEBUG=1, where the tests instead append
+ * fixture data to the real ~/.pi/agent/claude-bridge.log.
+ *
+ * Wiring this as `node --import ./tests/lib/setup.mjs` guarantees it runs first
+ * in every test child process. tests/unit-debug-path.mjs asserts it took effect.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const logDir = mkdtempSync(join(tmpdir(), "claude-bridge-test-log-"));
+process.env.CLAUDE_BRIDGE_DEBUG_PATH = join(logDir, "claude-bridge.log");
+process.on("exit", () => rmSync(logDir, { recursive: true, force: true }));

--- a/tests/unit-debug-path.mjs
+++ b/tests/unit-debug-path.mjs
@@ -1,0 +1,23 @@
+/**
+ * Guards the guard: if tests/lib/setup.mjs stops being preloaded, unit tests
+ * would silently start writing to the developer's real debug log instead of a
+ * temp dir. That regression is otherwise invisible unless CLAUDE_BRIDGE_DEBUG=1.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+describe("test harness", () => {
+	it("redirects the bridge debug log away from the real one", () => {
+		const path = process.env.CLAUDE_BRIDGE_DEBUG_PATH;
+		assert.ok(path, "CLAUDE_BRIDGE_DEBUG_PATH must be set — is tests/lib/setup.mjs still preloaded via --import?");
+		// Compare against the production default specifically; a blanket "not under
+		// $HOME" check would misfire for anyone whose TMPDIR lives inside their home.
+		assert.notEqual(
+			path,
+			join(homedir(), ".pi", "agent", "claude-bridge.log"),
+			"debug log must not resolve to the real one",
+		);
+	});
+});

--- a/tests/unit-prompt-blocks.mjs
+++ b/tests/unit-prompt-blocks.mjs
@@ -1,11 +1,8 @@
-import { describe, it, after, afterEach } from "node:test";
+import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
-const debugDir = mkdtempSync(join(tmpdir(), "prompt-blocks-debug-"));
-process.env.CLAUDE_BRIDGE_DEBUG_PATH = join(debugDir, "claude-bridge.log");
 
 const { __test } = await import("../src/index.js");
 
@@ -62,8 +59,6 @@ describe("extractUserPromptBlocks", () => {
 		);
 	});
 });
-
-after(() => rmSync(debugDir, { recursive: true, force: true }));
 
 describe("history/prompt split", () => {
 	afterEach(() => __test.resetSharedSession());

--- a/tests/unit-session-integrity.mjs
+++ b/tests/unit-session-integrity.mjs
@@ -8,6 +8,7 @@
 import { describe, it, after } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { repairToolPairing } from "cc-session-io";
 import { verifyWrittenSession } from "../src/session-verify.js";
@@ -46,7 +47,7 @@ describe("repairToolPairing", () => {
 });
 
 describe("verifyWrittenSession", () => {
-	const dir = mkdtempSync("/tmp/verify-session-");
+	const dir = mkdtempSync(join(tmpdir(), "verify-session-"));
 	const path = join(dir, "session.jsonl");
 	const SID = "abc-123";
 	const rec = (sessionId, i) => JSON.stringify({ sessionId, idx: i });

--- a/tests/unit-sync-shared-session.mjs
+++ b/tests/unit-sync-shared-session.mjs
@@ -1,22 +1,15 @@
 /**
  * Regression tests for syncSharedSession's session reuse decisions.
  */
-import { describe, it, after, afterEach } from "node:test";
+import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-const debugDir = mkdtempSync(join(tmpdir(), "sync-shared-session-debug-"));
-process.env.CLAUDE_BRIDGE_DEBUG_PATH = join(debugDir, "claude-bridge.log");
-
 const { __test } = await import("../src/index.js");
 
 describe("syncSharedSession", () => {
-	after(() => {
-		rmSync(debugDir, { recursive: true, force: true });
-	});
-
 	afterEach(() => {
 		__test.resetSharedSession();
 	});


### PR DESCRIPTION
 - The unit suite set CLAUDE_BRIDGE_DEBUG_PATH per-file, so a new test file silently wrote to the real ~/.pi/agent/claude-bridge.log under CLAUDE_BRIDGE_DEBUG=1. Now preloaded once via tests/lib/setup.mjs, with
   unit-debug-path.mjs failing loudly if the preload is dropped.
 - Integration tests need write access to ~/.claude; a sandbox that blocks it surfaced much later as No conversation found with session ID on the next --resume. The RPC harness now probes at startup. Documented in the README.
 - mkdtempSync("/tmp/…") → os.tmpdir() in the session-integrity test.
 - No behavior change to shipped code.