### PR TITLE
Real mid-turn steering!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Add steering support** — a steer sent while a tool was running used to be stashed and replayed as a continuation query after Claude's whole turn finished - so basically the same as a followup. The prompt is now a long-lived streaming-input generator, and a steer is written to CC's stdin (`priority: "next"`) *before* the tool result is released to the MCP handler. Both travel the same stdin FIFO, so CC drains the steer at that tool boundary and acts on it in the same turn. Image steers keep their images. Removes `deferredUserMessages` and the continuation-replay path.
 - **Fix: images dropped when not on the final user message (issue #34)** — `extractUserPromptBlocks` only scanned the last message, so an image followed by a trailing text preview lost the image. Now scans the full trailing run of user messages and hoists all image blocks.
 - **Fix: crash on data-less image blocks** — the debug log read `block.data.length` before the guard that skips data-less images, so one malformed block threw out of the fresh-query path on every retry.
 - **Tests: harness hygiene** — the unit suite redirects `CLAUDE_BRIDGE_DEBUG_PATH` via a preloaded `tests/lib/setup.mjs` instead of per-file boilerplate, so no test can write to the real bridge log; the integration harness now probes `~/.claude` for writability at startup and fails fast instead of surfacing a confusing `No conversation found with session ID` on the next resume.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Integration tests spawn real `pi` and Claude Code subprocesses, so they need wri
 Set `CLAUDE_BRIDGE_DEBUG=1` to enable debug output:
 
 - **Bridge log** at `~/.pi/agent/claude-bridge.log` — every provider call, session sync decision, tool result delivery, and CC's stderr. Override location with `CLAUDE_BRIDGE_DEBUG_PATH`.
-- **Per-query Claude Code CLI logs** at `~/.pi/agent/cc-cli-logs/<timestamp>-<tag>-<seq>.log` — the CC subprocess's own debug stream, one file per `query()` call. Tags are `provider` (main turn), `continuation` (steer replay), or `askclaude` (sub-delegation). Useful when a resume fails or CC misbehaves internally — shows the CLI's own view of session loading, API requests, and tool calls.
+- **Per-query Claude Code CLI logs** at `~/.pi/agent/cc-cli-logs/<timestamp>-<tag>-<seq>.log` — the CC subprocess's own debug stream, one file per `query()` call. Tags are `provider` (main turn) or `askclaude` (sub-delegation). Useful when a resume fails or CC misbehaves internally — shows the CLI's own view of session loading, API requests, and tool calls.
 
 When filing a bug about a session-resume failure (e.g. "No conversation found"), the most useful attachments are the `syncResult:` lines from the bridge log plus the matching `cc-cli-logs/` file for the failing query.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pi install npm:pi-claude-bridge
 
 Use `/model` to select `claude-bridge/claude-fable-5`, `claude-bridge/claude-opus-5`, `claude-bridge/claude-opus-4-8`, `claude-bridge/claude-opus-4-7`, `claude-bridge/claude-opus-4-6`, `claude-bridge/claude-sonnet-5`, `claude-bridge/claude-sonnet-4-6`, or `claude-bridge/claude-haiku-4-5`.
 
-Behind the scenes, pi's tools are bridged to Claude Code but it should all work like normal in pi. Bash commands get a 120-second default timeout (matching Claude Code's default) since pi's bash has no timeout by default. Skills in pi are copied over to Claude Code's system prompt so should work as they would with any other pi provider.
+Behind the scenes, pi's tools are bridged to Claude Code but it should all work like normal in pi. Bash commands get a 120-second default timeout (matching Claude Code's default) since pi's bash has no timeout by default. Skills in pi are copied over to Claude Code's system prompt so should work as they would with any other pi provider. Steering works mid-turn: a message sent while Claude is running a tool reaches it at that tool boundary, not after the whole turn finishes.
 
 **1M Context:** Opus 5, Opus 4.8, and Opus 4.7 get 1M context by default. Opus 4.6 only gets 1M if you're on a Max plan or pay for Extra Usage. Sonnet 4.6 only gets 1M if you pay for Extra Usage. You will need to set `provider.plan` and/or `provider.longContextExtraUsage` for 1M context in Opus 4.6/Sonnet 4.6 as described in [Configuration](#configuration).
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ import { calculateCost, StringEnum, type AssistantMessage, type AssistantMessage
 import * as piAi from "@earendil-works/pi-ai";
 import { getModels } from "@earendil-works/pi-ai/compat";
 import { buildSessionContext, compact, keyHint, type CompactionEntry, type ExtensionAPI, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
-import { createSdkMcpServer, query, type EffortLevel, type SDKMessage, type SDKUserMessage, type SettingSource } from "@anthropic-ai/claude-agent-sdk";
-import type { Base64ImageSource, ContentBlockParam, MessageParam } from "@anthropic-ai/sdk/resources";
+import { createSdkMcpServer, query, type EffortLevel, type SDKMessage, type SettingSource } from "@anthropic-ai/claude-agent-sdk";
+import type { Base64ImageSource, ContentBlockParam } from "@anthropic-ai/sdk/resources";
 import { Type } from "typebox";
 import { Text } from "@earendil-works/pi-tui";
 import { createSession, deleteSession, repairToolPairing } from "cc-session-io";
@@ -16,6 +16,7 @@ import { MCP_SERVER_NAME, MCP_TOOL_PREFIX, extractSkillsBlock } from "./skills.j
 import { verifyWrittenSession as _verifyWrittenSession } from "./session-verify.js";
 import { extractAllToolResults as _extractAllToolResults, type McpResult } from "./extract-tool-results.js";
 import { QueryContext, ctx } from "./query-state.js";
+import { makePromptStream, userMessage } from "./prompt-stream.js";
 import { loadConfig, type Config } from "./config.js";
 import { extractAgentsAppend } from "./agents-md.js";
 import { jsonSchemaToZodShape } from "./typebox-to-zod.js";
@@ -305,14 +306,6 @@ function extractUserPromptBlocks(messages: Context["messages"]): ContentBlockPar
 	}
 	debug(`extractUserPromptBlocks: ${turn.length} msgs in turn, ${blocks.length} blocks, types=${blocks.map((b) => b.type).join(",")}`);
 	return hasImage ? blocks : null;
-}
-
-async function* wrapPromptStream(blocks: ContentBlockParam[]): AsyncIterable<SDKUserMessage> {
-	yield {
-		type: "user",
-		message: { role: "user", content: blocks } as MessageParam,
-		parent_tool_use_id: null,
-	};
 }
 
 function newAssistantOutput(model: Model<any>, text: string, stopReason: AssistantMessage["stopReason"], errorMessage?: string): AssistantMessage {
@@ -1048,6 +1041,10 @@ async function consumeQuery(
 
 	for await (const message of sdkQuery) {
 		if (wasAborted()) break;
+		// Ahead of the currentPiStream guard: nothing else closes the CLI's stdin
+		// now that the prompt is a streamed generator (isSingleUserTurn=false), so
+		// missing this would hang the query forever.
+		if (message.type === "result") queryCtx.promptStream?.end();
 		if (!queryCtx.currentPiStream || !queryCtx.turnOutput) continue;
 
 		switch (message.type) {
@@ -1075,7 +1072,13 @@ async function consumeQuery(
 				}
 				break;
 			case "user":
-				break; // SDK echo of user prompt — not needed
+				// SDK echo of the user prompt — no stream events to emit. Note it
+				// carries only prompts and tool results: a steer CC drained at a
+				// tool boundary is recorded in its session transcript as a
+				// `queued_command` attachment and never reaches this stream, which
+				// is why the mid-turn steering tripwire has to live in the
+				// integration test.
+				break;
 			case "rate_limit_event": {
 				const info = (message as any).rate_limit_info;
 				debug("consumeQuery: rate_limit_event", JSON.stringify(info).slice(0, 300));
@@ -1097,6 +1100,87 @@ async function consumeQuery(
 	debug(`consumeQuery: for-await loop exited, wasAborted=${wasAborted()}, capturedSessionId=${capturedSessionId?.slice(0, 8) ?? "none"}`);
 
 	return { capturedSessionId };
+}
+
+/** The trailing user turn as content blocks, or null if there isn't one.
+ *  Blocks rather than text so image steers keep their images. */
+function steerBlocks(messages: Context["messages"]): ContentBlockParam[] | null {
+	const blocks = extractUserPromptBlocks(messages);
+	if (blocks) return blocks;
+	const text = extractUserPrompt(messages);
+	return text ? [{ type: "text", text }] : null;
+}
+
+/** A steer that never made it into CC's session. The cursor has already counted
+ *  it, so count-based sync would skip it forever — rebuild instead, which
+ *  re-imports the message from pi's context. */
+function steerMissedSession(text: string): void {
+	if (!sharedSession) return;
+	sharedSession = { ...sharedSession, needsRebuild: true };
+	debug(`provider: steer never reached CC, marked session for rebuild: ${text.slice(0, 60)}`);
+}
+
+/** Releases this turn's tool results to their MCP handlers, after first pushing
+ *  any steer to CC.
+ *
+ *  The ordering is mandatory, not an optimization. The steer and the MCP tool
+ *  result travel back to CC over the same stdin FIFO. Awaiting the push ack
+ *  (which resolves only once the SDK's write to stdin completed) before
+ *  resolving any handler guarantees CC enqueues the steer *before* it reads the
+ *  tool result, so its post-tool-call drain sees it and acts on it this turn.
+ *  Resolve first and the steer misses the drain, silently degrading to
+ *  follow-up semantics.
+ *
+ *  Both the post-tool-call drain and the FIFO ordering are CC CLI internals,
+ *  not SDK contract — tests/int-tool-message.mjs is the tripwire if they move. */
+async function deliverToolResults(
+	c: QueryContext,
+	results: McpResult[],
+	steer: ContentBlockParam[] | null,
+	contextLength: number,
+): Promise<void> {
+	if (steer) {
+		const text = steer.map((b) => (b.type === "text" ? b.text : "[image]")).join("\n");
+		if (!c.promptStream) {
+			debug(`WARNING: steer with no prompt stream, dropping: ${text.slice(0, 60)}`);
+			steerMissedSession(text);
+		} else {
+			try {
+				await c.promptStream.push(userMessage(steer, "next"));
+				debug(`provider: steer written to CC stdin before tool result: ${text.slice(0, 60)}`);
+			} catch (error) {
+				// The query is ending — pushing further input would wedge tool-result
+				// delivery, so the steer doesn't reach this query. It is still in
+				// pi's context, and the caller has already advanced the session
+				// cursor past it, so force a rebuild or CC would never see it.
+				debug(`provider: steer push rejected, delivering tool result anyway:`, error);
+				steerMissedSession(text);
+			}
+		}
+	}
+
+	debug(`provider: tool results, ${results.length} results, ${c.pendingToolCalls.size} waiting handlers, ctx.msgs=${contextLength}`);
+	for (const result of results) {
+		const id = result.toolCallId;
+		if (id && c.pendingToolCalls.has(id)) {
+			const pending = c.pendingToolCalls.get(id)!;
+			c.pendingToolCalls.delete(id);
+			debug(`provider: resolving ${pending.toolName} [${id}]${result.isError ? " (error)" : ""}`, JSON.stringify(result.content).slice(0, 200));
+			pending.resolve(result);
+		} else if (id) {
+			c.pendingResults.set(id, result);
+			debug(`provider: queued result [${id}] (${c.pendingResults.size} pending)`);
+		} else {
+			debug(`WARNING: tool result without toolCallId, cannot match`);
+		}
+		if (c.pendingToolCalls.size > 0 && c.pendingResults.size > 0) {
+			debug(`BUG: both maps non-empty! handlers=${c.pendingToolCalls.size} results=${c.pendingResults.size}`);
+		}
+	}
+	if (c.pendingToolCalls.size > 0) {
+		debug(`WARNING: ${c.pendingToolCalls.size} MCP handlers still waiting after delivering ${results.length} results`);
+		piUI?.notify(`Claude bridge: ${c.pendingToolCalls.size} tool handler(s) still waiting — provider may be stuck`, "warning");
+	}
 }
 
 /** Provider entry point. Pi calls this for each new prompt and each tool result.
@@ -1123,45 +1207,14 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	if (resultCtx) {
 		claimCurrentPiStream(stream, "tool-result", resultCtx);
 		resultCtx.resetTurnState(model);
-		debug(`provider: tool results, ${allResults.length} results, ${resultCtx.pendingToolCalls.size} waiting handlers, ctx.msgs=${context.messages.length}`);
-		for (const result of allResults) {
-			const id = result.toolCallId;
-			if (id && resultCtx.pendingToolCalls.has(id)) {
-				const pending = resultCtx.pendingToolCalls.get(id)!;
-				resultCtx.pendingToolCalls.delete(id);
-				debug(`provider: resolving ${pending.toolName} [${id}]${result.isError ? " (error)" : ""}`, JSON.stringify(result.content).slice(0, 200));
-				pending.resolve(result);
-			} else if (id) {
-				resultCtx.pendingResults.set(id, result);
-				debug(`provider: queued result [${id}] (${resultCtx.pendingResults.size} pending)`);
-			} else {
-				debug(`WARNING: tool result without toolCallId, cannot match`);
-			}
-			if (resultCtx.pendingToolCalls.size > 0 && resultCtx.pendingResults.size > 0) {
-				debug(`BUG: both maps non-empty! handlers=${resultCtx.pendingToolCalls.size} results=${resultCtx.pendingResults.size}`);
-			}
-		}
-		if (resultCtx.pendingToolCalls.size > 0) {
-			debug(`WARNING: ${resultCtx.pendingToolCalls.size} MCP handlers still waiting after delivering ${allResults.length} results`);
-			piUI?.notify(`Claude bridge: ${resultCtx.pendingToolCalls.size} tool handler(s) still waiting — provider may be stuck`, "warning");
-		}
-
-		// Detect user messages (steer/followUp) that pi injected into context
-		// during the active query. This happens when:
-		//   - User sends a steer while a tool is executing; pi drains the steer
-		//     queue at the turn boundary and appends it to context alongside the
-		//     tool result, then calls the provider again.
-		//   - A followUp is delivered between tool-result turns.
-		// The bridge can't forward these mid-query (the SDK query is in progress),
-		// so we save them for replay as continuation queries after consumeQuery ends.
-		if (lastMsgRole === "user") {
-			const userPrompt = extractUserPrompt(context.messages);
-			if (userPrompt) {
-				resultCtx.deferredUserMessages.push(userPrompt);
-				debug(`provider: deferred user message for replay after query: ${userPrompt.slice(0, 60)}`);
-			}
-		}
-
+		// User messages (steer/followUp) pi injected into context during the
+		// active query: a steer sent while a tool was executing, drained by pi at
+		// the turn boundary and appended alongside the tool result.
+		const steer = lastMsgRole === "user" ? steerBlocks(context.messages) : null;
+		// Delivery is async because the steer must reach CC's stdin *before* the
+		// tool result does — see deliverToolResults. Detached so the provider
+		// still returns its stream synchronously.
+		void deliverToolResults(resultCtx, allResults, steer, context.messages.length);
 		if (sharedSession) sharedSession.cursor = context.messages.length;
 		resultCtx.latestCursor = Math.max(resultCtx.latestCursor, context.messages.length);
 		return stream;
@@ -1197,7 +1250,10 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	claimCurrentPiStream(stream, "fresh-query", queryCtx);
 	queryCtx.pendingToolCalls.clear();
 	queryCtx.pendingResults.clear();
-	queryCtx.deferredUserMessages = [];
+	// Stale ids would let a late result from the previous query route here via
+	// contextForToolResults — which now means pushing its steer into this
+	// query's stdin, not just mismatching a map.
+	queryCtx.turnToolCallIds = [];
 	queryCtx.resetTurnState(model);
 	queryCtx.latestCursor = 0;
 
@@ -1224,9 +1280,15 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		promptText = "[continue]";
 	}
 
-	const prompt: string | AsyncIterable<SDKUserMessage> = promptBlocks
-		? wrapPromptStream(promptBlocks)
-		: promptText;
+	// Always stream the prompt rather than passing a string: a parked input
+	// generator is what lets us write steers to CC's stdin mid-turn. The cost is
+	// that `isSingleUserTurn` is false, so the SDK no longer closes stdin on the
+	// first result — consumeQuery ends the stream explicitly instead, or the
+	// query would never terminate.
+	const promptStream = makePromptStream();
+	void promptStream.push(userMessage(promptBlocks ?? [{ type: "text", text: promptText }]))
+		.catch((error) => debug(`provider: initial prompt push rejected:`, error));
+	queryCtx.promptStream = promptStream;
 	const mcpServers = buildMcpServers(mcpTools, queryCtx);
 	const appendSystemPrompt = providerSettings.appendSystemPrompt !== false;
 	const agentsAppend = appendSystemPrompt ? extractAgentsAppend() : undefined;
@@ -1300,7 +1362,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 
 	// 3. Start SDK query and claim it for this context
 	let wasAborted = false;
-	const sdkQuery = query({ prompt, options: queryOptions });
+	const sdkQuery = query({ prompt: promptStream.stream, options: queryOptions });
 	queryCtx.activeQuery = sdkQuery;
 	activeQueryContexts.add(queryCtx);
 
@@ -1315,8 +1377,10 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	};
 	const onAbort = () => {
 		wasAborted = true;
-		// Discard deferred messages when aborting the query.
-		abortCtx.deferredUserMessages = [];
+		// Terminate the input generator and settle its acks — the pump abandons
+		// iteration on abort, so an in-flight push would otherwise hang forever
+		// and take tool-result delivery with it.
+		promptStream.fail(new Error("Operation aborted"));
 		for (const pending of abortCtx.pendingToolCalls.values()) { pending.resolve({ content: [{ type: "text", text: "Operation aborted" }] }); }
 		abortCtx.pendingToolCalls.clear();
 		abortCtx.pendingResults.clear();
@@ -1335,7 +1399,6 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 			// --- Abort detection in normal completion path ---
 			if (wasAborted || options?.signal?.aborted) {
 				if (sharedSession) sharedSession = { ...sharedSession, needsRebuild: true, forceRotate: true };
-				queryCtx.deferredUserMessages = [];
 				debug(`provider: abort detected, marked sharedSession needsRebuild + forceRotate`);
 				if (queryCtx.turnOutput) {
 					queryCtx.turnOutput.stopReason = "aborted";
@@ -1363,42 +1426,6 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 				sharedSession = { sessionId, cursor, cwd };
 			}
 
-			// --- Replay deferred user messages as continuation queries ---
-			try {
-				while (queryCtx.deferredUserMessages.length > 0 && !isReentrant && !wasAborted) {
-					const steerPrompt = queryCtx.deferredUserMessages.shift()!;
-					debug(`provider: replaying deferred user message: ${steerPrompt.slice(0, 60)}`);
-					queryCtx.resetTurnState(model);
-
-					const resumeId = sharedSession?.sessionId;
-					if (!resumeId) {
-						debug(`WARNING: no session to resume for deferred message, dropping`);
-						break;
-					}
-
-					const contOptions = { ...queryOptions, resume: resumeId, ...makeCliDebugOptions("continuation") };
-					const contQuery = query({ prompt: steerPrompt, options: contOptions });
-					queryCtx.activeQuery = contQuery;
-
-					debug(`provider: continuation query, model=${cliModel}, resume=${resumeId.slice(0, 8)}, prompt=${steerPrompt.slice(0, 60)}`);
-
-					try {
-						const { capturedSessionId: contSid } = await consumeQuery(contQuery, customToolNameToPi, model, () => wasAborted, queryCtx);
-						const sid = contSid ?? sharedSession?.sessionId;
-						if (sid) {
-							sharedSession = { sessionId: sid, cursor: sharedSession?.cursor ?? 0, cwd };
-						}
-					} catch (contError) {
-						debug(`provider: continuation query error:`, contError);
-						break;
-					} finally {
-						contQuery.close();
-					}
-				}
-			} finally {
-				queryCtx.activeQuery = sdkQuery;
-			}
-
 			if (!isReentrant && queryCtx.activeQuery === sdkQuery) {
 				debug("provider: clearing activeQuery before final stream completion");
 				queryCtx.activeQuery = null;
@@ -1412,7 +1439,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 			} else {
 				sharedSession = null;
 			}
-			queryCtx.deferredUserMessages = [];
+			promptStream.fail(error instanceof Error ? error : new Error(String(error)));
 			if (queryCtx.turnOutput) {
 				queryCtx.turnOutput.stopReason = options?.signal?.aborted ? "aborted" : "error";
 				queryCtx.turnOutput.errorMessage = error instanceof Error ? error.message : String(error);
@@ -1432,6 +1459,11 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		})
 		.finally(() => {
 			if (options?.signal) options.signal.removeEventListener("abort", onAbort);
+			// Settle any ack still parked in the generator — the CLI is gone, so
+			// nothing will resume it. Clear the handle only if a later query
+			// hasn't already claimed the shared context.
+			promptStream.fail(new Error("query ended"));
+			if (queryCtx.promptStream === promptStream) queryCtx.promptStream = null;
 			if (queryCtx.activeQuery === sdkQuery) {
 				// Drain pending handlers for this query
 				for (const pending of queryCtx.pendingToolCalls.values()) { pending.resolve({ content: [{ type: "text", text: "Query ended" }] }); }

--- a/src/prompt-stream.ts
+++ b/src/prompt-stream.ts
@@ -1,0 +1,89 @@
+// Long-lived streaming-input prompt for query().
+//
+// The SDK accepts `prompt: AsyncIterable<SDKUserMessage>` and pumps it to the
+// CLI's stdin. Keeping that iterable parked for the life of the query lets us
+// write a steer to stdin *while* a tool is running, which is what makes CC
+// drain it at the next tool boundary (`priority: "next"`) instead of treating
+// it as a follow-up turn.
+//
+// The ack is the load-bearing part. `push()` resolves on the line *after*
+// `yield`, and the SDK's pump is `for await (m of stream) { await
+// transport.write(m) }` — so resuming past the yield proves the write to stdin
+// completed. Callers await that before releasing the MCP tool result, which
+// travels back over the same stdin FIFO; winning that race is what guarantees
+// CC sees the steer before the tool result.
+//
+// The drain and the FIFO ordering are CC CLI internals, not SDK contract, so
+// this can break under a CC upgrade without any type error.
+
+import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+
+export interface PromptStream {
+	stream: AsyncGenerator<SDKUserMessage>;
+	/** Enqueue a message; resolves once the SDK has written it to stdin.
+	 *  Rejects (never hangs) if the stream is already ended or failed. */
+	push: (msg: SDKUserMessage) => Promise<void>;
+	/** Close the input: the generator returns, the SDK closes the CLI's stdin. */
+	end: () => void;
+	/** Abandon the input, rejecting every queued and in-flight ack. */
+	fail: (error: Error) => void;
+}
+
+export function makePromptStream(): PromptStream {
+	type Item = { msg: SDKUserMessage; resolve: () => void; reject: (e: Error) => void };
+	const queue: Item[] = [];
+	// The item currently parked at `yield`. Tracked separately so fail() can
+	// settle it — a dying CLI may abandon the pump without ever resuming us,
+	// and an unsettled ack would wedge tool-result delivery forever.
+	let inflight: Item | null = null;
+	let wake: (() => void) | null = null;
+	let done = false;
+	let failure: Error | null = null;
+
+	const kick = () => { wake?.(); wake = null; };
+
+	async function* gen(): AsyncGenerator<SDKUserMessage> {
+		while (true) {
+			while (queue.length === 0 && !done && !failure) {
+				await new Promise<void>((resolve) => { wake = resolve; });
+			}
+			if (failure) throw failure;
+			const item = queue.shift();
+			if (!item) return; // ended and drained
+			inflight = item;
+			try {
+				yield item.msg;
+				item.resolve();
+			} finally {
+				// Reached either normally (no-op, already resolved) or when the
+				// pump abandons iteration — a `for await` break/throw calls
+				// gen.return(), which resumes the yield as a return.
+				item.reject(new Error("prompt stream closed"));
+				inflight = null;
+			}
+		}
+	}
+
+	return {
+		stream: gen(),
+		push: (msg) => failure || done
+			? Promise.reject(failure ?? new Error("prompt stream closed"))
+			: new Promise<void>((resolve, reject) => { queue.push({ msg, resolve, reject }); kick(); }),
+		end: () => { done = true; kick(); },
+		fail: (error) => {
+			failure = error;
+			queue.splice(0).forEach((item) => item.reject(error));
+			inflight?.reject(error);
+			kick();
+		},
+	};
+}
+
+export function userMessage(content: SDKUserMessage["message"]["content"], priority?: SDKUserMessage["priority"]): SDKUserMessage {
+	return {
+		type: "user",
+		message: { role: "user", content } as SDKUserMessage["message"],
+		parent_tool_use_id: null,
+		...(priority ? { priority } : {}),
+	};
+}

--- a/src/prompt-stream.ts
+++ b/src/prompt-stream.ts
@@ -79,6 +79,8 @@ export function makePromptStream(): PromptStream {
 	};
 }
 
+/** `uuid` is deliberately omitted: we need no dedup, and supplying one makes
+ *  CC's stdin loop do a session lookup on the message. */
 export function userMessage(content: SDKUserMessage["message"]["content"], priority?: SDKUserMessage["priority"]): SDKUserMessage {
 	return {
 		type: "user",

--- a/src/query-state.ts
+++ b/src/query-state.ts
@@ -8,6 +8,7 @@
 
 import type { AssistantMessage, AssistantMessageEventStream, Model } from "@earendil-works/pi-ai";
 import type { McpResult } from "./extract-tool-results.js";
+import type { PromptStream } from "./prompt-stream.js";
 
 export interface PendingToolCall {
 	toolName: string;
@@ -23,7 +24,8 @@ export class QueryContext {
 	pendingResults = new Map<string, McpResult>();
 	turnToolCallIds: string[] = [];
 	nextHandlerIdx = 0;
-	deferredUserMessages: string[] = [];
+	/** Streaming-input handle for the active query — how steers reach CC mid-turn. */
+	promptStream: PromptStream | null = null;
 
 	// Per-turn (reset together)
 	turnOutput: AssistantMessage | null = null;

--- a/tests/int-tool-message.mjs
+++ b/tests/int-tool-message.mjs
@@ -5,6 +5,8 @@
 
 import { describe, it, before, after, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { getProjectDir } from "cc-session-io";
 import { createRpcHarness } from "./lib/rpc-harness.mjs";
 
 const TEST_TIMEOUT = 40_000;
@@ -16,7 +18,29 @@ const harness = createRpcHarness({
 });
 
 describe("tool-message integration", () => {
-	const { startAndWait, stop, send, waitForEvent, waitForMatch, collectText, promptAndWait, DEBUG_LOG, RPC_LOG } = harness;
+	const { startAndWait, stop, send, addListener, waitForEvent, waitForMatch, collectText, promptAndWait, DEBUG_LOG, RPC_LOG } = harness;
+
+	// The debug log accumulates across tests in this file (one pi process), so
+	// scope assertions to the bytes a single test wrote.
+	const logMark = () => statSync(DEBUG_LOG).size;
+	const logSince = (mark) => readFileSync(DEBUG_LOG, "utf8").slice(mark);
+
+	/** Session id of the last query in a slice of the debug log. Logged
+	 *  abbreviated, which is enough to pick the file out of the project dir. */
+	function sessionIdFrom(log) {
+		const ids = [...log.matchAll(/query done, session=([0-9a-f]+)/g)].map((m) => m[1]);
+		assert.ok(ids.length > 0, "no session id in debug log — the query never completed");
+		const prefix = ids[ids.length - 1];
+		const dir = getProjectDir(harness.DIR);
+		const file = readdirSync(dir).find((f) => f.startsWith(prefix) && f.endsWith(".jsonl"));
+		assert.ok(file, `no session file for ${prefix} in ${dir}`);
+		return `${dir}/${file}`;
+	}
+
+	/** CC's session transcript as parsed JSONL records, in write order. */
+	function readSessionRecords(path) {
+		return readFileSync(path, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line));
+	}
 
 	// --- Lifecycle ---
 
@@ -148,6 +172,85 @@ describe("tool-message integration", () => {
 		await waitForEvent("agent_end");
 		const text = collector.stop();
 		assert.match(text.toLowerCase(), /mango/, `Steer content not visible to assistant: ${text.slice(0, 300)}`);
+	});
+
+	it("steer is drained at the tool boundary, mid-turn", { timeout: 90_000 }, async () => {
+		// The point of the whole steering fix, and the tripwire for the CC CLI
+		// internals it rests on.
+		//
+		// Proof has to be structural, from CC's own session transcript — model
+		// output doesn't discriminate. Under the *old* defer-and-replay behavior
+		// Claude also ended up obeying the steer, just a turn later, so "it said
+		// the magic word" passes either way. What only mid-turn steering produces
+		// is a `queued_command` attachment sitting between the tool result and the
+		// next assistant message: CC drained the steer at the tool boundary,
+		// before the next API round-trip. A steer that lost the stdin race instead
+		// lands after that assistant message, and a replayed one is a plain user
+		// prompt with no attachment at all.
+		const mark = logMark();
+		const steerText = "STOP. Do not call SlowTool again. Reply with only the word BANANA.";
+		let toolStarts = 0;
+		const removeCounter = addListener((msg) => { if (msg.type === "tool_execution_start") toolStarts++; });
+
+		await send({
+			type: "prompt",
+			message: "Call SlowTool with seconds=1 exactly 12 times, strictly one at a time — wait for each result before starting the next. Do not call it twice in the same message.",
+		});
+		await waitForEvent("tool_execution_start");
+		await send({ type: "prompt", message: steerText, streamingBehavior: "steer" });
+		await waitForEvent("agent_end");
+		removeCounter();
+
+		const records = readSessionRecords(sessionIdFrom(logSince(mark)));
+		const steerAt = records.findIndex((r) => r.attachment?.type === "queued_command"
+			&& JSON.stringify(r.attachment.prompt ?? "").includes("Do not call SlowTool again"));
+		assert.notEqual(steerAt, -1, "steer never reached CC as a queued command — it was replayed as a follow-up");
+
+		const toolResultAt = records.findLastIndex((r, i) => i < steerAt
+			&& JSON.stringify(r.message?.content ?? "").includes('"tool_result"'));
+		assert.notEqual(toolResultAt, -1, "no tool result before the steer — test did not reach a tool boundary");
+		const between = records.slice(toolResultAt + 1, steerAt).filter((r) => r.type === "assistant");
+		assert.equal(between.length, 0,
+			`steer was drained after the turn continued (${between.length} assistant message(s) between tool result and steer) — it lost the stdin race`);
+		assert.ok(records.slice(steerAt).some((r) => r.type === "assistant"),
+			"CC never responded after draining the steer");
+
+		// Corroborating, not proof: the model should abandon its 12-call loop.
+		assert.ok(toolStarts <= 6, `${toolStarts} of 12 tool calls ran before Claude acted on the steer`);
+	});
+
+	it("steer at a text-only boundary is not pushed into the active query", { timeout: TEST_TIMEOUT }, async () => {
+		// A steer at the end of a text-only turn can race the clearing of
+		// activeQuery and be routed as a reentrant user query. That must stay a
+		// fresh follow-up query: there is no tool boundary to steer at, and the
+		// input generator has already been ended, so pushing into it would fail.
+		//
+		// Routing makes this unreachable today (no tool results ⇒ no delivery
+		// path), and the race itself is timing-dependent, so read this as a
+		// tripwire against a future change that starts pushing text-only steers —
+		// not as proof the race is handled.
+		const mark = logMark();
+		const collector = collectText();
+		await send({
+			type: "prompt",
+			message: "Write exactly 12 short numbered sentences about the history of computing. Do NOT call any tools.",
+		});
+		await waitForMatch(
+			(msg) => msg.type === "message_update" && msg.assistantMessageEvent?.type === "text_delta",
+			"text_delta during assistant response",
+		);
+		await send({
+			type: "prompt",
+			message: "After you finish, also say the exact word 'KIWI' on its own line.",
+			streamingBehavior: "steer",
+		});
+		await waitForEvent("agent_end");
+		const text = collector.stop();
+		const log = logSince(mark);
+
+		assert.match(text.toLowerCase(), /kiwi/);
+		assert.doesNotMatch(log, /steer written to CC stdin/, "text-only steer was pushed into the active query's input stream");
+		assert.doesNotMatch(log, /steer push rejected/, "text-only steer reached the push path at all");
 	});
 
 	it("abort during tool execution recovers cleanly", { timeout: TEST_TIMEOUT }, async () => {

--- a/tests/lib/rpc-harness.mjs
+++ b/tests/lib/rpc-harness.mjs
@@ -87,7 +87,7 @@ export function createRpcHarness(opts) {
 				buffer = buffer.slice(i + 1);
 				try {
 					const msg = JSON.parse(line);
-					rpcLog.write(`< ${line}\n`);
+					rpcLog?.write(`< ${line}\n`);
 					for (const fn of [...listeners]) fn(msg);
 				} catch {}
 			}
@@ -102,7 +102,12 @@ export function createRpcHarness(opts) {
 	function stop() {
 		stopped = true;
 		pi?.kill();
-		return new Promise((r) => rpcLog?.end(r));
+		// Drop the handle before ending it: pi can still emit a line or two after
+		// kill(), and writing to an ended stream throws asynchronously, which the
+		// test runner reports as a file-level failure.
+		const log = rpcLog;
+		rpcLog = null;
+		return new Promise((r) => (log ? log.end(r) : r()));
 	}
 
 	function addListener(fn) {
@@ -116,7 +121,7 @@ export function createRpcHarness(opts) {
 	function send(cmd, timeout = defaultTimeout) {
 		const id = `req_${++reqId}`;
 		const full = { ...cmd, id };
-		rpcLog.write(`> ${JSON.stringify(full)}\n`);
+		rpcLog?.write(`> ${JSON.stringify(full)}\n`);
 		pi.stdin.write(JSON.stringify(full) + "\n");
 		return new Promise((resolve, reject) => {
 			const timer = setTimeout(() => reject(new Error(`Timeout: ${cmd.type}`)), timeout);

--- a/tests/unit-prompt-stream.mjs
+++ b/tests/unit-prompt-stream.mjs
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for makePromptStream — the streaming-input prompt behind mid-turn
+ * steering.
+ *
+ * The consumer here mirrors the SDK's real pump:
+ *   for await (const m of stream) { await transport.write(m) }
+ * The ack contract only holds against that shape, so the tests exercise it
+ * rather than a bare `for await`.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { makePromptStream, userMessage } from "../src/prompt-stream.ts";
+
+const text = (msg) => msg.message.content[0].text;
+
+/** Drives the stream like the SDK does. `write` may return a promise; the pump
+ *  awaits it before pulling the next message. */
+function pump(stream, write) {
+	return (async () => {
+		for await (const msg of stream) await write(msg);
+	})();
+}
+
+describe("makePromptStream", () => {
+	it("resolves the ack only after the write completes", async () => {
+		const ps = makePromptStream();
+		const written = [];
+		let releaseWrite;
+		const writeGate = new Promise((r) => { releaseWrite = r; });
+		const pumping = pump(ps.stream, async (msg) => { written.push(text(msg)); await writeGate; });
+
+		let acked = false;
+		const ack = ps.push(userMessage([{ type: "text", text: "steer" }])).then(() => { acked = true; });
+
+		// Write is in flight but not finished — the ack must not have resolved,
+		// or a caller could release a tool result before the steer hits stdin.
+		await new Promise((r) => setTimeout(r, 10));
+		assert.deepStrictEqual(written, ["steer"]);
+		assert.equal(acked, false, "ack resolved before the write completed");
+
+		releaseWrite();
+		await ack;
+		assert.equal(acked, true);
+
+		ps.end();
+		await pumping;
+	});
+
+	it("delivers messages in push order and ends after draining", async () => {
+		const ps = makePromptStream();
+		const written = [];
+		const pumping = pump(ps.stream, (msg) => { written.push(text(msg)); });
+
+		await ps.push(userMessage([{ type: "text", text: "first" }]));
+		await ps.push(userMessage([{ type: "text", text: "second" }]));
+		ps.end();
+		await pumping;
+
+		assert.deepStrictEqual(written, ["first", "second"]);
+	});
+
+	it("carries priority through to the SDK message", () => {
+		const msg = userMessage([{ type: "text", text: "steer" }], "next");
+		assert.equal(msg.priority, "next");
+		assert.equal(msg.parent_tool_use_id, null);
+		// uuid is deliberately omitted — no dedup needed, and it would trigger a
+		// session lookup in CC's stdin loop.
+		assert.equal(msg.uuid, undefined);
+	});
+
+	it("rejects a push after end instead of hanging", async () => {
+		const ps = makePromptStream();
+		const pumping = pump(ps.stream, () => {});
+		ps.end();
+		await pumping;
+
+		// A steer racing end-of-turn must fail fast — an unsettled ack would wedge
+		// tool-result delivery forever.
+		await assert.rejects(ps.push(userMessage([{ type: "text", text: "late" }])), /closed/);
+	});
+
+	it("fail settles queued and in-flight acks", async () => {
+		const ps = makePromptStream();
+		// Pump that never finishes its write — models a CLI that died mid-write.
+		const pumping = pump(ps.stream, () => new Promise(() => {}));
+
+		const inflight = ps.push(userMessage([{ type: "text", text: "inflight" }]));
+		await new Promise((r) => setTimeout(r, 10));
+		const queued = ps.push(userMessage([{ type: "text", text: "queued" }]));
+
+		ps.fail(new Error("query ended"));
+		await assert.rejects(inflight, /query ended/);
+		await assert.rejects(queued, /query ended/);
+		await assert.rejects(ps.push(userMessage([{ type: "text", text: "after" }])), /query ended/);
+		void pumping;
+	});
+
+	it("settles the ack when the consumer abandons the stream", async () => {
+		const ps = makePromptStream();
+		// `break` in the pump calls gen.return(), which must run the generator's
+		// finally and settle the parked ack.
+		const pumping = (async () => {
+			for await (const _msg of ps.stream) break;
+		})();
+
+		await assert.rejects(ps.push(userMessage([{ type: "text", text: "abandoned" }])), /closed/);
+		await pumping;
+	});
+});


### PR DESCRIPTION
 - Closes #39. Sending a steering message used to be equivalent to a follow-up message. A steer sent while a tool was running was stashed and replayed as a continuation query after the whole turn finished.
 - The prompt is now a long-lived streaming-input generator. A steer is written to CC's stdin with priority: "next" before the tool result is released to its MCP handler; both travel the same stdin FIFO, so CC drains the steer at
   that tool boundary. The order is important! If the handler resolves first it silently degrades back to being a follow-up.
 - Removes deferredUserMessages, the continuation-replay path, and the continuation CC-log tag. Image steers keep their images.
 - CC emits no SDK-visible echo for a drained steer, so the integration test asserts on CC's session transcript: a queued_command attachment with no assistant record between it and the tool_result. 
 - Fragility note: the post-tool-call drain and FIFO ordering are CC CLI internals, not SDK contract. Re-verified across @anthropic-ai/claude-agent-sdk 0.2.141 → 0.3.220: streaming-input prompt type,
   priority, isSingleUserTurn, and the stdin-closing path are all unchanged, so the fix isn't tied to the pinned SDK version. unstable_v2_* was dropped rather than stabilized, and its send() wouldn't have helped — it resolves
   after enqueue, not after the stdin write.