### PR TITLE
Add profile-aware providers for multiple Claude Code accounts (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,30 @@ Config: `~/.pi/agent/claude-bridge.json` (global) or the project Pi config direc
 
 **Extension providers and models.json:** pi's `modelOverrides` in `~/.pi/agent/models.json` do not currently apply to extension-registered providers (like claude-bridge). Overriding `contextWindow` or other fields requires editing `src/models.ts` directly.
 
+## Profiles (multiple Claude Code accounts)
+
+Claude Code supports several accounts side by side via `CLAUDE_CONFIG_DIR` — each config dir gets its own login (on macOS, its own keychain entry). `provider.profiles` exposes those accounts as separate pi providers:
+
+```json
+{
+  "provider": {
+    "profiles": [
+      { "slug": "work", "label": "Work", "configDir": "~/.claude-work" }
+    ]
+  }
+}
+```
+
+Log the account in once (`CLAUDE_CONFIG_DIR=~/.claude-work claude auth login`), and `/model` gains a `claude-bridge-work/*` provider whose model names carry the label — e.g. `Opus 5 1M (Work)`. The default `claude-bridge/*` provider keeps using the environment as-is, exactly as before.
+
+- `slug` — lowercase `[a-z0-9-]`; the provider registers as `claude-bridge-<slug>`.
+- `label` — display suffix in the model picker (defaults to the slug).
+- `configDir` — the account's `CLAUDE_CONFIG_DIR`; `~` expands. Use `null` to force default resolution (the variable is *removed* from the child env — on macOS, unset and `~/.claude` are different keychain namespaces, and the default profile's `.claude.json` lives at `~/.claude.json`, not inside `~/.claude`).
+- Profiles are read from the **global** config only; a project-level `profiles` list is ignored (providers register once per process).
+- A profile with a `configDir` also drops inherited `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` from the child environment — those override the config dir's stored login, which would silently run every profile on one account (relevant when the default account authenticates via a token in the environment, e.g. for daemons). `configDir: null` profiles alias the default account and keep inherited credentials.
+
+Each profile keeps its own Claude Code session store: switching profiles mid-conversation rebuilds the CC session from pi's history under the new account (one slower first turn; thinking blocks signed by the other account are dropped from the replay). Quotas, subscriptions, and rate limits are per account. Subagents can pin an account via model overrides like `claude-bridge-work/claude-opus-5`; AskClaude follows the profile of the session it resumes, or the default account when starting fresh.
+
 ## Tests
 
 `npm run test:unit` for offline tests (`tests/unit-*.mjs`: queue, import, skills). 

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,6 +32,12 @@ export interface Config {
 		// Anthropic billing). Enables Sonnet 4.6 [1m] on every plan and Opus 4.6
 		// [1m] on Pro.
 		longContextExtraUsage?: boolean;
+		// Extra Claude Code accounts, each registered as provider
+		// claude-bridge-<slug> pinned to its own CLAUDE_CONFIG_DIR. configDir is
+		// a path, or null to force default resolution (variable removed from the
+		// child env). Global config only — providers register once per process,
+		// so a per-project list would desync co-hosted sessions. See profiles.ts.
+		profiles?: Array<{ slug: string; label?: string; configDir: string | null }>;
 	};
 }
 
@@ -81,9 +87,14 @@ export function markStartupNoticeShown(): string {
 export function loadConfig(cwd: string): Config {
 	const global = tryParseJson(globalConfigPath());
 	const project = tryParseJson(join(cwd, CONFIG_DIR_NAME, "claude-bridge.json"));
+	const provider = { ...global.provider, ...project.provider };
+	// Profiles are global-only: registration happens once per process, so a
+	// project override would leave co-hosted sessions with mismatched provider sets.
+	if (global.provider?.profiles) provider.profiles = global.provider.profiles;
+	else delete provider.profiles;
 	return {
 		startupNoticeShown: project.startupNoticeShown ?? global.startupNoticeShown,
 		askClaude: { ...global.askClaude, ...project.askClaude },
-		provider: { ...global.provider, ...project.provider },
+		provider,
 	};
 }

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -102,6 +102,7 @@ export type DroppedContent = {
 export function convertPiMessages(
 	messages: PiMessage[],
 	customToolNameToSdk?: Map<string, string>,
+	thinkingProviderId: string = PROVIDER_ID,
 ): { anthropicMessages: SessionMessage[]; sanitizedIds: Map<string, string>; dropped: DroppedContent } {
 	const anthropicMessages = [];
 	const sanitizedIds = new Map();
@@ -138,11 +139,12 @@ export function convertPiMessages(
 				if (block.type === "text" && block.text) {
 					blocks.push({ type: "text", text: block.text });
 				} else if (block.type === "thinking") {
-					// Only replay thinking Claude Code itself produced. A signature minted
-					// by any other provider — including pi's own Anthropic provider — is
+					// Only replay thinking Claude Code itself produced UNDER THIS PROFILE.
+					// A signature minted by any other provider — pi's own Anthropic
+					// provider, or the bridge running a different account profile — is
 					// not ours to hand back, and Anthropic rejects ones it can't verify.
 					const sig = block.thinkingSignature;
-					if (msg.provider === PROVIDER_ID && sig) {
+					if (msg.provider === thinkingProviderId && sig) {
 						blocks.push({ type: "thinking", thinking: block.thinking ?? "", signature: sig });
 					} else {
 						dropped.thinking++;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,12 @@ import { appendFileSync, mkdirSync, realpathSync, statSync } from "fs";
 import { homedir } from "os";
 import { dirname, join } from "path";
 import { PROVIDER_ID, messageContentToText, convertPiMessages } from "./convert.js";
-import { applyLongContext, buildModels, claudeCodeModelId, type LongContextSettings, resolveModel as _resolveModel } from "./models.js";
+import { applyLongContext, buildModels, claudeCodeModelId, labelModels, type LongContextSettings, resolveModel as _resolveModel } from "./models.js";
+import { DEFAULT_PROFILE, applyProfileEnv, effectiveClaudeDir, extraProfiles, profileForProvider, type BridgeProfile } from "./profiles.js";
 import { MCP_SERVER_NAME, MCP_TOOL_PREFIX, renderSkillsBlock } from "./skills.js";
 import { verifyWrittenSession as _verifyWrittenSession } from "./session-verify.js";
 import { extractAllToolResults as _extractAllToolResults, type McpResult } from "./extract-tool-results.js";
-import { QueryContext, ctx } from "./query-state.js";
+import { QueryContext, ctx, type SessionState } from "./query-state.js";
 import { makePromptStream, userMessage, type PromptStream } from "./prompt-stream.js";
 import { claudeCodeSettings, loadConfig, markStartupNoticeShown, type Config } from "./config.js";
 import {
@@ -206,35 +207,15 @@ const MODE_DISALLOWED_TOOLS: Record<string, string[]> = {
 
 // --- Session persistence ---
 
-interface SessionState {
-	sessionId: string;
-	cursor: number;
-	cwd: string;
-	// Force the next syncSharedSession call down the REBUILD path. Set when
-	// pi has mutated its messages array out from under us (compact, tree
-	// navigation) or after an abort left the JSONL in an indeterminate state.
-	// REBUILD wipes and rewrites the file to match pi's current history.
-	needsRebuild?: boolean;
-	// Set ONLY after an abort. The killed CC subprocess may still be flushing
-	// a late "[Request interrupted by user]" record to the session JSONL.
-	// Reusing the same sessionId/path would race that orphan write into our
-	// fresh file and break CC's parent-uuid chain on the next resume. When
-	// this flag is set, REBUILD takes a fresh UUID and skips deleteSession
-	// so the orphan writes land on a dead inode. Compact/tree do NOT set
-	// this — there's no concurrent CC writer during those events, so
-	// in-place rebuild (preserve UUID, deleteSession + createSession) is safe.
-	forceRotate?: boolean;
-}
-
 /**
  * Claude Code's `@file` expansions from the session about to be replaced.
  *
  * Must be called before `deleteSession`, which wipes the file they live in —
  * reading after it yields nothing, with no error to notice.
  */
-function readCarriedAttachments(sessionId: string, cwd: string): CarriedAttachment[] {
+function readCarriedAttachments(sessionId: string, cwd: string, claudeDir?: string): CarriedAttachment[] {
 	try {
-		const previous = openSession({ sessionId, projectPath: cwd, claudeDir: process.env.CLAUDE_CONFIG_DIR });
+		const previous = openSession({ sessionId, projectPath: cwd, claudeDir });
 		return collectCarriedAttachments(previous.records);
 	} catch (error) {
 		// A post-abort rebuild reads a file the killed CC subprocess may have been
@@ -261,8 +242,9 @@ function convertAndImportMessages(
 	messages: Context["messages"],
 	customToolNameToSdk?: Map<string, string>,
 	carried?: readonly CarriedAttachment[],
+	thinkingProviderId?: string,
 ): void {
-	const { anthropicMessages, sanitizedIds, dropped } = convertPiMessages(messages, customToolNameToSdk);
+	const { anthropicMessages, sanitizedIds, dropped } = convertPiMessages(messages, customToolNameToSdk, thinkingProviderId);
 
 	debug(`convertAndImportMessages: ${messages.length} pi msgs → ${anthropicMessages.length} anthropic msgs`);
 	debug(`convertAndImportMessages: imported roles:`, anthropicMessages.map((m, i) => {
@@ -458,14 +440,15 @@ async function runIsolatedSummary(
 		const cwd = (options as { cwd?: string } | undefined)?.cwd ?? process.cwd();
 		const compactProviderSettings = loadConfig(cwd).provider;
 		const claudeExecutable = compactProviderSettings?.pathToClaudeCodeExecutable;
+		const profile = profileForProvider(model.provider, providerSettings);
 		const cliModel = claudeCodeModelId(model, longContextSettings);
-		debug(`compact summary: spawn model=${cliModel} registeredModel=${model.id} promptLen=${promptText.length}`);
+		debug(`compact summary: spawn model=${cliModel} registeredModel=${model.id} profile=${profile.providerId} promptLen=${promptText.length}`);
 
 		sdkQuery = query({
 			prompt: promptText,
 			options: {
 				cwd,
-				env: { ...process.env, ...CC_CHILD_ENV },
+				env: applyProfileEnv({ ...process.env, ...CC_CHILD_ENV }, profile),
 				settings: { autoMemoryEnabled: false },
 				tools: [],
 				strictMcpConfig: true,
@@ -568,18 +551,19 @@ function verifyWrittenSession(
 	expectedSessionId: string,
 	expectedRecordCount: number,
 	cwd: string,
+	claudeDir?: string,
 ): void {
 	const warnings = _verifyWrittenSession(jsonlPath, expectedSessionId, expectedRecordCount);
 	for (const msg of warnings) {
 		debug(`WARNING session verify: ${msg}`);
 		piUI?.notify(
 			`Session file issue: ${msg}\n` +
-			`cwd=${cwd} realpath=${safeRealpath(cwd)} CLAUDE_CONFIG_DIR=${process.env.CLAUDE_CONFIG_DIR ?? "(unset)"}\n` +
+			`cwd=${cwd} realpath=${safeRealpath(cwd)} claudeDir=${claudeDir ?? process.env.CLAUDE_CONFIG_DIR ?? "(default)"}\n` +
 			`Please copy and paste this message into a new issue at https://github.com/elidickinson/pi-claude-bridge/issues/new` +
 			(DEBUG ? ` and attach ${DEBUG_LOG_PATH}` : ` (rerun with CLAUDE_BRIDGE_DEBUG=1 to capture a debug log)`),
 			"warning",
 		);
-		diagDump("session_verify_fail", { msg, jsonlPath, cwd, realpath: safeRealpath(cwd), claudeConfigDir: process.env.CLAUDE_CONFIG_DIR ?? null });
+		diagDump("session_verify_fail", { msg, jsonlPath, cwd, realpath: safeRealpath(cwd), claudeConfigDir: claudeDir ?? process.env.CLAUDE_CONFIG_DIR ?? null });
 	}
 }
 
@@ -636,8 +620,12 @@ function syncSharedSession(
 	cwd: string,
 	customToolNameToSdk?: Map<string, string>,
 	modelId?: string,
+	profile: BridgeProfile = DEFAULT_PROFILE,
 ): SyncResult {
 	const priorMessages = messages.slice(0, turnStart(messages)); // everything before the current user turn
+	const claudeDir = effectiveClaudeDir(profile);
+	const profileSwitched =
+		sharedSession != null && (sharedSession.providerId ?? PROVIDER_ID) !== profile.providerId;
 
 	// REUSE path
 	//
@@ -646,7 +634,7 @@ function syncSharedSession(
 	// pi-side history rewrites such as /compact and session_tree: without it,
 	// missed = [].slice(cursor) can falsely hit REUSE and resume an unrelated
 	// longer CC session. See issue #25.
-	if (sharedSession && !sharedSession.needsRebuild && priorMessages.length >= sharedSession.cursor) {
+	if (sharedSession && !sharedSession.needsRebuild && !profileSwitched && priorMessages.length >= sharedSession.cursor) {
 		const missed = priorMessages.slice(sharedSession.cursor);
 		const trailingAssistantOnly =
 			missed.length === 1 && (missed[0] as { role?: string }).role === "assistant";
@@ -687,39 +675,45 @@ function syncSharedSession(
 	}
 	const previousSessionId = sharedSession?.sessionId;
 	const previousCursor = sharedSession?.cursor ?? 0;
-	// preserveId: rebuild in place (deleteSession + createSession with the
-	// existing UUID), so prompt-cache UUIDs stay stable for log correlation
-	// and for any tools that key off them. Skipped only when there's a
-	// concurrent writer we shouldn't race — see forceRotate docs above.
-	const preserveId = previousSessionId !== undefined && !sharedSession?.forceRotate;
+	const previousProviderId = sharedSession?.providerId ?? PROVIDER_ID;
+	// A profile switch cannot see the existing session file. Rotate rather than
+	// deleting or overwriting the foreign profile's session.
+	const preserveId = previousSessionId !== undefined && !sharedSession?.forceRotate && !profileSwitched;
 	// Before deleteSession — it wipes the file these live in.
-	const carried = previousSessionId !== undefined ? readCarriedAttachments(previousSessionId, cwd) : [];
+	const carried = !profileSwitched && previousSessionId !== undefined
+		? readCarriedAttachments(previousSessionId, cwd, claudeDir)
+		: [];
 	if (preserveId) {
 		// Wipe prior jsonl + companion dir (no-op if nothing to wipe).
-		deleteSession(previousSessionId!, cwd, process.env.CLAUDE_CONFIG_DIR);
+		deleteSession(previousSessionId!, cwd, claudeDir);
 	}
 	const session = createSession({
 		projectPath: cwd,
-		claudeDir: process.env.CLAUDE_CONFIG_DIR,
+		claudeDir,
 		...(preserveId ? { sessionId: previousSessionId } : {}),
 		...(modelId ? { model: modelId } : {}),
 	});
-	convertAndImportMessages(session, priorMessages, customToolNameToSdk, carried);
+	convertAndImportMessages(session, priorMessages, customToolNameToSdk, carried, profile.providerId);
 	session.save();
 	// records, not messages: `messages` filters out the attachment records that
 	// carrying an `@file` expansion across a rebuild writes into the same file.
-	verifyWrittenSession(session.jsonlPath, session.sessionId, session.records.length, cwd);
-	sharedSession = { sessionId: session.sessionId, cursor: priorMessages.length, cwd };
+	verifyWrittenSession(session.jsonlPath, session.sessionId, session.records.length, cwd, claudeDir);
+	sharedSession = { sessionId: session.sessionId, cursor: priorMessages.length, cwd, providerId: profile.providerId };
+	if (profileSwitched) {
+		debug(`rebuild reason: profile switched (${previousProviderId} → ${profile.providerId}); previous file left in its own config dir`);
+	}
 	if (previousSessionId === undefined) {
 		debug(`Case 2: first turn with ${priorMessages.length} prior messages → session ${session.sessionId.slice(0, 8)}, ${session.records.length} records`);
 	} else if (preserveId) {
 		const missedCount = priorMessages.length - previousCursor;
 		debug(`Case 4: ${missedCount} missed messages, ${priorMessages.length} total → rewrote session ${session.sessionId.slice(0, 8)} (same id), ${session.records.length} records`);
+	} else if (profileSwitched) {
+		debug(`Case 4 profile switch: ${priorMessages.length} total → new session ${session.sessionId.slice(0, 8)} (was ${previousSessionId.slice(0, 8)}, foreign file left untouched), ${session.records.length} records`);
 	} else {
 		debug(`Case 4 post-abort: ${priorMessages.length} total → new session ${session.sessionId.slice(0, 8)} (was ${previousSessionId.slice(0, 8)}, rotated to avoid race with orphan writer), ${session.records.length} records`);
 	}
 	debugSessionPaths(`${session.sessionId.slice(0, 8)}`, cwd, session.jsonlPath);
-	debug(`syncResult: path=rebuild sessionId=${session.sessionId} priors=${priorMessages.length} ${previousSessionId === undefined ? "first" : preserveId ? "preserved" : "rotated-post-abort"}`);
+	debug(`syncResult: path=rebuild sessionId=${session.sessionId} priors=${priorMessages.length} ${previousSessionId === undefined ? "first" : preserveId ? "preserved" : profileSwitched ? "rotated-profile" : "rotated-post-abort"}`);
 	return { sessionId: session.sessionId };
 }
 
@@ -1518,10 +1512,15 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	queryCtx.latestCursor = 0;
 
 	const cwd = (options as { cwd?: string } | undefined)?.cwd ?? process.cwd();
+	// Which account serves this query: the registered provider id on the model
+	// picks the profile, the profile picks the child CLAUDE_CONFIG_DIR and the
+	// session store the tracked CC session lives in.
+	const profile = profileForProvider(model.provider, providerSettings);
+	const profileClaudeDir = effectiveClaudeDir(profile);
 	// cliModel is the actual id sent to Claude Code (may carry [1m]); model.id is the
 	// pi-registered id. Log cliModel so debug lines reflect what CC actually received.
 	const cliModel = claudeCodeModelId(model, longContextSettings);
-	const syncResult = syncSharedSession(context.messages, cwd, customToolNameToSdk, cliModel);
+	const syncResult = syncSharedSession(context.messages, cwd, customToolNameToSdk, cliModel, profile);
 	const { sessionId: resumeSessionId } = syncResult;
 	const promptBlocks = extractUserPromptBlocks(context.messages);
 	let promptText = extractUserPrompt(context.messages) ?? "";
@@ -1585,7 +1584,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// also autocompact would double-flush the prompt cache and races pi's
 	// threshold with CC's, including CC's anti-thrashing guard (issue #8).
 	// Manual /compact in CC still works (we never invoke it).
-	const childEnv = { ...process.env, ...CC_CHILD_ENV };
+	const childEnv = applyProfileEnv({ ...process.env, ...CC_CHILD_ENV }, profile);
 	const queryOptions: NonNullable<Parameters<typeof query>[0]["options"]> = {
 		cwd,
 		env: childEnv,
@@ -1607,6 +1606,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 
 	debug("provider: fresh query",
 		`model=${cliModel} msgs=${context.messages.length} tools=${mcpTools.length}`,
+		`profile=${profile.providerId}${profile.configDir ? ` configDir=${profile.configDir}` : ""}`,
 		`resume=${resumeSessionId?.slice(0, 8) ?? "none"} effort=${effort ?? "default"}`,
 		`ctxFiles=${promptCapture?.contextFiles.length ?? 0} strictMcp=${strictMcpConfigEnabled}`,
 		`prompt=${promptText.slice(0, 60)}${promptBlocks ? " [+images]" : ""}`);
@@ -1661,14 +1661,22 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 			const sessionId = capturedSessionId ?? sharedSession?.sessionId;
 			if (syncResult.preserveSharedSession) {
 				if (capturedSessionId && capturedSessionId !== sharedSession?.sessionId) {
-					deleteSession(capturedSessionId, cwd, process.env.CLAUDE_CONFIG_DIR);
+					// The ephemeral session was written by THIS query's CC subprocess,
+					// so it lives under this query's profile dir — not the shared
+					// session's, which may belong to a different profile.
+					deleteSession(capturedSessionId, cwd, profileClaudeDir);
 					debug(`provider: query done, deleted ephemeral session ${capturedSessionId.slice(0, 8)} to preserve shared session`);
 				}
 				debug(`provider: query done, ignoring captured session ${capturedSessionId?.slice(0, 8) ?? "none"} to preserve shared session`);
 			} else if (sessionId) {
 				const cursor = Math.max(context.messages.length, queryCtx.latestCursor, sharedSession?.cursor ?? 0);
 				debug(`provider: query done, session=${sessionId.slice(0, 8)}, cursor=${cursor}`);
-				sharedSession = { sessionId, cursor, cwd };
+				// Stamp providerId only when this query captured the session: a fallback
+				// id may belong to a concurrent query using another profile.
+				sharedSession = {
+					...(sharedSession ?? {}), sessionId, cursor, cwd,
+					...(capturedSessionId ? { providerId: profile.providerId } : {}),
+				};
 			}
 
 			if (!isReentrant && queryCtx.activeQuery === sdkQuery) {
@@ -1748,6 +1756,9 @@ async function promptAndWait(
 	const model = resolveModel(requestedModel);
 	const modelId = model?.id ?? requestedModel;
 	const cliModel = model ? claudeCodeModelId(model, longContextSettings) : modelId;
+	// AskClaude follows the profile owning the session it may resume; with no
+	// tracked session it uses the default account.
+	const profile = profileForProvider(sharedSession?.providerId, providerSettings);
 
 	// Session resume for shared mode — reuse provider's session if it exists,
 	// otherwise create one from pi's context.
@@ -1762,7 +1773,7 @@ async function promptAndWait(
 		} else {
 			// No provider session yet — create one from pi's context
 			const contextWithPrompt = [...options.context, { role: "user" as const, content: prompt, timestamp: Date.now() }];
-			const sync = syncSharedSession(contextWithPrompt as Context["messages"], cwd, undefined, cliModel);
+			const sync = syncSharedSession(contextWithPrompt as Context["messages"], cwd, undefined, cliModel, profile);
 			resumeSessionId = sync.sessionId;
 		}
 	}
@@ -1799,7 +1810,7 @@ async function promptAndWait(
 
 	debug("askClaude:",
 		`mode=${mode} model=${modelId} cliModel=${cliModel} effort=${effort ?? "default"}`,
-		`isolated=${options?.isolated ?? false} resume=${resumeSessionId?.slice(0, 8) ?? "none"}`,
+		`profile=${profile.providerId} isolated=${options?.isolated ?? false} resume=${resumeSessionId?.slice(0, 8) ?? "none"}`,
 		`skills=${Boolean(skillsBlock)} promptLen=${prompt.length}`);
 
 	// skills: [] suppresses Claude Code's own skill listing, a system-reminder naming every
@@ -1811,7 +1822,7 @@ async function promptAndWait(
 		prompt,
 		options: {
 			cwd,
-			env: { ...process.env, ...CC_CHILD_ENV },
+			env: applyProfileEnv({ ...process.env, ...CC_CHILD_ENV }, profile),
 			permissionMode: "bypassPermissions",
 			settings: { ...claudeCodeSettings(providerSettings), claudeMdExcludes: CLAUDE_MD_EXCLUDES },
 			skills: [],
@@ -2081,6 +2092,18 @@ export default function (pi: ExtensionAPI) {
 			// Cast: pi-ai AssistantMessageEventStream diamond dep between pi-coding-agent and pi-agent-core
 			streamSimple: streamClaudeAgentSdk as any,
 		});
+		// One provider per configured account profile, sharing the same baseUrl so
+		// baseUrl-keyed compact takeover and AskClaude guards cover all profiles.
+		for (const p of extraProfiles(providerSettings)) {
+			pi.registerProvider(p.providerId, {
+				baseUrl: "claude-bridge",
+				apiKey: "not-used",
+				api: "claude-bridge",
+				models: labelModels(registeredModels, p.label!),
+				streamSimple: streamClaudeAgentSdk as any,
+			});
+			debug(`provider: registered profile provider ${p.providerId} (${p.configDir ?? "default resolution"})`);
+		}
 	} else {
 		// Subsequent instance (subagent session): skip registration entirely.
 		// The subagent already has access to claude-bridge models via the shared

--- a/src/models.ts
+++ b/src/models.ts
@@ -93,3 +93,9 @@ export function applyLongContext<T extends { id: string; name: string; contextWi
 		return contextWindow === m.contextWindow && name === m.name ? m : { ...m, contextWindow, name };
 	});
 }
+
+// Display names for a profile provider's model list, so the picker shows which
+// account a model burns at a glance: "Opus 5 1M (Work)".
+export function labelModels<T extends { name: string }>(models: T[], label: string): T[] {
+	return models.map((m) => ({ ...m, name: `${m.name} (${label})` }));
+}

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -1,0 +1,131 @@
+// Profile-aware providers: each configured profile registers its own provider
+// id (claude-bridge-<slug>) bound to its own CLAUDE_CONFIG_DIR, so several
+// Claude Code accounts serve pi sessions side by side (upstream issue #57).
+//
+// The default profile is implicit and inherits the process environment
+// untouched — including an inherited CLAUDE_CONFIG_DIR. `configDir: null` on a
+// configured profile means "force default resolution" (REMOVE the variable):
+// on macOS the keychain entry is namespaced by the config dir, and the default
+// profile's .claude.json lives at ~/.claude.json in the home root, so setting
+// CLAUDE_CONFIG_DIR=~/.claude explicitly is NOT equivalent to leaving it unset.
+//
+// Extracted from index.ts so tests can import without activating the extension.
+
+import { homedir } from "os";
+import { join } from "path";
+import { PROVIDER_ID } from "./convert.js";
+import type { Config } from "./config.js";
+
+export interface BridgeProfile {
+	/** Provider id this profile serves under; PROVIDER_ID for the default. */
+	providerId: string;
+	/** Picker label appended to model names, e.g. "Work". */
+	label?: string;
+	/** Expanded CLAUDE_CONFIG_DIR to pin the child to. */
+	configDir?: string;
+	/** Remove CLAUDE_CONFIG_DIR from the child env (configDir: null). */
+	stripConfigDir?: boolean;
+}
+
+export const DEFAULT_PROFILE: BridgeProfile = { providerId: PROVIDER_ID };
+
+export function expandHome(p: string): string {
+	if (p === "~") return homedir();
+	if (p.startsWith("~/")) return join(homedir(), p.slice(2));
+	return p;
+}
+
+const SLUG_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+// Memoized per settings object: extraProfiles sits on the per-query hot path
+// (profileForProvider), and re-validating there would also re-print every
+// console.error once per turn into a live TUI. bs.providerSettings is assigned
+// once per activation, so object identity is a stable cache key.
+const profileCache = new WeakMap<object, BridgeProfile[]>();
+
+/** Configured extra profiles, validated. Invalid entries are dropped with a
+ *  console.error so the extension always starts. */
+export function extraProfiles(provider: Config["provider"]): BridgeProfile[] {
+	if (provider) {
+		const cached = profileCache.get(provider);
+		if (cached) return cached;
+	}
+	const out: BridgeProfile[] = [];
+	const seen = new Set<string>();
+	for (const entry of provider?.profiles ?? []) {
+		const slug = typeof entry?.slug === "string" ? entry.slug.toLowerCase() : "";
+		if (!SLUG_RE.test(slug)) {
+			console.error(`claude-bridge: profile slug ${JSON.stringify(entry?.slug)} is invalid (want [a-z0-9-], starting alphanumeric) — profile skipped`);
+			continue;
+		}
+		if (seen.has(slug)) {
+			console.error(`claude-bridge: duplicate profile slug "${slug}" — profile skipped`);
+			continue;
+		}
+		if ((typeof entry.configDir !== "string" || entry.configDir.trim() === "") && entry.configDir !== null) {
+			console.error(`claude-bridge: profile "${slug}" needs configDir (non-empty path, or null for default resolution) — profile skipped`);
+			continue;
+		}
+		seen.add(slug);
+		out.push({
+			providerId: `${PROVIDER_ID}-${slug}`,
+			label: typeof entry.label === "string" && entry.label.trim() ? entry.label.trim() : slug,
+			...(entry.configDir === null
+				? { stripConfigDir: true }
+				: { configDir: expandHome(entry.configDir) }),
+		});
+	}
+	if (provider) profileCache.set(provider, out);
+	return out;
+}
+
+/** Resolve the profile serving `providerId`. Non-bridge and default ids map to
+ *  the default profile, preserving pre-profile behavior exactly. A
+ *  `claude-bridge-*` id with no configured profile throws: it means the profile
+ *  was removed or re-slugged while its provider registration (or a tracked
+ *  session labeled with it) is still alive, and silently degrading to the
+ *  default ACCOUNT is the exact failure mode this module exists to prevent. */
+export function profileForProvider(providerId: string | undefined, provider: Config["provider"]): BridgeProfile {
+	if (!providerId || !providerId.startsWith(`${PROVIDER_ID}-`)) return DEFAULT_PROFILE;
+	const found = extraProfiles(provider).find((p) => p.providerId === providerId);
+	if (!found) {
+		throw new Error(
+			`claude-bridge: no configured profile for provider "${providerId}" — it was removed or renamed in provider.profiles. ` +
+			`Restore the profile in the global claude-bridge.json (and /reload), or switch to a configured model.`,
+		);
+	}
+	return found;
+}
+
+/** Apply a profile's CLAUDE_CONFIG_DIR policy to a child env (mutates and
+ *  returns `env`, which callers construct fresh per query).
+ *
+ *  A PINNED profile also drops inherited credential overrides: verified
+ *  empirically that CLAUDE_CODE_OAUTH_TOKEN beats the config dir's stored
+ *  login (auth status flips to `oauth_token`), so a host that authenticates
+ *  its default account through the environment (e.g. a token in ~/.zshenv for
+ *  daemon use) would otherwise run every profile on that one account — the
+ *  silent wrong-account failure profiles exist to prevent. Strip profiles
+ *  alias the default account, so they keep inherited credentials. */
+export function applyProfileEnv(env: Record<string, string | undefined>, profile: BridgeProfile): Record<string, string | undefined> {
+	if (profile.configDir) {
+		env.CLAUDE_CONFIG_DIR = profile.configDir;
+		delete env.CLAUDE_CODE_OAUTH_TOKEN;
+		delete env.ANTHROPIC_API_KEY;
+	} else if (profile.stripConfigDir) {
+		delete env.CLAUDE_CONFIG_DIR;
+	}
+	return env;
+}
+
+/** The claudeDir under which this profile's CC session files live — what
+ *  cc-session-io's createSession/deleteSession must be pointed at. Never
+ *  undefined for a strip profile: cc-session-io's own fallback chain is
+ *  `claudeDir ?? process.env.CLAUDE_CONFIG_DIR ?? ~/.claude`, so returning
+ *  undefined would make pi WRITE the session under an inherited
+ *  CLAUDE_CONFIG_DIR while the stripped child READS ~/.claude. */
+export function effectiveClaudeDir(profile: BridgeProfile): string | undefined {
+	if (profile.configDir) return profile.configDir;
+	if (profile.stripConfigDir) return join(homedir(), ".claude");
+	return process.env.CLAUDE_CONFIG_DIR;
+}

--- a/src/query-state.ts
+++ b/src/query-state.ts
@@ -15,6 +15,32 @@ export interface PendingToolCall {
 	resolve: (result: McpResult) => void;
 }
 
+/** The Claude Code session this pi session is currently tracking. */
+export interface SessionState {
+	sessionId: string;
+	cursor: number;
+	cwd: string;
+	// Provider id of the profile whose CLAUDE_CONFIG_DIR this CC session file
+	// lives under (undefined = default profile, incl. pre-profile states). A
+	// query on a different profile can neither resume nor delete this file —
+	// its config dir cannot see it, so a mismatch forces a rotated REBUILD.
+	providerId?: string;
+	// Force the next syncSharedSession call down the REBUILD path. Set when
+	// pi has mutated its messages array out from under us (compact, tree
+	// navigation) or after an abort left the JSONL in an indeterminate state.
+	// REBUILD wipes and rewrites the file to match pi's current history.
+	needsRebuild?: boolean;
+	// Set ONLY after an abort. The killed CC subprocess may still be flushing
+	// a late "[Request interrupted by user]" record to the session JSONL.
+	// Reusing the same sessionId/path would race that orphan write into our
+	// fresh file and break CC's parent-uuid chain on the next resume. When
+	// this flag is set, REBUILD takes a fresh UUID and skips deleteSession
+	// so the orphan writes land on a dead inode. Compact/tree do NOT set
+	// this — there's no concurrent CC writer during those events, so
+	// in-place rebuild (preserve UUID, deleteSession + createSession) is safe.
+	forceRotate?: boolean;
+}
+
 export class QueryContext {
 	// Query-scoped (fully isolated per query)
 	activeQuery: unknown | null = null;

--- a/tests/int-profile-switch.mjs
+++ b/tests/int-profile-switch.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Switching to a different account profile mid-conversation must rebuild the
+// Claude Code session under the new profile's provider id — rotated, with the
+// history intact — instead of resuming a session file the new profile's config
+// dir cannot see ("No conversation found").
+//
+// Self-contained with ONE real account: the test registers an extra profile
+// with `configDir: null` (strip semantics) in a throwaway agent dir, so both
+// providers resolve to the same login. That exercises registration, /model
+// routing to a profile provider, and the rotated-profile rebuild against a
+// live CC subprocess — NOT the env isolation between two real accounts, which
+// only a second login can prove (unit tests cover the env/dir policy itself).
+
+import { createRpcHarness } from "./lib/rpc-harness.mjs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getProjectDir } from "cc-session-io";
+
+const TIMEOUT = 90_000;
+
+console.log("=== profile-switch-test.mjs ===");
+
+const CWD = mkdtempSync(join(tmpdir(), "profile-switch."));
+const AGENT_DIR = mkdtempSync(join(tmpdir(), "profile-switch-agent."));
+writeFileSync(join(AGENT_DIR, "claude-bridge.json"), JSON.stringify({
+	provider: { profiles: [{ slug: "alt", label: "Alt", configDir: null }] },
+}));
+
+const harness = createRpcHarness({
+	name: "profile-switch",
+	args: ["--model", "claude-bridge/claude-haiku-4-5", "-e", process.cwd()],
+	cwd: CWD,
+	env: { PI_CODING_AGENT_DIR: AGENT_DIR },
+	defaultTimeout: TIMEOUT,
+});
+
+const { startAndWait, stop, send, promptAndWait } = harness;
+
+function fail(msg) {
+	console.error(`FAIL: ${msg}`);
+	console.error(`  RPC log:   ${harness.RPC_LOG}`);
+	console.error(`  Debug log: ${harness.DEBUG_LOG}`);
+	process.exitCode = 1;
+}
+
+await startAndWait();
+try {
+	console.log("Turn 1 on claude-bridge: plant a codeword...");
+	const first = await promptAndWait(
+		"The codeword is PINEAPPLE. Acknowledge with just the word OK.",
+		TIMEOUT,
+	);
+	console.log(`  Response: ${first.trim().slice(0, 60)}`);
+
+	console.log("Switching to claude-bridge-alt/claude-haiku-4-5...");
+	await send({ type: "set_model", provider: "claude-bridge-alt", modelId: "claude-haiku-4-5" }, TIMEOUT);
+
+	console.log("Turn 2 on the alt profile: recall through the rebuilt session...");
+	const answer = await promptAndWait(
+		"What is the codeword from earlier in this conversation? Reply with just the codeword, or NONE if you cannot see one.",
+		TIMEOUT,
+	);
+	console.log(`  Response: ${answer.trim().slice(0, 80)}`);
+	if (!/pineapple/i.test(answer)) {
+		fail(`history did not survive the profile switch (got: ${answer.trim().slice(0, 120)})`);
+	}
+
+	// The switch must have gone down the rotated-profile REBUILD, not REUSE:
+	// resuming the old id under another profile is exactly the cross-account
+	// failure mode this feature exists to prevent.
+	const debugLog = readFileSync(harness.DEBUG_LOG, "utf8");
+	if (!debugLog.includes("rotated-profile")) {
+		fail("debug log shows no rotated-profile rebuild — the switch resumed or preserved the old profile's session");
+	}
+
+	if (!process.exitCode) console.log("PASS");
+} catch (err) {
+	if (!process.exitCode) throw err;
+} finally {
+	await stop();
+	const projectDir = getProjectDir(CWD);
+	rmSync(CWD, { recursive: true, force: true });
+	rmSync(AGENT_DIR, { recursive: true, force: true });
+	if (projectDir.includes("profile-switch")) rmSync(projectDir, { recursive: true, force: true });
+}

--- a/tests/unit-config.mjs
+++ b/tests/unit-config.mjs
@@ -77,6 +77,35 @@ describe("loadConfig", () => {
 		}
 	}));
 
+	it("profiles are global-only: a project-level list is dropped, a global one survives the merge", () => withTempHome(() => {
+		const cwd = mkdtempSync(join(tmpdir(), "claude-bridge-project-"));
+		try {
+			const globalDir = getAgentDir();
+			const projectDir = join(cwd, CONFIG_DIR_NAME);
+			mkdirSync(globalDir, { recursive: true });
+			mkdirSync(projectDir, { recursive: true });
+			const globalProfiles = [{ slug: "work", configDir: "~/.claude-work" }];
+			writeFileSync(join(globalDir, "claude-bridge.json"), JSON.stringify({
+				provider: { profiles: globalProfiles },
+			}));
+			// Providers register once per process, so a project override would give
+			// co-hosted sessions mismatched provider sets — it must be ignored.
+			writeFileSync(join(projectDir, "claude-bridge.json"), JSON.stringify({
+				provider: { plan: "max", profiles: [{ slug: "evil", configDir: "/tmp/x" }] },
+			}));
+
+			const merged = loadConfig(cwd);
+			assert.deepEqual(merged.provider.profiles, globalProfiles);
+			assert.equal(merged.provider.plan, "max");
+
+			// And with no global list, the project list must not sneak in.
+			writeFileSync(join(globalDir, "claude-bridge.json"), JSON.stringify({ provider: { plan: "pro" } }));
+			assert.equal(loadConfig(cwd).provider.profiles, undefined);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	}));
+
 	it("markStartupNoticeShown records today's date without dropping existing settings", () => withTempHome(() => {
 		const cwd = mkdtempSync(join(tmpdir(), "claude-bridge-project-"));
 		try {

--- a/tests/unit-profiles.mjs
+++ b/tests/unit-profiles.mjs
@@ -1,0 +1,252 @@
+/**
+ * Profile-aware providers (profiles.ts + syncSharedSession's profile keying).
+ *
+ * Two accounts sharing one bridge is only safe if (a) each child process gets
+ * exactly the CLAUDE_CONFIG_DIR its profile dictates — set, inherited, or
+ * REMOVED, which macOS keychain namespacing makes three distinct states — and
+ * (b) a session tracked under one profile is never resumed or deleted through
+ * another profile's config dir.
+ */
+import { describe, it, after, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { createSession, getSessionPath } from "cc-session-io";
+
+// Rebuild paths write real CC session files — keep them in a throwaway dir.
+const defaultClaudeDir = mkdtempSync(join(tmpdir(), "profiles-default-claude-"));
+const workClaudeDir = mkdtempSync(join(tmpdir(), "profiles-work-claude-"));
+process.env.CLAUDE_CONFIG_DIR = defaultClaudeDir;
+
+const { extraProfiles, profileForProvider, applyProfileEnv, effectiveClaudeDir, DEFAULT_PROFILE, expandHome } =
+	await import("../src/profiles.js");
+const { labelModels } = await import("../src/models.js");
+const { PROVIDER_ID, convertPiMessages } = await import("../src/convert.js");
+const { __test } = await import("../src/index.js");
+
+const WORK = { providerId: "claude-bridge-work", label: "Work", configDir: workClaudeDir };
+
+describe("extraProfiles", () => {
+	it("builds a provider id, expands ~, defaults the label to the slug", () => {
+		const [p] = extraProfiles({ profiles: [{ slug: "work", configDir: "~/.claude-work" }] });
+		assert.equal(p.providerId, "claude-bridge-work");
+		assert.equal(p.label, "work");
+		assert.equal(p.configDir, join(homedir(), ".claude-work"));
+		assert.equal(p.stripConfigDir, undefined);
+	});
+
+	it("configDir: null means strip, not a path", () => {
+		const [p] = extraProfiles({ profiles: [{ slug: "home", label: "Home", configDir: null }] });
+		assert.equal(p.configDir, undefined);
+		assert.equal(p.stripConfigDir, true);
+		assert.equal(p.label, "Home");
+	});
+
+	it("drops invalid slugs, duplicates, missing and empty configDir instead of throwing", () => {
+		const profiles = extraProfiles({
+			profiles: [
+				{ slug: "ok", configDir: "/tmp/a" },
+				{ slug: "Bad Slug!", configDir: "/tmp/b" },
+				{ slug: "ok", configDir: "/tmp/c" },
+				{ slug: "no-dir" },
+				// "" is falsy everywhere downstream — accepted, it would silently
+				// alias the inherited account under a differently-labeled picker entry.
+				{ slug: "empty", configDir: "" },
+				{ slug: "blank", configDir: "   " },
+			],
+		});
+		assert.deepEqual(profiles.map((p) => p.providerId), ["claude-bridge-ok"]);
+	});
+
+	it("memoizes per settings object — hot-path calls must not revalidate", () => {
+		const settings = { profiles: [{ slug: "work", configDir: "/tmp/a" }] };
+		assert.equal(extraProfiles(settings), extraProfiles(settings));
+	});
+
+	it("empty and absent lists yield no extra providers", () => {
+		assert.deepEqual(extraProfiles({}), []);
+		assert.deepEqual(extraProfiles(undefined), []);
+		assert.deepEqual(extraProfiles({ profiles: [] }), []);
+	});
+});
+
+describe("profileForProvider", () => {
+	const settings = { profiles: [{ slug: "work", label: "Work", configDir: workClaudeDir }] };
+
+	it("default for undefined, the base provider id, and non-bridge ids", () => {
+		assert.equal(profileForProvider(undefined, settings), DEFAULT_PROFILE);
+		assert.equal(profileForProvider(PROVIDER_ID, settings), DEFAULT_PROFILE);
+		assert.equal(profileForProvider("openai-codex", settings), DEFAULT_PROFILE);
+	});
+
+	it("throws for a claude-bridge-* id with no configured profile — never silently the wrong account", () => {
+		assert.throws(() => profileForProvider("claude-bridge-gone", settings), /no configured profile/);
+	});
+
+	it("resolves a configured profile by provider id", () => {
+		const p = profileForProvider("claude-bridge-work", settings);
+		assert.equal(p.configDir, workClaudeDir);
+	});
+});
+
+describe("applyProfileEnv", () => {
+	it("pins CLAUDE_CONFIG_DIR and drops inherited credential overrides for a configDir profile", () => {
+		// CLAUDE_CODE_OAUTH_TOKEN beats the config dir's stored login (verified:
+		// auth status flips to oauth_token), so a host that authenticates its
+		// default account via env would run every profile on that one account.
+		const env = applyProfileEnv(
+			{ CLAUDE_CONFIG_DIR: "/inherited", CLAUDE_CODE_OAUTH_TOKEN: "tok", ANTHROPIC_API_KEY: "key", OTHER: "kept" },
+			WORK,
+		);
+		assert.equal(env.CLAUDE_CONFIG_DIR, workClaudeDir);
+		assert.equal("CLAUDE_CODE_OAUTH_TOKEN" in env, false);
+		assert.equal("ANTHROPIC_API_KEY" in env, false);
+		assert.equal(env.OTHER, "kept");
+	});
+
+	it("REMOVES the variable for a strip profile — unset and ~/.claude are not equivalent — but keeps inherited credentials (it aliases the default account)", () => {
+		const env = applyProfileEnv(
+			{ CLAUDE_CONFIG_DIR: "/inherited", CLAUDE_CODE_OAUTH_TOKEN: "tok", OTHER: "kept" },
+			{ providerId: "claude-bridge-home", stripConfigDir: true },
+		);
+		assert.equal("CLAUDE_CONFIG_DIR" in env, false);
+		assert.equal(env.CLAUDE_CODE_OAUTH_TOKEN, "tok");
+		assert.equal(env.OTHER, "kept");
+	});
+
+	it("inherits untouched for the default profile", () => {
+		const env = applyProfileEnv({ CLAUDE_CONFIG_DIR: "/inherited" }, DEFAULT_PROFILE);
+		assert.equal(env.CLAUDE_CONFIG_DIR, "/inherited");
+	});
+});
+
+describe("effectiveClaudeDir", () => {
+	it("profile dir; inherited env for default", () => {
+		assert.equal(effectiveClaudeDir(WORK), workClaudeDir);
+		assert.equal(effectiveClaudeDir(DEFAULT_PROFILE), defaultClaudeDir);
+	});
+
+	// cc-session-io's fallback chain is `claudeDir ?? env.CLAUDE_CONFIG_DIR ??
+	// ~/.claude`. A strip profile's child reads ~/.claude, so pi must WRITE
+	// there explicitly — returning undefined here (with CLAUDE_CONFIG_DIR
+	// inherited, as in this suite) would make pi write one store while the
+	// child reads another, and every resume would fail.
+	it("strip profile pins ~/.claude even when the process inherits CLAUDE_CONFIG_DIR", () => {
+		assert.equal(effectiveClaudeDir({ providerId: "x", stripConfigDir: true }), join(homedir(), ".claude"));
+	});
+});
+
+describe("labelModels", () => {
+	it("suffixes display names and leaves ids alone", () => {
+		const models = labelModels([{ id: "claude-opus-5", name: "Opus 5 1M" }], "Work");
+		assert.deepEqual(models, [{ id: "claude-opus-5", name: "Opus 5 1M (Work)" }]);
+	});
+});
+
+describe("thinking replay across profiles", () => {
+	// A signature is only ours to hand back to the account that minted it.
+	// Cross-profile replays must drop the thinking block — same treatment as
+	// thinking from any other provider.
+	const history = [
+		{ role: "user", content: "hi" },
+		{
+			role: "assistant",
+			provider: PROVIDER_ID,
+			content: [
+				{ type: "thinking", thinking: "private reasoning", thinkingSignature: "sig-abc" },
+				{ type: "text", text: "hello" },
+			],
+		},
+	];
+
+	const blockTypes = (msgs) => msgs[1].content.map((b) => b.type);
+
+	it("replays thinking for the same profile's provider id", () => {
+		const { anthropicMessages } = convertPiMessages(history, undefined, PROVIDER_ID);
+		assert.deepEqual(blockTypes(anthropicMessages), ["thinking", "text"]);
+	});
+
+	it("drops thinking when a different profile rebuilds the history", () => {
+		const { anthropicMessages } = convertPiMessages(history, undefined, "claude-bridge-work");
+		assert.deepEqual(blockTypes(anthropicMessages), ["text"]);
+	});
+});
+
+describe("expandHome", () => {
+	it("expands ~ and ~/ but not mid-path tildes", () => {
+		assert.equal(expandHome("~"), homedir());
+		assert.equal(expandHome("~/.claude-work"), join(homedir(), ".claude-work"));
+		assert.equal(expandHome("/abs/~x"), "/abs/~x");
+	});
+});
+
+describe("syncSharedSession profile keying", () => {
+	after(() => {
+		rmSync(defaultClaudeDir, { recursive: true, force: true });
+		rmSync(workClaudeDir, { recursive: true, force: true });
+	});
+
+	afterEach(() => {
+		__test.resetSharedSession();
+	});
+
+	const userMsg = (text) => ({ role: "user", content: text, timestamp: Date.now() });
+	const assistantMsg = (text) => ({ role: "assistant", content: [{ type: "text", text }], timestamp: Date.now() });
+
+	it("a profile switch rotates the session and leaves the other profile's file alone", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "profiles-sync-"));
+		try {
+			// A tracked session written under the DEFAULT profile, with a real file.
+			const tracked = createSession({ projectPath: cwd, claudeDir: defaultClaudeDir });
+			tracked.importMessages([{ role: "user", content: "hi" }, { role: "assistant", content: [{ type: "text", text: "hello" }] }]);
+			tracked.save();
+			__test.setSharedSession({ sessionId: tracked.sessionId, cursor: 2, cwd });
+
+			// Same history, but the query arrives on the work profile. Without the
+			// profile guard this REUSEs — and the work-account CC child then fails
+			// with "No conversation found" because its config dir can't see the file.
+			const messages = [userMsg("hi"), assistantMsg("hello"), userMsg("next question")];
+			const result = __test.syncSharedSession(messages, cwd, undefined, undefined, WORK);
+
+			assert.notEqual(result.sessionId, null);
+			assert.notEqual(result.sessionId, tracked.sessionId, "must not resume a foreign profile's session id");
+			const state = __test.getSharedSession();
+			assert.equal(state.providerId, "claude-bridge-work");
+			assert.ok(existsSync(getSessionPath(result.sessionId, cwd, workClaudeDir)), "rebuilt session must live in the work profile's dir");
+			assert.ok(existsSync(tracked.jsonlPath), "the default profile's file must be left untouched");
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("the same profile still REUSEs its tracked session", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "profiles-sync-"));
+		try {
+			const messages = [userMsg("hi"), assistantMsg("hello"), userMsg("next question")];
+			const first = __test.syncSharedSession(messages, cwd, undefined, undefined, WORK);
+			assert.notEqual(first.sessionId, null);
+
+			const again = __test.syncSharedSession(messages, cwd, undefined, undefined, WORK);
+			assert.equal(again.sessionId, first.sessionId, "same profile with unchanged history must resume");
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("pre-profile states (providerId undefined) mean the default profile", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "profiles-sync-"));
+		try {
+			const tracked = createSession({ projectPath: cwd, claudeDir: defaultClaudeDir });
+			tracked.importMessages([{ role: "user", content: "hi" }, { role: "assistant", content: [{ type: "text", text: "hello" }] }]);
+			tracked.save();
+			__test.setSharedSession({ sessionId: tracked.sessionId, cursor: 2, cwd });
+
+			const messages = [userMsg("hi"), assistantMsg("hello"), userMsg("next question")];
+			const result = __test.syncSharedSession(messages, cwd);
+			assert.equal(result.sessionId, tracked.sessionId, "default profile must keep resuming pre-profile sessions");
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
Implements #57: each entry in a new `provider.profiles` list registers an extra provider `claude-bridge-<slug>` pinned to its own `CLAUDE_CONFIG_DIR`, so several Claude Code accounts are selectable side by side from `/model` and usable as explicit subagent model overrides.

## Config

```json
{
  "provider": {
    "profiles": [
      { "slug": "work", "label": "Work", "configDir": "~/.claude-work" }
    ]
  }
}
```

The default `claude-bridge/*` provider keeps inheriting the process environment untouched - zero-diff for existing configs. Model names carry the label in the picker (`Opus 5 1M (Work)`).

## Isolation, per the issue's acceptance criteria

- **Child env per provider call**: `configDir` string sets `CLAUDE_CONFIG_DIR` (with `~` expansion); `configDir: null` REMOVES the variable rather than setting `~/.claude` - unset and explicit are different keychain namespaces on macOS, and the default profile's `.claude.json` lives at `~/.claude.json`, not inside `~/.claude` (verified empirically).
- **Pinned profiles also drop inherited `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY`**: verified that the env token beats the config dir's stored login, so a host authenticating its default account through the environment would otherwise run every profile on that one account.
- **Session/resume state keyed by profile**: `sharedSession.providerId` records which profile's dir the tracked CC session lives under. A query on a different profile never REUSEs it (its config dir cannot see the file - `--resume` would fail with "No conversation found") and never deletes it; it takes a rotated rebuild (`rotated-profile`) and leaves the foreign file untouched. Ephemeral subagent sessions are deleted under the query's own profile dir.
- **Thinking replay is exact-match on provider id**: one account's signatures are never handed back through another account.
- **Deterministic, no failover**: an unknown `claude-bridge-*` provider id (profile removed/renamed while registered) throws loudly instead of silently degrading to the default account. Profiles are read from the global config only, since providers register once per process.
- AskClaude follows the profile of the session it resumes (default account otherwise); isolated compact summaries follow the active model's profile.

## Testing

- `npm run typecheck`, `npm run test:unit` green (206 tests).
- New `tests/unit-profiles.mjs` (env policy, validation, claudeDir resolution, profile-switch rotation via `syncSharedSession`, thinking replay) and a global-only-profiles case in `tests/unit-config.mjs`.
- New `tests/int-profile-switch.mjs`: live two-provider session against a real CC subprocess - plants a codeword on the default provider, switches to a profile provider, asserts recall plus a `rotated-profile` rebuild in the debug log. Self-contained with one logged-in account (uses a `configDir: null` profile).
- Cross-account E2E on a machine with two real logins (Max + Team): personal -> work -> personal in one pi session, history intact, session files verified to land in their respective `projects/` stores, both directions rotated.
