### PR TITLE
Allow opting out of compaction and branch summarization takeover

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Config: `~/.pi/agent/claude-bridge.json` (global) or the project Pi config direc
     "longContextExtraUsage": false,
     "strictMcpConfig": true,
     "pathToClaudeCodeExecutable": "/home/you/.nix-profile/bin/claude"
+  },
+  "compaction": {
+    "takeover": true
+  },
+  "branchSummary": {
+    "takeover": true
   }
 }
 ```
@@ -86,6 +92,18 @@ Config: `~/.pi/agent/claude-bridge.json` (global) or the project Pi config direc
 - `strictMcpConfig` — block MCP servers from `~/.claude.json` / `.mcp.json` (default `true`). Cloud MCP (Gmail/Drive via claude.ai OAuth) is always blocked.
 - `autoMemoryEnabled` — enable Claude Code's auto-memory system (default `false`)
 - `pathToClaudeCodeExecutable` — path to the `claude` binary. Useful if your OS/filesystem has the SDK's bundled musl/glibc binaries in a place where they can't run. For example, with Nix you can set the binary to e.g. `"/home/you/.nix-profile/bin/claude"`.
+
+`compaction`:
+- `takeover` (default `true`) — answer `session_before_compact` and run pi's `compact()` through an isolated Claude Code subprocess (no tools, no skills, single turn, `persistSession: false`). This only changes the *transport* of the summarization call: the preparation, prompt and summary format are pi's own.
+
+  Set to `false` if you use a context-management extension that owns compaction itself (for example one that maintains its own memory ledger). With `takeover: true`, the bridge runs first and produces a summary that the other extension then overwrites, so you pay for a summarization that gets discarded — and if the bridge's call fails it returns `cancel`, which aborts compaction before the other extension's handler ever runs.
+
+  With `takeover: false` the bridge still re-injects cumulative file operations from the previous compaction entry, since pi's native extraction skips `details` on hook-authored entries.
+
+`branchSummary`:
+- `takeover` (default `true`) — the same thing for `session_before_tree`, the summary pi generates when you rewind or fork-at-point with "summarize".
+
+  Set to `false` only when another extension answers that event. Unlike `compaction.takeover`, falling through to pi's own path does **not** work on a bridge model: branch summaries run through the agent's stream function, so pi's internal branch-summary prompt reaches this provider having never been recorded by `before_agent_start`, and `resolveOrDerive` throws rather than silently sending Claude Code no context files, skills or instructions. Turn this off when something else owns branch summaries, not to get pi's native behaviour back.
 
 
 **Startup notice:** the first interactive session to reach Claude Code lists whichever of `provider.plan` and `askClaude.enabled` you have left unset, then records `startupNoticeShown` (the date, `YYYY-MM-DD`) in the global config so it doesn't nag again.

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,21 @@ export interface Config {
 		// [1m] on Pro.
 		longContextExtraUsage?: boolean;
 	};
+	compaction?: {
+		// When true (default), the extension answers session_before_compact and
+		// runs pi's compact() through an isolated Claude Code subprocess (no
+		// tools, no skills, single turn). Set to false to stand down so native
+		// pi compaction or another extension owns the summary instead.
+		takeover?: boolean;
+	};
+	branchSummary?: {
+		// When true (default), the extension answers session_before_tree the same
+		// way. Set to false only when another extension owns branch summaries:
+		// unlike compaction, native fall-through cannot work on a bridge model,
+		// because pi's branch-summary prompt reaches the provider unrecorded and
+		// resolveOrDerive throws on it.
+		takeover?: boolean;
+	};
 }
 
 export function tryParseJson(path: string): Partial<Config> {
@@ -85,5 +100,7 @@ export function loadConfig(cwd: string): Config {
 		startupNoticeShown: project.startupNoticeShown ?? global.startupNoticeShown,
 		askClaude: { ...global.askClaude, ...project.askClaude },
 		provider: { ...global.provider, ...project.provider },
+		compaction: { ...global.compaction, ...project.compaction },
+		branchSummary: { ...global.branchSummary, ...project.branchSummary },
 	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1983,6 +1983,14 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_before_compact", async (event, ctx) => {
 		if (ctx.model?.baseUrl !== "claude-bridge") return undefined;
+		if (config.compaction?.takeover === false) {
+			// Still contribute cumulative file ops. pi's own extractFileOperations
+			// skips details from hook-authored compaction entries, so whoever owns
+			// the summary would otherwise restart file tracking from scratch.
+			reinjectPriorCompactionFileOps(event.branchEntries, event.preparation);
+			debug(`session_before_compact: takeover disabled, deferring reason=${event.reason}`);
+			return undefined;
+		}
 		debug(
 			`session_before_compact: takeover reason=${event.reason} willRetry=${event.willRetry} ` +
 			`isSplitTurn=${event.preparation.isSplitTurn} messages=${event.preparation.messagesToSummarize.length} ` +
@@ -2040,6 +2048,13 @@ export default function (pi: ExtensionAPI) {
 	// Claude Code subprocess, never touching the live session or the resolver.
 	pi.on("session_before_tree", async (event, ctx) => {
 		if (ctx.model?.baseUrl !== "claude-bridge") return undefined;
+		if (config.branchSummary?.takeover === false) {
+			// Only sound when a later handler answers this event. Falling through to
+			// pi's own path sends the branch-summary prompt to the provider, where
+			// resolveOrDerive throws because no before_agent_start ever recorded it.
+			debug(`session_before_tree: takeover disabled, deferring target=${event.preparation.targetId.slice(0, 8)}`);
+			return undefined;
+		}
 		const { entriesToSummarize, userWantsSummary, customInstructions, replaceInstructions } = event.preparation;
 		if (!userWantsSummary || entriesToSummarize.length === 0) return undefined;
 		debug(`session_before_tree: takeover entries=${entriesToSummarize.length} target=${event.preparation.targetId.slice(0, 8)}`);

--- a/tests/fixtures/summary-override-extension.ts
+++ b/tests/fixtures/summary-override-extension.ts
@@ -1,0 +1,54 @@
+// Test extension: stands in for a context-management extension that owns
+// compaction and branch summarization itself (pi-observational-memory and
+// friends). Loaded *after* the bridge, so `emit` keeps this handler's result —
+// the runner assigns every truthy return in order and the last one wins.
+//
+// SUMMARY_OVERRIDE_MODE=override answers both `session_before_*` events with a
+// fixed summary and no model call. `probe` answers neither, and only records
+// what pi ended up persisting, so a test can assert that nothing produced a
+// summary at all.
+//
+// Both modes append to SUMMARY_OVERRIDE_MARKER. The post-events carry what was
+// actually written to the session (`compactionEntry`, `summaryEntry`), so the
+// marker proves the override reached the transcript rather than merely being
+// returned from a handler.
+import { appendFileSync } from "node:fs";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export const COMPACTION_SENTINEL = "OVERRIDE-COMPACTION-SUMMARY-8f21";
+export const BRANCH_SENTINEL = "OVERRIDE-BRANCH-SUMMARY-4c07";
+
+const MARKER = process.env.SUMMARY_OVERRIDE_MARKER;
+const OVERRIDING = process.env.SUMMARY_OVERRIDE_MODE !== "probe";
+
+function mark(line: string): void {
+	if (MARKER) appendFileSync(MARKER, `${line}\n`);
+}
+
+export default function (pi: ExtensionAPI) {
+	if (OVERRIDING) {
+		pi.on("session_before_compact", async (event) => {
+			const { firstKeptEntryId, tokensBefore } = event.preparation;
+			mark(`before_compact reason=${event.reason} firstKept=${firstKeptEntryId}`);
+			return {
+				compaction: { summary: COMPACTION_SENTINEL, firstKeptEntryId, tokensBefore },
+			};
+		});
+
+		pi.on("session_before_tree", async (event) => {
+			const { userWantsSummary, entriesToSummarize } = event.preparation;
+			if (!userWantsSummary || entriesToSummarize.length === 0) return undefined;
+			mark(`before_tree entries=${entriesToSummarize.length}`);
+			return { summary: { summary: BRANCH_SENTINEL, details: {} } };
+		});
+	}
+
+	pi.on("session_compact", async (event) => {
+		mark(`compacted fromExtension=${event.fromExtension} summary=${JSON.stringify(event.compactionEntry.summary)}`);
+	});
+
+	pi.on("session_tree", async (event) => {
+		const summary = event.summaryEntry ? JSON.stringify(event.summaryEntry.summary) : "none";
+		mark(`navigated fromExtension=${event.fromExtension} summary=${summary}`);
+	});
+}

--- a/tests/int-takeover-optout.mjs
+++ b/tests/int-takeover-optout.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+// compaction.takeover / branchSummary.takeover, end to end against real pi.
+//
+// The bridge answers `session_before_compact` and `session_before_tree` for every
+// bridge model. Both flags let another extension own those summaries instead. What
+// needs proving is that standing down actually yields: the runner keeps the *last*
+// truthy handler result, and the bridge is loaded before the extension here, so a
+// takeover that still ran would produce a summary that gets overwritten — paying for
+// a discarded call — and a takeover that failed would return `cancel` and short-circuit
+// the emit before the other handler was ever reached.
+//
+// The two flags are not symmetrical, and the third case pins that down. Compaction
+// falls through safely with or without another handler. Branch summaries do not:
+// they run through the agent's stream function, so pi's summarization prompt reaches
+// the provider unrecorded and `resolveOrDerive` throws. Turning that flag off is only
+// sound when something else answers the event.
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { createRpcHarness } from "./lib/rpc-harness.mjs";
+import { BRANCH_SENTINEL, COMPACTION_SENTINEL } from "./fixtures/summary-override-extension.js";
+
+const TIMEOUT = 180_000;
+const BRIDGE_MODEL = "claude-bridge/claude-haiku-4-5";
+
+/** Agent dir carrying the bridge config under test. `getAgentDir()` honours
+ *  PI_CODING_AGENT_DIR, so this is how claude-bridge.json gets injected without
+ *  touching the developer's real one. keepRecentTokens is small so a handful of
+ *  short turns is enough for prepareCompaction to have something to cut. */
+function agentDir(name, bridgeConfig) {
+	const dir = mkdtempSync(join(tmpdir(), `takeover-${name}-`));
+	writeFileSync(join(dir, "settings.json"), JSON.stringify({ compaction: { keepRecentTokens: 50 } }));
+	writeFileSync(join(dir, "claude-bridge.json"), JSON.stringify(bridgeConfig));
+	return dir;
+}
+
+function markerPath(name) {
+	const path = join(mkdtempSync(join(tmpdir(), `takeover-marker-${name}-`)), "marker.log");
+	writeFileSync(path, "");
+	return path;
+}
+
+function cleanup(...paths) {
+	for (const path of paths) rmSync(path, { recursive: true, force: true });
+}
+
+function readMarker(path) {
+	try {
+		return readFileSync(path, "utf8");
+	} catch {
+		return "";
+	}
+}
+
+/** A slash command returns before navigation finishes and emits no agent_end, so
+ *  poll the artifact the work leaves behind rather than racing it. */
+async function waitFor(read, pattern, timeout = 90_000) {
+	const deadline = Date.now() + timeout;
+	let last = "";
+	while (Date.now() < deadline) {
+		last = read();
+		if (pattern.test(last)) return last;
+		await sleep(500);
+	}
+	return last;
+}
+
+describe("compaction.takeover: false hands compaction to another extension", () => {
+	const dir = agentDir("compact", { compaction: { takeover: false } });
+	const marker = markerPath("compact");
+	const harness = createRpcHarness({
+		name: "takeover-optout-compact",
+		args: ["-e", "./tests/fixtures/summary-override-extension.ts", "--model", BRIDGE_MODEL],
+		env: { PI_CODING_AGENT_DIR: dir, SUMMARY_OVERRIDE_MARKER: marker },
+		defaultTimeout: TIMEOUT,
+	});
+	const { startAndWait, stop, send, promptAndWait, DEBUG_LOG } = harness;
+
+	before(async () => { await startAndWait(); });
+	after(async () => {
+		await stop();
+		cleanup(dir, dirname(marker));
+	});
+
+	it("uses the extension's summary and never runs its own", { timeout: TIMEOUT }, async () => {
+		await promptAndWait("Reply with exactly the word ALPHA and nothing else.");
+		await promptAndWait("Reply with exactly the word BETA and nothing else.");
+
+		const result = await send({ type: "compact" }, TIMEOUT);
+
+		assert.equal(
+			result.summary,
+			COMPACTION_SENTINEL,
+			`compaction did not come from the extension: ${JSON.stringify(result.summary)?.slice(0, 300)}`,
+		);
+		assert.ok(result.firstKeptEntryId, "extension compaction lost firstKeptEntryId");
+
+		// Persisted, not merely returned from the handler.
+		const marks = await waitFor(() => readMarker(marker), /compacted /);
+		assert.match(marks, /before_compact reason=manual/, `the extension's handler never ran:\n${marks}`);
+		assert.match(
+			marks,
+			new RegExp(`compacted fromExtension=true summary="${COMPACTION_SENTINEL}"`),
+			`the extension's summary is not what landed in the session:\n${marks}`,
+		);
+
+		const log = readFileSync(DEBUG_LOG, "utf8");
+		assert.match(log, /session_before_compact: takeover disabled, deferring reason=manual/, "the bridge never logged standing down");
+		// The whole point of the flag: no discarded summarization.
+		assert.doesNotMatch(log, /session_before_compact: takeover complete/, "the bridge summarized anyway, and that work was thrown away");
+	});
+});
+
+describe("branchSummary.takeover: false hands branch summarization to another extension", () => {
+	const dir = agentDir("branch", { branchSummary: { takeover: false } });
+	const marker = markerPath("branch");
+	const harness = createRpcHarness({
+		name: "takeover-optout-branch",
+		args: [
+			"-e", "./tests/fixtures/tree-nav-extension.ts",
+			"-e", "./tests/fixtures/summary-override-extension.ts",
+			"--model", BRIDGE_MODEL,
+		],
+		env: { PI_CODING_AGENT_DIR: dir, SUMMARY_OVERRIDE_MARKER: marker },
+		defaultTimeout: TIMEOUT,
+	});
+	const { startAndWait, stop, send, promptAndWait, DEBUG_LOG } = harness;
+
+	before(async () => { await startAndWait(); });
+	after(async () => {
+		await stop();
+		cleanup(dir, dirname(marker));
+	});
+
+	it("uses the extension's summary and never runs its own", { timeout: TIMEOUT }, async () => {
+		// Two turns, so rewinding to the first leaves a branch worth summarizing.
+		await promptAndWait("Reply with exactly the word GAMMA and nothing else.");
+		await promptAndWait("Reply with exactly the word DELTA and nothing else.");
+
+		await send({ type: "prompt", message: "/rewind-summarize" });
+
+		const marks = await waitFor(() => readMarker(marker), /navigated /);
+		assert.match(marks, /before_tree entries=\d+/, `the extension's handler never ran:\n${marks}`);
+		assert.match(
+			marks,
+			new RegExp(`navigated fromExtension=true summary="${BRANCH_SENTINEL}"`),
+			`the extension's summary is not what landed on the branch entry:\n${marks}`,
+		);
+
+		const log = readFileSync(DEBUG_LOG, "utf8");
+		assert.match(log, /session_before_tree: takeover disabled, deferring/, "the bridge never logged standing down");
+		assert.doesNotMatch(log, /session_before_tree: takeover complete/, "the bridge summarized anyway, and that work was thrown away");
+	});
+});
+
+describe("branchSummary.takeover: false with nothing else answering", () => {
+	const dir = agentDir("orphan", { branchSummary: { takeover: false } });
+	const marker = markerPath("orphan");
+	const harness = createRpcHarness({
+		name: "takeover-optout-orphan",
+		args: [
+			"-e", "./tests/fixtures/tree-nav-extension.ts",
+			"-e", "./tests/fixtures/summary-override-extension.ts",
+			"--model", BRIDGE_MODEL,
+		],
+		// probe mode: the fixture records the outcome but answers neither event.
+		env: { PI_CODING_AGENT_DIR: dir, SUMMARY_OVERRIDE_MARKER: marker, SUMMARY_OVERRIDE_MODE: "probe" },
+		defaultTimeout: TIMEOUT,
+	});
+	const { startAndWait, stop, send, promptAndWait, DEBUG_LOG, RPC_LOG } = harness;
+
+	before(async () => { await startAndWait(); });
+	after(async () => {
+		await stop();
+		cleanup(dir, dirname(marker));
+	});
+
+	// Documents the asymmetry the README warns about, and the reason the flag is not
+	// simply "restore pi's native behaviour". Falling through reaches the provider
+	// with a system prompt no before_agent_start recorded, so `resolveOrDerive`
+	// refuses it rather than silently sending Claude Code no context files or skills.
+	// That refusal is deliberate (e1677f5); this pins the consequence.
+	it("refuses the summary, because falling through cannot work on a bridge model", { timeout: TIMEOUT }, async () => {
+		await promptAndWait("Reply with exactly the word EPSILON and nothing else.");
+		await promptAndWait("Reply with exactly the word ZETA and nothing else.");
+
+		// RPC_LOG is appended across runs, so slice from here.
+		const debugMark = statSync(DEBUG_LOG).size;
+		const rpcMark = statSync(RPC_LOG).size;
+		await send({ type: "prompt", message: "/rewind-summarize" });
+
+		const log = await waitFor(
+			() => readFileSync(DEBUG_LOG, "utf8").slice(debugMark),
+			/session_before_tree: takeover disabled, deferring/,
+		);
+		assert.match(log, /session_before_tree: takeover disabled, deferring/, `the bridge never stood down:\n${log.slice(-1500)}`);
+
+		// The refusal itself, rather than an empty marker that would also match a
+		// navigation that simply never started.
+		const rpc = await waitFor(
+			() => readFileSync(RPC_LOG, "utf8").slice(rpcMark),
+			/no capture for this \d+-char system prompt/,
+		);
+		assert.match(
+			rpc,
+			/no capture for this \d+-char system prompt/,
+			`expected the prompt resolver to refuse pi's branch-summary prompt:\n${rpc.slice(-1500)}`,
+		);
+
+		// And nothing was written to the branch either way.
+		const marks = readMarker(marker);
+		assert.doesNotMatch(
+			marks,
+			/navigated fromExtension=\w+ summary="[^"]/,
+			`a branch summary was produced with no handler to produce it:\n${marks}`,
+		);
+	});
+});

--- a/tests/unit-config.mjs
+++ b/tests/unit-config.mjs
@@ -45,6 +45,8 @@ describe("loadConfig", () => {
 				startupNoticeShown: undefined,
 				provider: { plan: "max" },
 				askClaude: { enabled: false },
+				compaction: {},
+				branchSummary: {},
 			});
 		} finally {
 			rmSync(cwd, { recursive: true, force: true });
@@ -71,7 +73,61 @@ describe("loadConfig", () => {
 				startupNoticeShown: undefined,
 				provider: { plan: "max", strictMcpConfig: true, autoMemoryEnabled: true },
 				askClaude: { enabled: false, defaultMode: "read" },
+				compaction: {},
+				branchSummary: {},
 			});
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	}));
+
+	it("merges takeover flags with project overriding global", () => withTempHome(() => {
+		const cwd = mkdtempSync(join(tmpdir(), "claude-bridge-project-"));
+		try {
+			const globalDir = getAgentDir();
+			const projectDir = join(cwd, CONFIG_DIR_NAME);
+			mkdirSync(globalDir, { recursive: true });
+			mkdirSync(projectDir, { recursive: true });
+			writeFileSync(join(globalDir, "claude-bridge.json"), JSON.stringify({
+				compaction: { takeover: true },
+				branchSummary: { takeover: true },
+			}));
+			writeFileSync(join(projectDir, "claude-bridge.json"), JSON.stringify({
+				compaction: { takeover: false },
+				branchSummary: { takeover: false },
+			}));
+
+			const config = loadConfig(cwd);
+			assert.equal(config.compaction?.takeover, false);
+			assert.equal(config.branchSummary?.takeover, false);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	}));
+
+	it("leaves the takeover flags independent of each other", () => withTempHome(() => {
+		const cwd = mkdtempSync(join(tmpdir(), "claude-bridge-project-"));
+		try {
+			const projectDir = join(cwd, CONFIG_DIR_NAME);
+			mkdirSync(projectDir, { recursive: true });
+			writeFileSync(join(projectDir, "claude-bridge.json"), JSON.stringify({
+				compaction: { takeover: false },
+			}));
+
+			const config = loadConfig(cwd);
+			assert.equal(config.compaction?.takeover, false);
+			assert.equal(config.branchSummary?.takeover, undefined);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	}));
+
+	it("leaves both takeover flags undefined when unconfigured, so takeover stays on", () => withTempHome(() => {
+		const cwd = mkdtempSync(join(tmpdir(), "claude-bridge-project-"));
+		try {
+			const config = loadConfig(cwd);
+			assert.equal(config.compaction?.takeover, undefined);
+			assert.equal(config.branchSummary?.takeover, undefined);
 		} finally {
 			rmSync(cwd, { recursive: true, force: true });
 		}
@@ -135,6 +191,8 @@ describe("loadConfig", () => {
 				startupNoticeShown: undefined,
 				provider: { plan: "max" },
 				askClaude: {},
+				compaction: {},
+				branchSummary: {},
 			});
 		} finally {
 			if (oldEnv === undefined) delete process.env.PI_CODING_AGENT_DIR;


### PR DESCRIPTION
Hello!

I wanted to use a custom compaction extension while using this bridge and noticed that it didn't seem to have much effect, or, if I installed the bridge before the compaction extension it would use more quota than I expected.

Got Opus to investigate a bit and find both the reason why bridge overrides compaction and also if it was safe to instead let it be handled by another extension (having the claude session re-created with the correct entries).

This is the resulting change, including new tests showing the 2 new config options. 