### PR TITLE
Add Oh My Pi compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,10 @@
     "extensions": [
       "./src/index.ts"
     ]
+  },
+  "omp": {
+    "extensions": [
+      "./src/index.ts"
+    ]
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,12 +1,14 @@
 // User-facing extension config. Loaded once at extension registration from
-// the global agent dir (getAgentDir(), e.g. ~/.pi/agent/claude-bridge.json)
-// and the project Pi config directory, project overriding global. Missing or
-// unparseable files are ignored (error to console.error, empty object
-// returned) so the extension always starts.
+// the active host's global agent dir. Pi also supports project overrides.
+// OMP project overrides stay disabled until its extension API exposes the
+// project-trust decision, so an untrusted repository cannot replace the
+// Claude executable or enable native Claude hooks.
 
-import { CONFIG_DIR_NAME, getAgentDir } from "@earendil-works/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
+
+export type ClaudeSettingSource = "user" | "project" | "local";
 
 export interface Config {
 	/** Date (YYYY-MM-DD) the one-time startup notice was shown. Written by the extension, not the user. */
@@ -32,6 +34,7 @@ export interface Config {
 		// Anthropic billing). Enables Sonnet 4.6 [1m] on every plan and Opus 4.6
 		// [1m] on Pro.
 		longContextExtraUsage?: boolean;
+		settingSources?: ClaudeSettingSource[];
 	};
 }
 
@@ -51,6 +54,17 @@ export function claudeCodeSettings(provider: Config["provider"] = {}): { autoMem
 
 export function globalConfigPath(): string {
 	return join(getAgentDir(), "claude-bridge.json");
+}
+
+export function isOmpAgentDir(agentDir: string): boolean {
+	return agentDir.split(/[\\/]/).includes(".omp");
+}
+
+export function claudeCodeSettingSources(
+	provider: Config["provider"] = {},
+	agentDir = getAgentDir(),
+): ClaudeSettingSource[] | undefined {
+	return provider.settingSources ?? (isOmpAgentDir(agentDir) ? [] : undefined);
 }
 
 /** Record today's date in the global config so the startup notice shows once, preserving every
@@ -79,8 +93,11 @@ export function markStartupNoticeShown(): string {
 }
 
 export function loadConfig(cwd: string): Config {
-	const global = tryParseJson(globalConfigPath());
-	const project = tryParseJson(join(cwd, CONFIG_DIR_NAME, "claude-bridge.json"));
+	const agentDir = getAgentDir();
+	const global = tryParseJson(join(agentDir, "claude-bridge.json"));
+	const project = isOmpAgentDir(agentDir)
+		? {}
+		: tryParseJson(join(cwd, ".pi", "claude-bridge.json"));
 	return {
 		startupNoticeShown: project.startupNoticeShown ?? global.startupNoticeShown,
 		askClaude: { ...global.askClaude, ...project.askClaude },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { calculateCost, StringEnum, type AssistantMessage, type AssistantMessageEventStream, type Context, type ImageContent, type Model, type SimpleStreamOptions, type TextContent, type Tool, type UserMessage } from "@earendil-works/pi-ai";
 import * as piAi from "@earendil-works/pi-ai";
 import { getModels } from "@earendil-works/pi-ai/compat";
-import { buildSessionContext, compact, generateBranchSummary, keyHint, type BranchSummaryResult, type CompactionEntry, type ExtensionAPI, type ExtensionContext, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import * as codingAgent from "@earendil-works/pi-coding-agent";
+import type { BranchSummaryResult, CompactionEntry, ExtensionAPI, ExtensionContext, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import { query, type EffortLevel, type SDKMessage, type SettingSource } from "@anthropic-ai/claude-agent-sdk";
 import type { Base64ImageSource, ContentBlockParam } from "@anthropic-ai/sdk/resources";
 import { Type } from "typebox";
@@ -17,15 +18,56 @@ import { verifyWrittenSession as _verifyWrittenSession } from "./session-verify.
 import { extractAllToolResults as _extractAllToolResults, type McpResult } from "./extract-tool-results.js";
 import { QueryContext, ctx } from "./query-state.js";
 import { makePromptStream, userMessage, type PromptStream } from "./prompt-stream.js";
-import { claudeCodeSettings, loadConfig, markStartupNoticeShown, type Config } from "./config.js";
+import {
+	claudeCodeSettingSources,
+	claudeCodeSettings,
+	loadConfig,
+	markStartupNoticeShown,
+	type Config,
+} from "./config.js";
 import {
 	collectPromptSkills,
 	projectPromptCapture,
 	PromptCaptures,
+	type PromptCaptureInput,
 } from "./prompt-capture.js";
 import { collectCarriedAttachments, placeCarriedAttachments, type CarriedAttachment } from "./attachments.js";
 import { createToolServer } from "./mcp-server.js";
 import { buildActionSummary, type ToolCallState } from "./askclaude-ui.js";
+
+// OMP loads legacy Pi extensions through a package compatibility layer, but a
+// few former top-level helpers no longer exist. Read them dynamically so the
+// provider can load on both hosts and only installs lifecycle takeovers the
+// active host supports.
+type HostSessionManager = {
+	buildSessionContext?: () => { messages: Context["messages"] };
+	getBranch: () => Parameters<typeof codingAgent.buildSessionContext>[0];
+};
+type HostCodingAgent = {
+	compact?: typeof codingAgent.compact;
+	generateBranchSummary?: typeof codingAgent.generateBranchSummary;
+	buildSessionContext?: (entries: Parameters<typeof codingAgent.buildSessionContext>[0]) => { messages: Context["messages"] };
+	keyHint?: (action: string, fallback: string) => string;
+};
+
+const hostCodingAgent = codingAgent as unknown as HostCodingAgent;
+const hostCompact = hostCodingAgent.compact;
+const hostGenerateBranchSummary = hostCodingAgent.generateBranchSummary;
+
+function normalizeSystemPrompt(value: string | readonly string[] | undefined): string | undefined {
+	if (typeof value === "string") return value || undefined;
+	return value?.filter(Boolean).join("\n\n") || undefined;
+}
+
+function buildHostSessionContext(sessionManager: HostSessionManager): Context["messages"] {
+	if (sessionManager.buildSessionContext) return sessionManager.buildSessionContext().messages;
+	if (!hostCodingAgent.buildSessionContext) throw new Error("claude-bridge: host cannot build session context");
+	return hostCodingAgent.buildSessionContext(sessionManager.getBranch()).messages;
+}
+
+function hostKeyHint(action: string, fallback: string): string {
+	return hostCodingAgent.keyHint?.(action, fallback) ?? fallback;
+}
 
 // Compat (#2): use factory if available (pi-ai ≥0.66), else fall back to constructor (gsd-pi etc.)
 const _piAi = piAi as any;
@@ -472,7 +514,7 @@ async function runIsolatedSummary(
 				settingSources: [] as SettingSource[],
 				skills: [],
 				persistSession: false,
-				systemPrompt: context.systemPrompt,
+				systemPrompt: normalizeSystemPrompt(context.systemPrompt),
 				model: cliModel,
 				maxTurns: 1,
 				...(claudeExecutable ? { pathToClaudeCodeExecutable: claudeExecutable } : {}),
@@ -1498,7 +1540,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// `--no-skills` reach Claude Code by leaving nothing to forward. A sub-agent's
 	// custom override embeds its parent's assembled Pi prompt; recursive projection
 	// replaces that exact inherited prompt with its already-safe portable parts.
-	const promptCapture = promptCaptures.resolveOrDerive(context.systemPrompt);
+	const promptCapture = promptCaptures.resolveOrDerive(normalizeSystemPrompt(context.systemPrompt));
 	const systemPromptAppend = promptCapture
 		? projectPromptCapture(promptCapture, {
 			skillReadTool: mcpTools.some((tool) => tool.name === "read") ? "mcp" : "none",
@@ -1553,12 +1595,12 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	queryCtx.promptStream = promptStream;
 	const mcpServers = buildMcpServers(mcpTools, queryCtx);
 
-	// MCP auto-loading suppression: CC reads MCP servers from ~/.claude.json (top-level
-	// + per-project) and .mcp.json. Since pi executes tools (not CC), those are pure
-	// token overhead. --strict-mcp-config tells the binary to use ONLY mcpServers passed
-	// programmatically and ignore filesystem MCP entries — applied unconditionally because
-	// settingSources is left at CC's default, which loads all sources.
+	// MCP auto-loading suppression: Claude Code can read MCP servers from its
+	// settings estate. Pi keeps its historical setting-source behavior. OMP
+	// disables all Claude setting sources by default, so repository hooks and
+	// user plugins cannot enter the bridge subprocess.
 	const strictMcpConfigEnabled = providerSettings.strictMcpConfig !== false;
+	const settingSources = claudeCodeSettingSources(providerSettings);
 	const claudeExecutable = providerSettings.pathToClaudeCodeExecutable;
 
 	// Prefer the model's own thinkingLevelMap when present (pi-ai 0.72+ ships
@@ -1593,6 +1635,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		permissionMode: "bypassPermissions",
 		includePartialMessages: true,
 		settings: { ...claudeCodeSettings(providerSettings), claudeMdExcludes: CLAUDE_MD_EXCLUDES },
+		...(settingSources ? { settingSources } : {}),
 		systemPrompt: {
 			type: "preset", preset: "claude_code",
 			append: systemPromptAppend ? systemPromptAppend : undefined,
@@ -1790,6 +1833,7 @@ async function promptAndWait(
 		? REASONING_TO_EFFORT[options.thinking] : undefined;
 
 	const claudeExecutable = providerSettings.pathToClaudeCodeExecutable;
+	const settingSources = claudeCodeSettingSources(providerSettings) ?? ["user", "project"] as SettingSource[];
 
 	const extraArgs: Record<string, string | null> = {
 		"strict-mcp-config": null,
@@ -1821,7 +1865,7 @@ async function promptAndWait(
 			// without the tool and permission guidance the bridge relies on everywhere else.
 			// Whether pi has skills to append is unrelated to whether the child needs that.
 			systemPrompt: { type: "preset", preset: "claude_code", append: skillsBlock },
-			settingSources: ["user", "project"] as SettingSource[],
+			settingSources,
 			extraArgs,
 			...(resumeSessionId ? { resume: resumeSessionId } : {}),
 			...(options?.isolated ? { persistSession: false } : {}),
@@ -1967,10 +2011,26 @@ export default function (pi: ExtensionAPI) {
 	// Code's preset carries its own tool and permission guidance that the bridge
 	// still depends on, so both flags are forwarded as an append.
 	pi.on("before_agent_start", (event) => {
-		const options = event.systemPromptOptions;
+		type PortablePromptEvent = {
+			systemPrompt: string | readonly string[];
+			systemPromptOptions?: {
+				selectedTools?: string[];
+				customPrompt?: string;
+				appendSystemPrompt?: string;
+				contextFiles?: PromptCaptureInput["contextFiles"];
+				skills?: PromptCaptureInput["skills"];
+			};
+		};
+		const portableEvent = event as unknown as PortablePromptEvent;
+		const systemPrompt = normalizeSystemPrompt(portableEvent.systemPrompt);
+		if (!systemPrompt) return;
+
+		const options = portableEvent.systemPromptOptions;
 		const hasRead = !options?.selectedTools || options.selectedTools.includes("read");
-		promptCaptures.record(event.systemPrompt, {
-			custom: options?.customPrompt,
+		promptCaptures.record(systemPrompt, {
+			// OMP provides the assembled prompt as ordered strings rather than
+			// Pi's source metadata. Preserve that complete prompt as custom text.
+			custom: options ? options.customPrompt : systemPrompt,
 			append: options?.appendSystemPrompt,
 			contextFiles: options?.contextFiles ?? [],
 			skills: hasRead ? options?.skills ?? [] : [],
@@ -1983,6 +2043,10 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_before_compact", async (event, ctx) => {
 		if (ctx.model?.baseUrl !== "claude-bridge") return undefined;
+		if (!hostCompact) {
+			debug("session_before_compact: host does not export compaction takeover API");
+			return undefined;
+		}
 		debug(
 			`session_before_compact: takeover reason=${event.reason} willRetry=${event.willRetry} ` +
 			`isSplitTurn=${event.preparation.isSplitTurn} messages=${event.preparation.messagesToSummarize.length} ` +
@@ -1990,7 +2054,7 @@ export default function (pi: ExtensionAPI) {
 		);
 		try {
 			reinjectPriorCompactionFileOps(event.branchEntries, event.preparation);
-			const compaction = await compact(
+			const compaction = await hostCompact(
 				event.preparation,
 				ctx.model,
 				undefined,
@@ -2040,11 +2104,15 @@ export default function (pi: ExtensionAPI) {
 	// Claude Code subprocess, never touching the live session or the resolver.
 	pi.on("session_before_tree", async (event, ctx) => {
 		if (ctx.model?.baseUrl !== "claude-bridge") return undefined;
+		if (!hostGenerateBranchSummary) {
+			debug("session_before_tree: host does not export branch-summary takeover API");
+			return undefined;
+		}
 		const { entriesToSummarize, userWantsSummary, customInstructions, replaceInstructions } = event.preparation;
 		if (!userWantsSummary || entriesToSummarize.length === 0) return undefined;
 		debug(`session_before_tree: takeover entries=${entriesToSummarize.length} target=${event.preparation.targetId.slice(0, 8)}`);
 		try {
-			const result = await generateBranchSummary(entriesToSummarize, {
+			const result = await hostGenerateBranchSummary(entriesToSummarize, {
 				model: ctx.model,
 				signal: event.signal,
 				customInstructions,
@@ -2153,7 +2221,7 @@ export default function (pi: ExtensionAPI) {
 					const truncated = body.length > PREVIEW_MAX_CHARS ? body.substring(0, PREVIEW_MAX_CHARS) : body;
 					const lines = truncated.split("\n").slice(0, PREVIEW_MAX_LINES);
 					if (lines.length) text += `\n${theme.fg("toolOutput", lines.join("\n"))}`;
-					if (body.length > PREVIEW_MAX_CHARS || body.split("\n").length > PREVIEW_MAX_LINES) text += `\n${theme.fg("dim", `… (${keyHint("app.tools.expand", "to expand")})`)}`;
+					if (body.length > PREVIEW_MAX_CHARS || body.split("\n").length > PREVIEW_MAX_LINES) text += `\n${theme.fg("dim", `… (${hostKeyHint("app.tools.expand", "to expand")})`)}`;
 
 				}
 
@@ -2191,7 +2259,7 @@ export default function (pi: ExtensionAPI) {
 						model: params.model,
 						thinking: params.thinking,
 						isolated,
-						context: isolated ? undefined : buildSessionContext(ctx.sessionManager.getBranch()).messages as Context["messages"],
+						context: isolated ? undefined : buildHostSessionContext(ctx.sessionManager),
 					});
 					clearInterval(progressInterval);
 					onUpdate?.({ content: [{ type: "text", text: "" }], details: {} });

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -1,9 +1,48 @@
-import { formatSkillsForPrompt, type Skill } from "@earendil-works/pi-coding-agent";
+import type { Skill } from "@earendil-works/pi-coding-agent";
 
 export const MCP_SERVER_NAME = "custom-tools";
 export const MCP_TOOL_PREFIX = `mcp__${MCP_SERVER_NAME}__`;
 
 export type SkillReadTool = "mcp" | "native" | "none";
+
+function escapeXml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&apos;");
+}
+
+/** Local copy of Pi's small skill-list renderer.
+ *
+ * Keeping this here avoids depending on a host-only export: OMP's legacy Pi
+ * loader supplies the Skill shape, but OMP no longer exports
+ * formatSkillsForPrompt. */
+function formatSkillsForPrompt(skills: Skill[]): string {
+	const visibleSkills = skills.filter((skill) => {
+		const candidate = skill as Skill & { hide?: boolean; disableModelInvocation?: boolean };
+		return !candidate.hide && !candidate.disableModelInvocation;
+	});
+	if (visibleSkills.length === 0) return "";
+
+	const lines = [
+		"The following skills provide specialized instructions for specific tasks.",
+		"Use the read tool to load a skill's file when the task matches its description.",
+		"When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
+		"",
+		"<available_skills>",
+	];
+	for (const skill of visibleSkills) {
+		lines.push("  <skill>");
+		lines.push(`    <name>${escapeXml(skill.name)}</name>`);
+		lines.push(`    <description>${escapeXml(skill.description)}</description>`);
+		lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
+		lines.push("  </skill>");
+	}
+	lines.push("</available_skills>");
+	return lines.join("\n");
+}
 
 export function renderSkillsBlock(skills: Skill[], readTool: SkillReadTool): string | undefined {
 	if (readTool === "none" || skills.length === 0) return undefined;

--- a/tests/unit-config.mjs
+++ b/tests/unit-config.mjs
@@ -5,7 +5,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readFileSync } from "node:fs";
 import { CONFIG_DIR_NAME, getAgentDir } from "@earendil-works/pi-coding-agent";
-import { claudeCodeSettings, loadConfig, markStartupNoticeShown } from "../src/config.js";
+import {
+	claudeCodeSettingSources,
+	claudeCodeSettings,
+	isOmpAgentDir,
+	loadConfig,
+	markStartupNoticeShown,
+} from "../src/config.js";
 
 function withTempHome(fn) {
 	const oldHome = process.env.HOME;
@@ -27,6 +33,25 @@ describe("claudeCodeSettings", () => {
 
 	it("allows auto-memory to be enabled", () => {
 		assert.deepEqual(claudeCodeSettings({ autoMemoryEnabled: true }), { autoMemoryEnabled: true });
+	});
+});
+
+describe("OMP isolation", () => {
+	it("recognizes an OMP agent directory", () => {
+		assert.equal(isOmpAgentDir("/Users/example/.omp/agent"), true);
+		assert.equal(isOmpAgentDir("/Users/example/.pi/agent"), false);
+	});
+
+	it("disables Claude settings sources by default", () => {
+		assert.deepEqual(claudeCodeSettingSources({}, "/Users/example/.omp/agent"), []);
+		assert.equal(claudeCodeSettingSources({}, "/Users/example/.pi/agent"), undefined);
+	});
+
+	it("allows explicit Claude settings sources", () => {
+		assert.deepEqual(
+			claudeCodeSettingSources({ settingSources: ["user"] }, "/Users/example/.omp/agent"),
+			["user"],
+		);
 	});
 });
 
@@ -141,6 +166,34 @@ describe("loadConfig", () => {
 			else process.env.PI_CODING_AGENT_DIR = oldEnv;
 			rmSync(agentDir, { recursive: true, force: true });
 			rmSync(cwd, { recursive: true, force: true });
+		}
+	}));
+
+	it("ignores project config when the agent directory belongs to OMP", () => withTempHome(() => {
+		const root = mkdtempSync(join(tmpdir(), "claude-bridge-omp-"));
+		const agentDir = join(root, ".omp", "agent");
+		const cwd = join(root, "project");
+		const oldEnv = process.env.PI_CODING_AGENT_DIR;
+		try {
+			mkdirSync(agentDir, { recursive: true });
+			mkdirSync(join(cwd, ".pi"), { recursive: true });
+			writeFileSync(join(agentDir, "claude-bridge.json"), JSON.stringify({
+				provider: { plan: "pro" },
+			}));
+			writeFileSync(join(cwd, ".pi", "claude-bridge.json"), JSON.stringify({
+				provider: { plan: "max", pathToClaudeCodeExecutable: "/tmp/untrusted-claude" },
+			}));
+			process.env.PI_CODING_AGENT_DIR = agentDir;
+
+			assert.deepEqual(loadConfig(cwd), {
+				startupNoticeShown: undefined,
+				provider: { plan: "pro" },
+				askClaude: {},
+			});
+		} finally {
+			if (oldEnv === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = oldEnv;
+			rmSync(root, { recursive: true, force: true });
 		}
 	}));
 });


### PR DESCRIPTION
## Summary

- add an `omp` extension manifest while keeping the existing Pi entry point
- adapt host APIs, system prompt arrays, session context, and skill rendering for OMP 17
- isolate OMP runs from repository bridge configuration and Claude settings sources by default
- retain legacy Pi configuration and lifecycle behavior

## Verification

- `npm run typecheck`
- `npm run test:unit`, 189 tests passed
- `omp models claude-bridge`, 8 models registered
- installed provider smoke test returned `OMP_INSTALLED_OK`
- Claude debug log showed 0 enabled plugins and 0 registered hooks

OMP does not export Pi's legacy compaction and branch-summary helpers. The bridge registers those lifecycle handlers, but returns control to OMP's native lifecycle when the helper is unavailable.