### PR TITLE
fix: keep rebuilt sessions aligned with pi state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- **Fix: keep rebuilt Claude sessions aligned with Pi's current history and model (issues #30, #42, #55, #62)** — shrinking or compacting history now rebuilds instead of silently starting without context, completion preserves pending rebuilds, cursors track current history, and model changes invalidate the session.
+
 - **Fix: better isolate AskClaude tool (issue #59)** — AskClaude children no longer inherit the user's `~/.claude` `CLAUDE.md` files or skill listing, and now always get Claude Code's system prompt preset instead of only when pi-side skills exist. Thanks @JAtkinsonKO.
 - **Fix: Bogus debug message about "record count mismatch" after switching providers** — the post-rebuild integrity check did not take `@file` expansion into account when switching providers.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,6 +248,20 @@ function readCarriedAttachments(sessionId: string, cwd: string): CarriedAttachme
 }
 
 let sharedSession: SessionState | null = null;
+function markRebuild(reason: string): void {
+	if (!sharedSession) return;
+	debug(`${reason}: marking needsRebuild on session ${sharedSession.sessionId.slice(0, 8)}`);
+	sharedSession = { ...sharedSession, needsRebuild: true };
+}
+
+function recordQueryCompletion(sessionId: string, observedCursor: number, cwd: string, isReentrant: boolean): void {
+	const cursor = isReentrant ? Math.max(observedCursor, sharedSession?.cursor ?? 0) : observedCursor;
+	debug(`provider: query done, session=${sessionId.slice(0, 8)}, cursor=${cursor}`);
+	// A compaction can finish while a query is completing. Preserve its
+	// invalidation so the next turn cannot resume the pre-compaction session.
+	sharedSession = { ...sharedSession, sessionId, cursor, cwd };
+}
+
 
 // Convert pi messages to Anthropic API format for session import.
 // Lossy: only text, thinking and toolCall blocks survive, and thinking only when
@@ -636,6 +650,7 @@ function syncSharedSession(
 	cwd: string,
 	customToolNameToSdk?: Map<string, string>,
 	modelId?: string,
+	options?: { reentrant?: boolean },
 ): SyncResult {
 	const priorMessages = messages.slice(0, turnStart(messages)); // everything before the current user turn
 
@@ -659,24 +674,17 @@ function syncSharedSession(
 			return { sessionId: sharedSession.sessionId };
 		}
 	}
-	// This is what keeps a reentrant subagent from taking over the parent's
-	// session: a subagent starts with priors of its own, shorter than the parent's
-	// cursor, so it lands here, gets a fresh session, and the ephemeral session it
-	// captures is deleted once its query completes (see preserveSharedSession in
-	// the completion handler). Remove this branch and a subagent resumes — then
-	// overwrites — the parent's session. The non-isolated AskClaude path reaches it
-	// the same way.
-	//
-	// It is NOT, despite an earlier comment here, the isolated compact-summary
-	// path: runIsolatedSummary never calls syncSharedSession at all.
-	//
-	// Only reachable when needsRebuild is false — user-facing history rewrites
-	// (/compact, session_tree, /new, fork) always set needsRebuild or clear
-	// sharedSession before the next syncSharedSession call.
+	// A shorter context means one of two things. Nested queries must start a
+	// disposable session so they cannot overwrite the parent. Top-level turns
+	// reached here because Pi rewrote its history; rebuild from that history
+	// rather than silently answering without conversation context (#30, #55).
 	if (sharedSession && !sharedSession.needsRebuild && priorMessages.length < sharedSession.cursor) {
-		debug(`Case 1 synthetic: clean start for shorter context, preserving shared session ${sharedSession.sessionId.slice(0, 8)}, cursor=${sharedSession.cursor}`);
-		debug(`syncResult: path=clean-start preserve-shared sessionId=${sharedSession.sessionId} cursor=${sharedSession.cursor}`);
-		return { sessionId: null, preserveSharedSession: true };
+		if (options?.reentrant) {
+			debug(`Case 1 synthetic: clean start for shorter context, preserving shared session ${sharedSession.sessionId.slice(0, 8)}, cursor=${sharedSession.cursor}`);
+			debug(`syncResult: path=clean-start preserve-shared sessionId=${sharedSession.sessionId} cursor=${sharedSession.cursor}`);
+			return { sessionId: null, preserveSharedSession: true };
+		}
+		debug(`Case 3→4: Pi history compressed ${sharedSession.cursor}→${priorMessages.length} msgs on a top-level turn, forcing rebuild`);
 	}
 
 	// REBUILD path
@@ -738,6 +746,8 @@ export const __test = {
 		piUI = ui;
 	},
 	syncSharedSession,
+	markRebuild,
+	recordQueryCompletion,
 	extractUserPromptBlocks,
 	consumeQuery,
 	finalizeCurrentStream,
@@ -1521,7 +1531,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// cliModel is the actual id sent to Claude Code (may carry [1m]); model.id is the
 	// pi-registered id. Log cliModel so debug lines reflect what CC actually received.
 	const cliModel = claudeCodeModelId(model, longContextSettings);
-	const syncResult = syncSharedSession(context.messages, cwd, customToolNameToSdk, cliModel);
+	const syncResult = syncSharedSession(context.messages, cwd, customToolNameToSdk, cliModel, { reentrant: isReentrant });
 	const { sessionId: resumeSessionId } = syncResult;
 	const promptBlocks = extractUserPromptBlocks(context.messages);
 	let promptText = extractUserPrompt(context.messages) ?? "";
@@ -1666,9 +1676,8 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 				}
 				debug(`provider: query done, ignoring captured session ${capturedSessionId?.slice(0, 8) ?? "none"} to preserve shared session`);
 			} else if (sessionId) {
-				const cursor = Math.max(context.messages.length, queryCtx.latestCursor, sharedSession?.cursor ?? 0);
-				debug(`provider: query done, session=${sessionId.slice(0, 8)}, cursor=${cursor}`);
-				sharedSession = { sessionId, cursor, cwd };
+				const observedCursor = Math.max(context.messages.length, queryCtx.latestCursor);
+				recordQueryCompletion(sessionId, observedCursor, cwd, isReentrant);
 			}
 
 			if (!isReentrant && queryCtx.activeQuery === sdkQuery) {
@@ -1762,7 +1771,7 @@ async function promptAndWait(
 		} else {
 			// No provider session yet — create one from pi's context
 			const contextWithPrompt = [...options.context, { role: "user" as const, content: prompt, timestamp: Date.now() }];
-			const sync = syncSharedSession(contextWithPrompt as Context["messages"], cwd, undefined, cliModel);
+			const sync = syncSharedSession(contextWithPrompt as Context["messages"], cwd, undefined, cliModel, { reentrant: true });
 			resumeSessionId = sync.sessionId;
 		}
 	}
@@ -2014,21 +2023,9 @@ export default function (pi: ExtensionAPI) {
 		}
 	});
 
-	// pi /compact and session-tree navigation (rewind / fork-at-point /
-	// branch switch) both mutate pi's messages array out from under the
-	// bridge. syncSharedSession's REUSE check would otherwise see
-	// slice(cursor) === [] (or skip entries) and keep --resume'ing a CC
-	// session that no longer matches pi's history. /compact in particular
-	// triggers CC's autocompact-thrashing guard (issue #8). Force the next
-	// call down the REBUILD path so CC sees the current history.
-	const markRebuild = (event: string) => {
-		if (sharedSession) {
-			debug(`${event}: marking needsRebuild on session ${sharedSession.sessionId.slice(0, 8)}`);
-			sharedSession = { ...sharedSession, needsRebuild: true };
-		}
-	};
 	pi.on("session_compact", (event) => markRebuild(`session_compact:${event.reason}:willRetry=${event.willRetry}`));
 	pi.on("session_tree", () => markRebuild("session_tree"));
+	pi.on("model_select", (event) => markRebuild(`model_select:${event.previousModel?.id ?? "?"}->${event.model?.id ?? "?"}`));
 
 	// Branch summarization — rewind or fork-at-point with "summarize" — is the other
 	// place pi asks the model for a summary, and unlike compaction it runs through

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,18 +248,18 @@ function readCarriedAttachments(sessionId: string, cwd: string): CarriedAttachme
 }
 
 let sharedSession: SessionState | null = null;
+// Pi history mutation invalidates the cached CC session; REBUILD prevents stale
+// reuse and CC's issue #8 autocompact guard.
 function markRebuild(reason: string): void {
 	if (!sharedSession) return;
 	debug(`${reason}: marking needsRebuild on session ${sharedSession.sessionId.slice(0, 8)}`);
 	sharedSession = { ...sharedSession, needsRebuild: true };
 }
 
-function recordQueryCompletion(sessionId: string, observedCursor: number, cwd: string, isReentrant: boolean): void {
-	const cursor = isReentrant ? Math.max(observedCursor, sharedSession?.cursor ?? 0) : observedCursor;
-	debug(`provider: query done, session=${sessionId.slice(0, 8)}, cursor=${cursor}`);
-	// A compaction can finish while a query is completing. Preserve its
-	// invalidation so the next turn cannot resume the pre-compaction session.
-	sharedSession = { ...sharedSession, sessionId, cursor, cwd };
+function recordQueryCompletion(sessionId: string, observedCursor: number, cwd: string): void {
+	debug(`provider: query done, session=${sessionId.slice(0, 8)}, cursor=${observedCursor}`);
+	// Preserve invalidation recorded while the query was running.
+	sharedSession = { ...sharedSession, sessionId, cursor: observedCursor, cwd };
 }
 
 
@@ -653,6 +653,17 @@ function syncSharedSession(
 	options?: { reentrant?: boolean },
 ): SyncResult {
 	const priorMessages = messages.slice(0, turnStart(messages)); // everything before the current user turn
+	if (options?.reentrant) {
+		if (sharedSession) {
+			debug(`Case 1 synthetic: clean start, preserving shared session ${sharedSession.sessionId.slice(0, 8)}, cursor=${sharedSession.cursor}`);
+			debug(`syncResult: path=clean-start preserve-shared sessionId=${sharedSession.sessionId} cursor=${sharedSession.cursor}`);
+		} else {
+			debug("Case 1 synthetic: clean start without shared session");
+		}
+		// Completion deletes every reentrant session, even when no parent exists.
+		return { sessionId: null, preserveSharedSession: true };
+	}
+
 
 	// REUSE path
 	//
@@ -674,16 +685,8 @@ function syncSharedSession(
 			return { sessionId: sharedSession.sessionId };
 		}
 	}
-	// A shorter context means one of two things. Nested queries must start a
-	// disposable session so they cannot overwrite the parent. Top-level turns
-	// reached here because Pi rewrote its history; rebuild from that history
-	// rather than silently answering without conversation context (#30, #55).
+	// A shorter top-level context was rewritten by Pi, so rebuild from it.
 	if (sharedSession && !sharedSession.needsRebuild && priorMessages.length < sharedSession.cursor) {
-		if (options?.reentrant) {
-			debug(`Case 1 synthetic: clean start for shorter context, preserving shared session ${sharedSession.sessionId.slice(0, 8)}, cursor=${sharedSession.cursor}`);
-			debug(`syncResult: path=clean-start preserve-shared sessionId=${sharedSession.sessionId} cursor=${sharedSession.cursor}`);
-			return { sessionId: null, preserveSharedSession: true };
-		}
 		debug(`Case 3→4: Pi history compressed ${sharedSession.cursor}→${priorMessages.length} msgs on a top-level turn, forcing rebuild`);
 	}
 
@@ -1650,11 +1653,9 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	consumeQuery(sdkQuery, customToolNameToPi, model, () => wasAborted, queryCtx)
 		.then(async ({ capturedSessionId }) => {
 			debug(`provider: consumeQuery completed, stopReason=${queryCtx.turnOutput?.stopReason}, error=${queryCtx.turnOutput?.errorMessage}, aborted=${wasAborted}`);
-
-			// --- Abort detection in normal completion path ---
 			if (wasAborted || options?.signal?.aborted) {
-				if (sharedSession) sharedSession = { ...sharedSession, needsRebuild: true, forceRotate: true };
-				debug(`provider: abort detected, marked sharedSession needsRebuild + forceRotate`);
+				if (!isReentrant && sharedSession) sharedSession = { ...sharedSession, needsRebuild: true, forceRotate: true };
+				debug(`provider: abort detected${isReentrant ? " in disposable child" : ", marked sharedSession needsRebuild + forceRotate"}`);
 				if (queryCtx.turnOutput) {
 					queryCtx.turnOutput.stopReason = "aborted";
 					queryCtx.turnOutput.errorMessage = "Operation aborted";
@@ -1677,7 +1678,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 				debug(`provider: query done, ignoring captured session ${capturedSessionId?.slice(0, 8) ?? "none"} to preserve shared session`);
 			} else if (sessionId) {
 				const observedCursor = Math.max(context.messages.length, queryCtx.latestCursor);
-				recordQueryCompletion(sessionId, observedCursor, cwd, isReentrant);
+				recordQueryCompletion(sessionId, observedCursor, cwd);
 			}
 
 			if (!isReentrant && queryCtx.activeQuery === sdkQuery) {
@@ -1688,10 +1689,12 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		})
 		.catch((error) => {
 			debug(`provider: query error, model=${cliModel}, aborted=${Boolean(options?.signal?.aborted)}, error=`, error);
-			if ((wasAborted || options?.signal?.aborted) && sharedSession) {
-				sharedSession = { ...sharedSession, needsRebuild: true, forceRotate: true };
-			} else {
-				sharedSession = null;
+			if (!isReentrant) {
+				if ((wasAborted || options?.signal?.aborted) && sharedSession) {
+					sharedSession = { ...sharedSession, needsRebuild: true, forceRotate: true };
+				} else {
+					sharedSession = null;
+				}
 			}
 			promptStream.fail(error instanceof Error ? error : new Error(String(error)));
 			if (queryCtx.turnOutput) {
@@ -1757,22 +1760,26 @@ async function promptAndWait(
 	const model = resolveModel(requestedModel);
 	const modelId = model?.id ?? requestedModel;
 	const cliModel = model ? claudeCodeModelId(model, longContextSettings) : modelId;
-
-	// Session resume for shared mode — reuse provider's session if it exists,
-	// otherwise create one from pi's context.
-	// Note: doesn't update sharedSession.cursor after completion, so the next
-	// provider call will see missed messages and trigger a Case 4 rebuild.
+	// Shared mode resumes only a valid provider session. A pending rebuild must
+	// not rewrite that parent for AskClaude.
 	let resumeSessionId: string | null = null;
+	let ephemeralSessionId: string | null = null;
 	if (!options?.isolated && options?.context?.length) {
-		if (sharedSession) {
-			// Provider already has a session — just resume from it
-			// Any missed messages from other providers were already handled by the provider's Case 4
+		if (sharedSession && !sharedSession.needsRebuild) {
 			resumeSessionId = sharedSession.sessionId;
+			// Doesn't advance sharedSession.cursor: the next provider turn sees this
+			// exchange as missed messages and rebuilds (Case 4).
 		} else {
-			// No provider session yet — create one from pi's context
-			const contextWithPrompt = [...options.context, { role: "user" as const, content: prompt, timestamp: Date.now() }];
-			const sync = syncSharedSession(contextWithPrompt as Context["messages"], cwd, undefined, cliModel, { reentrant: true });
-			resumeSessionId = sync.sessionId;
+			const session = createSession({
+				projectPath: cwd,
+				claudeDir: process.env.CLAUDE_CONFIG_DIR,
+				...(cliModel ? { model: cliModel } : {}),
+			});
+			convertAndImportMessages(session, options.context);
+			session.save();
+			verifyWrittenSession(session.jsonlPath, session.sessionId, session.records.length, cwd);
+			ephemeralSessionId = resumeSessionId = session.sessionId;
+			debug(`askClaude: created ephemeral session ${session.sessionId.slice(0, 8)} without a reusable shared session`);
 		}
 	}
 
@@ -1919,6 +1926,8 @@ async function promptAndWait(
 	} finally {
 		signal?.removeEventListener("abort", onAbort);
 		sdkQuery.close();
+		// Ephemeral sessions exist only for this call.
+		if (ephemeralSessionId) deleteSession(ephemeralSessionId, cwd, process.env.CLAUDE_CONFIG_DIR);
 	}
 }
 

--- a/tests/int-session-resume.mjs
+++ b/tests/int-session-resume.mjs
@@ -150,48 +150,72 @@ try {
   await idle5;
 
 
-  // Turn 6: Provider turn after abort — should NOT get "conversation not found"
-  console.log("Turn 6: Provider turn after abort (should recover)...");
-  const text6 = await promptAndWait(
-    "What were all three words from earlier? Reply with just the three words separated by commas."
-  );
-  console.log(`  Response: ${text6.slice(0, 80)}`);
-  const lower6 = text6.toLowerCase();
-  if (!lower6.includes(WORD_A)) throw new Error(`Turn 6 response missing '${WORD_A}': ${text6}`);
-  if (!lower6.includes(WORD_B)) throw new Error(`Turn 6 response missing '${WORD_B}': ${text6}`);
-  if (!lower6.includes(WORD_C)) throw new Error(`Turn 6 response missing '${WORD_C}': ${text6}`);
-
-  // Turn 7: AskClaude shared mode — should see WORD_C which was only told to the non-provider model
+  // Turn 6: AskClaude after abort must not resume the invalidated parent.
+  const ephemeralMarkersBefore = (
+    readFileSync(DEBUG_LOG, "utf8").match(/askClaude: created ephemeral session/g) || []
+  ).length;
   console.log(`Switching to ${OTHER_PROVIDER}/${OTHER_MODEL}...`);
   await send({ type: "set_model", provider: OTHER_PROVIDER, modelId: OTHER_MODEL });
+  console.log("Turn 6: AskClaude shared mode after invalidation...");
+  await promptAndWait(
+    'Use the AskClaude tool with prompt="What were all three words mentioned earlier? Reply with just the words."'
+  );
+  console.log(`  AskClaude args: ${JSON.stringify(lastToolArgs)}`);
+  console.log(`  AskClaude result: ${(lastToolResult || "").slice(0, 120)}`);
+  const ephemeralMarkersAfter = (
+    readFileSync(DEBUG_LOG, "utf8").match(/askClaude: created ephemeral session/g) || []
+  ).length;
+  if (ephemeralMarkersAfter <= ephemeralMarkersBefore) {
+    throw new Error("Turn 6 AskClaude resumed or rebuilt the invalidated shared session instead of creating a new ephemeral one");
+  }
+  if (!promptContains(WORD_C) && !lastToolResult?.toLowerCase().includes(WORD_C)) {
+    throw new Error(`Turn 6 AskClaude result missing '${WORD_C}': ${lastToolResult}`);
+  }
 
-
-  console.log("Turn 7: AskClaude shared mode (should see non-provider context)...");
+  // Turn 7: Provider turn after abort — should recover.
+  console.log(`Switching back to ${BRIDGE_MODEL}...`);
+  await send({ type: "set_model", provider: bridgeProvider, modelId: bridgeModelId });
+  console.log("Turn 7: Provider turn after abort...");
   const text7 = await promptAndWait(
+    "What were all three words from earlier? Reply with just the three words separated by commas."
+  );
+  console.log(`  Response: ${text7.slice(0, 80)}`);
+  const lower7 = text7.toLowerCase();
+  if (!lower7.includes(WORD_A)) throw new Error(`Turn 7 response missing '${WORD_A}': ${text7}`);
+  if (!lower7.includes(WORD_B)) throw new Error(`Turn 7 response missing '${WORD_B}': ${text7}`);
+  if (!lower7.includes(WORD_C)) throw new Error(`Turn 7 response missing '${WORD_C}': ${text7}`);
+
+  // Turn 8: AskClaude shared mode — should see non-provider context.
+  console.log(`Switching to ${OTHER_PROVIDER}/${OTHER_MODEL}...`);
+  await send({ type: "set_model", provider: OTHER_PROVIDER, modelId: OTHER_MODEL });
+  console.log("Turn 8: AskClaude shared mode (should see non-provider context)...");
+  lastToolResult = null;
+  const text8 = await promptAndWait(
     'Use the AskClaude tool with prompt="What was the third word mentioned earlier? Reply with just the word."'
   );
   console.log(`  AskClaude args: ${JSON.stringify(lastToolArgs)}`);
   console.log(`  AskClaude result: ${(lastToolResult || "").slice(0, 120)}`);
+  if (lastToolResult === null) {
+    throw new Error("Turn 8: AskClaude tool was not called");
+  }
   if (promptContains(WORD_C)) {
     console.log(`  INCONCLUSIVE: ${OTHER_MODEL} put '${WORD_C}' in the prompt, so a correct answer proves nothing about shared context`);
-  } else if (!lastToolResult?.toLowerCase().includes(WORD_C)) {
-    throw new Error(`Turn 7 AskClaude tool result missing '${WORD_C}': ${lastToolResult}`);
+  } else if (!lastToolResult.toLowerCase().includes(WORD_C)) {
+    throw new Error(`Turn 8 AskClaude tool result missing '${WORD_C}': ${lastToolResult}`);
   }
 
-  // Turn 8: AskClaude isolated mode — should NOT see conversation history
-  console.log("Turn 8: AskClaude isolated mode (should not see context)...");
+  // Turn 9: AskClaude isolated mode — should NOT see conversation history.
+  console.log("Turn 9: AskClaude isolated mode (should not see context)...");
   lastToolResult = null;
-  const text8 = await promptAndWait(
+  const text9 = await promptAndWait(
     'Use the AskClaude tool with prompt="What was the third word mentioned earlier? If you don\'t know, say UNKNOWN." and isolated=true'
   );
   console.log(`  AskClaude args: ${JSON.stringify(lastToolArgs)}`);
   console.log(`  AskClaude result: ${(lastToolResult || "").slice(0, 120)}`);
   if (promptContains(WORD_C)) {
-    // The ~1-in-5 flake: isolated CC is echoing a word it was handed, not one it
-    // recovered from a session it should not have seen.
     console.log(`  INCONCLUSIVE: ${OTHER_MODEL} put '${WORD_C}' in the prompt, so isolation cannot be judged from the response`);
   } else if (lastToolResult?.toLowerCase().includes(WORD_C)) {
-    throw new Error(`Turn 8 isolated AskClaude should not know '${WORD_C}' (not in its prompt, so this is a real context leak): ${lastToolResult}`);
+    throw new Error(`Turn 9 isolated AskClaude should not know '${WORD_C}' (not in its prompt, so this is a real context leak): ${lastToolResult}`);
   }
 
   // sessionId stability: sessionId should stay stable across normal

--- a/tests/unit-sync-shared-session.mjs
+++ b/tests/unit-sync-shared-session.mjs
@@ -17,13 +17,8 @@ describe("syncSharedSession", () => {
 		__test.setPiUI(null);
 	});
 
-	// The branch this exercises is the guard that stops a reentrant subagent from
-	// resuming — and then overwriting — the parent's session: a subagent's context
-	// is shorter than the parent's cursor, so it starts fresh and the parent's
-	// session is preserved. It was previously described here as the compact-summary
-	// path, which cannot reach syncSharedSession at all, so the branch read as
-	// covered for a case that never happens.
-	it("starts a fresh session for a shorter context and preserves the parent's", () => {
+	// Nested queries get a disposable session instead of overwriting the parent.
+	it("starts a fresh session for a shorter reentrant context and preserves the parent", () => {
 		const cwd = mkdtempSync(join(tmpdir(), "sync-shared-session-"));
 		try {
 			const mainSession = {
@@ -39,7 +34,7 @@ describe("syncSharedSession", () => {
 					content: "Summarize this conversation.",
 					timestamp: Date.now(),
 				},
-			], cwd);
+			], cwd, undefined, undefined, { reentrant: true });
 
 			assert.equal(
 				result.sessionId,
@@ -55,6 +50,54 @@ describe("syncSharedSession", () => {
 		} finally {
 			rmSync(cwd, { recursive: true, force: true });
 		}
+	});
+
+	it("rebuilds a shorter top-level history instead of dropping conversation context", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "sync-shared-session-"));
+		const sessionId = randomUUID();
+		try {
+			__test.setSharedSession({ sessionId, cursor: 42, cwd });
+
+			const result = __test.syncSharedSession([
+				{ role: "user", content: "Remember this.", timestamp: 1 },
+				{ role: "assistant", content: [{ type: "text", text: "Remembered." }], timestamp: 2 },
+				{ role: "user", content: "What did I ask?", timestamp: 3 },
+			], cwd);
+
+			assert.equal(result.sessionId, sessionId);
+			assert.equal(result.preserveSharedSession, undefined);
+			assert.equal(__test.getSharedSession().cursor, 2);
+			assert.equal(openSession({ sessionId, projectPath: cwd }).messages.length, 2);
+		} finally {
+			deleteSession(sessionId, cwd);
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("carries a compaction invalidation through a concurrent query completion", () => {
+		const cwd = "/tmp/session-race";
+		const sessionId = "11111111-1111-4111-8111-111111111111";
+		__test.setSharedSession({ sessionId, cursor: 42, cwd });
+
+		__test.markRebuild("session_compact");
+		__test.recordQueryCompletion(sessionId, 5, cwd, false);
+
+		assert.deepEqual(__test.getSharedSession(), {
+			sessionId,
+			cursor: 5,
+			cwd,
+			needsRebuild: true,
+		});
+	});
+
+	it("does not lower the parent cursor when a reentrant query completes", () => {
+		const cwd = "/tmp/reentrant-session";
+		const sessionId = "11111111-1111-4111-8111-111111111111";
+		__test.setSharedSession({ sessionId, cursor: 42, cwd });
+
+		__test.recordQueryCompletion(sessionId, 5, cwd, true);
+
+		assert.equal(__test.getSharedSession().cursor, 42);
 	});
 
 	// The rebuilt file holds one line per record, and a carried `@file` expansion

--- a/tests/unit-sync-shared-session.mjs
+++ b/tests/unit-sync-shared-session.mjs
@@ -17,14 +17,14 @@ describe("syncSharedSession", () => {
 		__test.setPiUI(null);
 	});
 
-	// Nested queries get a disposable session instead of overwriting the parent.
-	it("starts a fresh session for a shorter reentrant context and preserves the parent", () => {
+	it("starts a disposable session for every reentrant context and preserves the parent", () => {
 		const cwd = mkdtempSync(join(tmpdir(), "sync-shared-session-"));
 		try {
 			const mainSession = {
 				sessionId: "11111111-1111-4111-8111-111111111111",
 				cursor: 42,
 				cwd,
+				needsRebuild: true,
 			};
 			__test.setSharedSession(mainSession);
 
@@ -36,20 +36,39 @@ describe("syncSharedSession", () => {
 				},
 			], cwd, undefined, undefined, { reentrant: true });
 
-			assert.equal(
-				result.sessionId,
-				null,
-				"a context shorter than the cursor — a subagent, or AskClaude — must start a fresh Claude Code session instead of resuming the parent's",
-			);
-			assert.equal(
-				result.preserveSharedSession,
-				true,
-				"the fresh session must not replace the parent's when it completes",
-			);
+			assert.equal(result.sessionId, null);
+			assert.equal(result.preserveSharedSession, true);
 			assert.deepEqual(__test.getSharedSession(), mainSession);
 		} finally {
 			rmSync(cwd, { recursive: true, force: true });
 		}
+	});
+
+	it("does not reuse a valid parent for a reentrant context", () => {
+		const parent = {
+			sessionId: "11111111-1111-4111-8111-111111111111",
+			cursor: 1,
+			cwd: "/tmp/parent-session",
+		};
+		__test.setSharedSession(parent);
+
+		const result = __test.syncSharedSession([
+			{ role: "user", content: "Earlier prompt.", timestamp: 1 },
+			{ role: "user", content: "Child prompt.", timestamp: 2 },
+		], parent.cwd, undefined, undefined, { reentrant: true });
+
+		assert.deepEqual(result, { sessionId: null, preserveSharedSession: true });
+		assert.deepEqual(__test.getSharedSession(), parent);
+	});
+
+	it("preserves (empty) shared session and marks disposable for an orphaned reentrant context", () => {
+		const result = __test.syncSharedSession([
+			{ role: "user", content: "Earlier prompt.", timestamp: 1 },
+			{ role: "user", content: "Child prompt.", timestamp: 2 },
+		], "/tmp/child-session", undefined, undefined, { reentrant: true });
+
+		assert.deepEqual(result, { sessionId: null, preserveSharedSession: true });
+		assert.equal(__test.getSharedSession(), null);
 	});
 
 	it("rebuilds a shorter top-level history instead of dropping conversation context", () => {
@@ -80,7 +99,7 @@ describe("syncSharedSession", () => {
 		__test.setSharedSession({ sessionId, cursor: 42, cwd });
 
 		__test.markRebuild("session_compact");
-		__test.recordQueryCompletion(sessionId, 5, cwd, false);
+		__test.recordQueryCompletion(sessionId, 5, cwd);
 
 		assert.deepEqual(__test.getSharedSession(), {
 			sessionId,
@@ -90,15 +109,6 @@ describe("syncSharedSession", () => {
 		});
 	});
 
-	it("does not lower the parent cursor when a reentrant query completes", () => {
-		const cwd = "/tmp/reentrant-session";
-		const sessionId = "11111111-1111-4111-8111-111111111111";
-		__test.setSharedSession({ sessionId, cursor: 42, cwd });
-
-		__test.recordQueryCompletion(sessionId, 5, cwd, true);
-
-		assert.equal(__test.getSharedSession().cursor, 42);
-	});
 
 	// The rebuilt file holds one line per record, and a carried `@file` expansion
 	// is an `attachment` record — which `session.messages` filters out. Counting


### PR DESCRIPTION
Keep Claude sessions aligned when Pi rewrites conversation history.

- rebuild shortened top-level histories instead of dropping context
- preserve pending compaction and model-change invalidations
- isolate reentrant children from the parent session
- import a temporary session when shared AskClaude cannot safely resume

Fixes #30, #42, #55, and #62.
