### PR TITLE
fix: share isolated prompt captures across instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- **Fix: isolated subagents can resolve their captured system prompt (issue #64)** — prompt captures now share one bounded process-wide registry across extension module instances.
+
 - **Fix: better isolate AskClaude tool (issue #59)** — AskClaude children no longer inherit the user's `~/.claude` `CLAUDE.md` files or skill listing, and now always get Claude Code's system prompt preset instead of only when pi-side skills exist. Thanks @JAtkinsonKO.
 - **Fix: Bogus debug message about "record count mismatch" after switching providers** — the post-rebuild integrity check did not take `@file` expansion into account when switching providers.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -831,8 +831,6 @@ function showStartupNoticeOnce(): void {
 	piUI?.notify([title, ...bullets, "─".repeat(64)].join("\n"), "info");
 }
 
-// Isolated agents record captures in a second module instance while streaming
-// stays pinned to the parent instance.
 const promptCaptures = sharedPromptCaptures();
 
 /** Whatever a settled session left behind, named in one greppable line.

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import { claudeCodeSettings, loadConfig, markStartupNoticeShown, type Config } f
 import {
 	collectPromptSkills,
 	projectPromptCapture,
-	PromptCaptures,
+	sharedPromptCaptures,
 } from "./prompt-capture.js";
 import { collectCarriedAttachments, placeCarriedAttachments, type CarriedAttachment } from "./attachments.js";
 import { createToolServer } from "./mcp-server.js";
@@ -831,9 +831,9 @@ function showStartupNoticeOnce(): void {
 	piUI?.notify([title, ...bullets, "─".repeat(64)].join("\n"), "info");
 }
 
-// Captures of what pi assembled per agent; see src/prompt-capture.ts for why this
-// is keyed rather than held in a single slot.
-const promptCaptures = new PromptCaptures();
+// Isolated agents record captures in a second module instance while streaming
+// stays pinned to the parent instance.
+const promptCaptures = sharedPromptCaptures();
 
 /** Whatever a settled session left behind, named in one greppable line.
  *

--- a/src/prompt-capture.ts
+++ b/src/prompt-capture.ts
@@ -187,6 +187,18 @@ export class PromptCaptures {
 	}
 }
 
+const SHARED_CAPTURES_KEY = Symbol.for("claude-bridge:promptCaptures");
+
+/**
+ * Isolated agents re-evaluate this module, while provider streaming stays pinned
+ * to the parent module instance. A process-wide registry keeps the child's
+ * capture visible to the parent and remains bounded by PromptCaptures' LRU cap.
+ */
+export function sharedPromptCaptures(): PromptCaptures {
+	const globals = globalThis as Record<symbol, PromptCaptures | undefined>;
+	return (globals[SHARED_CAPTURES_KEY] ??= new PromptCaptures());
+}
+
 export function projectPromptCapture(
 	capture: PromptCapture,
 	options: { skillReadTool: SkillReadTool },

--- a/src/prompt-capture.ts
+++ b/src/prompt-capture.ts
@@ -189,11 +189,7 @@ export class PromptCaptures {
 
 const SHARED_CAPTURES_KEY = Symbol.for("claude-bridge:promptCaptures");
 
-/**
- * Isolated agents re-evaluate this module, while provider streaming stays pinned
- * to the parent module instance. A process-wide registry keeps the child's
- * capture visible to the parent and remains bounded by PromptCaptures' LRU cap.
- */
+/** Isolated agents re-evaluate this module; process-wide state lets the parent stream their captures. */
 export function sharedPromptCaptures(): PromptCaptures {
 	const globals = globalThis as Record<symbol, PromptCaptures | undefined>;
 	return (globals[SHARED_CAPTURES_KEY] ??= new PromptCaptures());

--- a/tests/unit-prompt-capture.mjs
+++ b/tests/unit-prompt-capture.mjs
@@ -261,10 +261,10 @@ describe("PromptCaptures", () => {
 		assert.equal(resolved?.contextFiles[0].content, "isolated rules");
 	});
 
-	it("bounds the process-wide registry", () => {
-		const shared = sharedPromptCaptures();
-		for (let i = 0; i < 400; i++) shared.record(`shared-session-key-${i}`, capture());
-		assert.ok(shared.size <= 256);
-		assert.ok(shared.resolve("shared-session-key-399"));
+	it("bounds the capture registry", () => {
+		const captures = new PromptCaptures();
+		for (let i = 0; i < 400; i++) captures.record(`session-key-${i}`, capture());
+		assert.ok(captures.size <= 256);
+		assert.ok(captures.resolve("session-key-399"));
 	});
 });

--- a/tests/unit-prompt-capture.mjs
+++ b/tests/unit-prompt-capture.mjs
@@ -2,7 +2,12 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { collectPromptSkills, projectPromptCapture, PromptCaptures } from "../src/prompt-capture.js";
+import {
+	collectPromptSkills,
+	projectPromptCapture,
+	PromptCaptures,
+	sharedPromptCaptures,
+} from "../src/prompt-capture.js";
 
 const PI_HARNESS = "You are an expert coding assistant operating inside pi. Pi documentation: pi packages (docs/packages.md).";
 const PARENT_KEY = `${PI_HARNESS}\n\n<project_context>raw parent context</project_context>\nCurrent working directory: /parent`;
@@ -239,5 +244,27 @@ describe("PromptCaptures", () => {
 		assert.equal(captures.resolve("b"), undefined);
 		assert.equal(captures.resolve("a").custom, "refreshed");
 		assert.ok(captures.resolve("c") && captures.resolve("d"));
+	});
+
+	it("shares isolated-agent captures across module instances", async () => {
+		const childModule = await import("../src/prompt-capture.js?instance=isolated-child");
+		assert.notEqual(childModule.PromptCaptures, PromptCaptures);
+		const isolatedPrompt = "You are an isolated smoke-test agent.";
+
+		childModule.sharedPromptCaptures().record(isolatedPrompt, capture({
+			custom: isolatedPrompt,
+			contextFiles: [{ path: "/AGENTS.md", content: "isolated rules" }],
+		}));
+
+		const resolved = sharedPromptCaptures().resolveOrDerive(isolatedPrompt);
+		assert.equal(resolved?.assembledPrompt, isolatedPrompt);
+		assert.equal(resolved?.contextFiles[0].content, "isolated rules");
+	});
+
+	it("bounds the process-wide registry", () => {
+		const shared = sharedPromptCaptures();
+		for (let i = 0; i < 400; i++) shared.record(`shared-session-key-${i}`, capture());
+		assert.ok(shared.size <= 256);
+		assert.ok(shared.resolve("shared-session-key-399"));
 	});
 });


### PR DESCRIPTION
Share prompt captures across OMP extension instances so isolated subagents can resolve the parent system prompt.

The registry caps direct lookup keys and preserves inherited prompt projection across reloads.

Known limit: inherited parent links can outlive evicted keys, and the process-wide registry is not scoped to a host session.

Fixes #64.
