### PR TITLE
fix: recover literal invoke tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-- **Fix: recover tool calls emitted as literal `<invoke>` text (issue #36)** — complete leaked calls are converted to structured tool calls, while a stale literal draft beside a genuine call is hidden from the visible answer.
+- **Fix: recover complete literal `<invoke>` tool calls (issue #36)** — strict parsing rejects malformed calls; identical calls are recovered once. Literal text remains visible because streamed output cannot be retracted.
 
 - **Fix: better isolate AskClaude tool (issue #59)** — AskClaude children no longer inherit the user's `~/.claude` `CLAUDE.md` files or skill listing, and now always get Claude Code's system prompt preset instead of only when pi-side skills exist. Thanks @JAtkinsonKO.
 - **Fix: Bogus debug message about "record count mismatch" after switching providers** — the post-rebuild integrity check did not take `@file` expansion into account when switching providers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- **Fix: recover tool calls emitted as literal `<invoke>` text (issue #36)** — complete leaked calls are converted to structured tool calls, while a stale literal draft beside a genuine call is hidden from the visible answer.
+
 - **Fix: better isolate AskClaude tool (issue #59)** — AskClaude children no longer inherit the user's `~/.claude` `CLAUDE.md` files or skill listing, and now always get Claude Code's system prompt preset instead of only when pi-side skills exist. Thanks @JAtkinsonKO.
 - **Fix: Bogus debug message about "record count mismatch" after switching providers** — the post-rebuild integrity check did not take `@file` expansion into account when switching providers.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1054,7 +1054,6 @@ function finalizeCurrentStream(c: QueryContext, stopReason?: string): void {
 function processStreamEvent(
 	message: SDKMessage,
 	customToolNameToPi: Map<string, string>,
-	mcpTools: readonly Tool[],
 	model: Model<any>,
 	c: QueryContext,
 ): void {
@@ -1150,7 +1149,6 @@ function processStreamEvent(
 		// assistant message for this turn, but currentPiStream=null causes
 		// consumeQuery to skip it. The MCP handler blocks the generator until
 		// pi delivers the tool result via the next streamSimple call.
-		recoverLeakedInvokes(c, customToolNameToPi, mcpTools);
 		c.turnOutput.stopReason = "toolUse";
 		const stream = c.currentPiStream;
 		stream!.push({ type: "done", reason: "toolUse", message: c.turnOutput });
@@ -1174,7 +1172,7 @@ function processStreamEvent(
 // arrives before any stream_events, this is the primary content path. Must maintain
 // the same stream lifecycle as processStreamEvent — including ending the stream on
 // tool_use to prevent deadlock with the MCP handler.
-function processAssistantMessage(message: SDKMessage, model: Model<any>, customToolNameToPi: Map<string, string>, mcpTools: readonly Tool[], c: QueryContext): void {
+function processAssistantMessage(message: SDKMessage, model: Model<any>, customToolNameToPi: Map<string, string>, c: QueryContext): void {
 	if (c.turnSawStreamEvent) return;
 	const assistantMsg = (message as any).message;
 	if (!assistantMsg?.content) return;
@@ -1221,7 +1219,6 @@ function processAssistantMessage(message: SDKMessage, model: Model<any>, customT
 
 	// End the stream on tool_use, same as processStreamEvent's message_stop handler.
 	if (c.turnSawToolCall && c.currentPiStream && c.turnOutput) {
-		recoverLeakedInvokes(c, customToolNameToPi, mcpTools);
 		c.turnOutput.stopReason = "toolUse";
 		const stream = c.currentPiStream;
 		stream.push({ type: "done", reason: "toolUse", message: c.turnOutput });
@@ -1236,7 +1233,7 @@ function recoverLeakedInvokes(
 	customToolNameToPi: Map<string, string>,
 	mcpTools: readonly Tool[],
 ): void {
-	if (!c.turnOutput || c.turnOutput.stopReason === "error") return;
+	if (!c.turnOutput) return;
 	const plan = planInvokeRecovery(c.turnBlocks, {
 		sawToolCall: c.turnSawToolCall,
 		resolveToolName: (name) =>
@@ -1249,11 +1246,7 @@ function recoverLeakedInvokes(
 	});
 	if (!plan) return;
 
-	for (const rewrite of plan.rewrites) {
-		const block = c.turnBlocks[rewrite.blockIndex];
-		if (block?.type === "text") block.text = rewrite.text;
-	}
-	if (!plan.calls.length || !c.currentPiStream) return;
+	if (!c.currentPiStream) return;
 
 	const stream = c.currentPiStream;
 	ensureTurnStarted(c);
@@ -1285,7 +1278,7 @@ async function consumeQuery(
 	model: Model<any>,
 	wasAborted: () => boolean,
 	queryCtx: QueryContext,
-	mcpTools: readonly Tool[] = [],
+	mcpTools: readonly Tool[],
 ): Promise<{ capturedSessionId?: string }> {
 	let capturedSessionId: string | undefined;
 
@@ -1332,10 +1325,10 @@ async function consumeQuery(
 
 		switch (message.type) {
 			case "stream_event":
-				processStreamEvent(message, customToolNameToPi, mcpTools, model, queryCtx);
+				processStreamEvent(message, customToolNameToPi, model, queryCtx);
 				break;
 			case "assistant":
-				processAssistantMessage(message, model, customToolNameToPi, mcpTools, queryCtx);
+				processAssistantMessage(message, model, customToolNameToPi, queryCtx);
 				break;
 			case "result": {
 					// The failure itself was recorded above the guard, along with the served

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {
 import { collectCarriedAttachments, placeCarriedAttachments, type CarriedAttachment } from "./attachments.js";
 import { createToolServer } from "./mcp-server.js";
 import { buildActionSummary, type ToolCallState } from "./askclaude-ui.js";
+import { RECOVERED_CONTINUATION_PROMPT, coerceInvokeArgs, planInvokeRecovery, recoveredToolResultPending } from "./invoke-recovery.js";
 
 // Compat (#2): use factory if available (pi-ai ≥0.66), else fall back to constructor (gsd-pi etc.)
 const _piAi = piAi as any;
@@ -1053,6 +1054,7 @@ function finalizeCurrentStream(c: QueryContext, stopReason?: string): void {
 function processStreamEvent(
 	message: SDKMessage,
 	customToolNameToPi: Map<string, string>,
+	mcpTools: readonly Tool[],
 	model: Model<any>,
 	c: QueryContext,
 ): void {
@@ -1148,6 +1150,7 @@ function processStreamEvent(
 		// assistant message for this turn, but currentPiStream=null causes
 		// consumeQuery to skip it. The MCP handler blocks the generator until
 		// pi delivers the tool result via the next streamSimple call.
+		recoverLeakedInvokes(c, customToolNameToPi, mcpTools);
 		c.turnOutput.stopReason = "toolUse";
 		const stream = c.currentPiStream;
 		stream!.push({ type: "done", reason: "toolUse", message: c.turnOutput });
@@ -1171,7 +1174,7 @@ function processStreamEvent(
 // arrives before any stream_events, this is the primary content path. Must maintain
 // the same stream lifecycle as processStreamEvent — including ending the stream on
 // tool_use to prevent deadlock with the MCP handler.
-function processAssistantMessage(message: SDKMessage, model: Model<any>, customToolNameToPi: Map<string, string>, c: QueryContext): void {
+function processAssistantMessage(message: SDKMessage, model: Model<any>, customToolNameToPi: Map<string, string>, mcpTools: readonly Tool[], c: QueryContext): void {
 	if (c.turnSawStreamEvent) return;
 	const assistantMsg = (message as any).message;
 	if (!assistantMsg?.content) return;
@@ -1218,6 +1221,7 @@ function processAssistantMessage(message: SDKMessage, model: Model<any>, customT
 
 	// End the stream on tool_use, same as processStreamEvent's message_stop handler.
 	if (c.turnSawToolCall && c.currentPiStream && c.turnOutput) {
+		recoverLeakedInvokes(c, customToolNameToPi, mcpTools);
 		c.turnOutput.stopReason = "toolUse";
 		const stream = c.currentPiStream;
 		stream.push({ type: "done", reason: "toolUse", message: c.turnOutput });
@@ -1225,6 +1229,49 @@ function processAssistantMessage(message: SDKMessage, model: Model<any>, customT
 		stream.end();
 		c.currentPiStream = null;
 	}
+}
+
+function recoverLeakedInvokes(
+	c: QueryContext,
+	customToolNameToPi: Map<string, string>,
+	mcpTools: readonly Tool[],
+): void {
+	if (!c.turnOutput || c.turnOutput.stopReason === "error") return;
+	const plan = planInvokeRecovery(c.turnBlocks, {
+		sawToolCall: c.turnSawToolCall,
+		resolveToolName: (name) =>
+			piToolNameFor(name, customToolNameToPi)
+			?? piToolNameFor(`${MCP_TOOL_PREFIX}${name}`, customToolNameToPi),
+		mapArgs: (piName, args) => coerceInvokeArgs(
+			mapToolArgs(piName, args),
+			mcpTools.find((tool) => tool.name === piName)?.parameters,
+		),
+	});
+	if (!plan) return;
+
+	for (const rewrite of plan.rewrites) {
+		const block = c.turnBlocks[rewrite.blockIndex];
+		if (block?.type === "text") block.text = rewrite.text;
+	}
+	if (!plan.calls.length || !c.currentPiStream) return;
+
+	const stream = c.currentPiStream;
+	ensureTurnStarted(c);
+	for (const call of plan.calls) {
+		c.turnSawToolCall = true;
+		// Recovered ids do not enter turnToolCallIds because Claude Code has no
+		// MCP handler waiting for these synthesized calls.
+		c.turnBlocks.push({ type: "toolCall", id: call.id, name: call.name, arguments: call.arguments });
+		const index = c.turnBlocks.length - 1;
+		stream.push({ type: "toolcall_start", contentIndex: index, partial: c.turnOutput });
+		stream.push({ type: "toolcall_end", contentIndex: index, toolCall: c.turnBlocks[index], partial: c.turnOutput });
+	}
+	piUI?.notify(`Claude bridge: recovered ${plan.calls.length} tool call(s) Claude wrote as text instead of calling`, "warning");
+	c.turnOutput.stopReason = "toolUse";
+	stream.push({ type: "done", reason: "toolUse", message: c.turnOutput });
+	markStreamComplete(stream);
+	stream.end();
+	c.currentPiStream = null;
 }
 
 /** Background consumer: iterates the SDK generator, pushing events to currentPiStream.
@@ -1238,6 +1285,7 @@ async function consumeQuery(
 	model: Model<any>,
 	wasAborted: () => boolean,
 	queryCtx: QueryContext,
+	mcpTools: readonly Tool[] = [],
 ): Promise<{ capturedSessionId?: string }> {
 	let capturedSessionId: string | undefined;
 
@@ -1284,10 +1332,10 @@ async function consumeQuery(
 
 		switch (message.type) {
 			case "stream_event":
-				processStreamEvent(message, customToolNameToPi, model, queryCtx);
+				processStreamEvent(message, customToolNameToPi, mcpTools, model, queryCtx);
 				break;
 			case "assistant":
-				processAssistantMessage(message, model, customToolNameToPi, queryCtx);
+				processAssistantMessage(message, model, customToolNameToPi, mcpTools, queryCtx);
 				break;
 			case "result": {
 					// The failure itself was recorded above the guard, along with the served
@@ -1325,6 +1373,9 @@ async function consumeQuery(
 
 	// DEBUG: trace when consumeQuery exits
 	debug(`consumeQuery: for-await loop exited, wasAborted=${wasAborted()}, capturedSessionId=${capturedSessionId?.slice(0, 8) ?? "none"}`);
+	if (!wasAborted() && queryCtx.turnOutput?.stopReason === "stop") {
+		recoverLeakedInvokes(queryCtx, customToolNameToPi, mcpTools);
+	}
 
 	return { capturedSessionId };
 }
@@ -1461,11 +1512,11 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		return stream;
 	}
 
-	// --- Orphaned tool result (e.g. user aborted a tool call) ---
-	// The query is gone but pi still delivered the result. Nothing to do — just
-	// emit end_turn so pi waits for the next real user message.
+	// A recovered call has no live MCP handler by construction. Its result must
+	// start a continuation query so Claude can consume it.
 	const lastMsg = context.messages[context.messages.length - 1];
-	if (lastMsg?.role === "toolResult") {
+	const recoveredInvokeResult = lastMsg?.role === "toolResult" && recoveredToolResultPending(context.messages);
+	if (lastMsg?.role === "toolResult" && !recoveredInvokeResult) {
 		debug(`provider: orphaned tool result after abort, emitting end_turn`);
 		if (sharedSession && activeQueryContexts.size === 0) sharedSession.cursor = context.messages.length;
 		// No query owns this result, so there is no context to reset: resetTurnState
@@ -1525,6 +1576,9 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	const { sessionId: resumeSessionId } = syncResult;
 	const promptBlocks = extractUserPromptBlocks(context.messages);
 	let promptText = extractUserPrompt(context.messages) ?? "";
+	if (recoveredInvokeResult && !promptText && !promptBlocks) {
+		promptText = RECOVERED_CONTINUATION_PROMPT;
+	}
 
 	// Guard: empty prompt means the last context message isn't a user message.
 	// This should never happen with per-query state — dump diagnostics if it does.
@@ -1637,7 +1691,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	}
 
 	// Background consumer — runs until query ends
-	consumeQuery(sdkQuery, customToolNameToPi, model, () => wasAborted, queryCtx)
+	consumeQuery(sdkQuery, customToolNameToPi, model, () => wasAborted, queryCtx, mcpTools)
 		.then(async ({ capturedSessionId }) => {
 			debug(`provider: consumeQuery completed, stopReason=${queryCtx.turnOutput?.stopReason}, error=${queryCtx.turnOutput?.errorMessage}, aborted=${wasAborted}`);
 

--- a/src/invoke-recovery.ts
+++ b/src/invoke-recovery.ts
@@ -1,0 +1,292 @@
+// Recovery for tool calls Claude typed as literal text instead of emitting as a
+// structured tool_use block (issue #36). The leaked shape is the invoke syntax
+// Claude is trained on:
+//
+//     <invoke name="bash">
+//       <parameter name="command">npm test</parameter>
+//     </invoke>
+//
+// When that text is the whole action of a turn, pi sees an ordinary answer and the
+// work stops: nothing was dispatched, nothing failed, the agent just goes quiet.
+// Mostly seen on long 1M-context sessions.
+//
+// Two cases, one pass over the turn's blocks:
+//   1. no structured tool call this turn → synthesize the call the text describes
+//   2. a structured tool call for the same tool exists → the literal text is a
+//      stale draft of it; cut it from the visible answer so the user is not shown
+//      the same command twice
+//
+// The parser is deliberately small and total. It never throws, and anything it
+// cannot parse in full is left as plain text: a half-built call would run the
+// wrong thing, which is worse than the stall it is recovering from.
+//
+// What this deliberately does NOT do is guess at context — an invoke block inside
+// a fenced example is indistinguishable from a leaked one, and refusing to
+// recover fenced text would silently reinstate the stall for the leaks that
+// arrive fenced. The gate is instead the caller's: end_turn, no structured call,
+// and a tool the bridge is actually serving this turn.
+//
+// Kept out of index.ts so it is testable without activating the extension.
+
+import { randomUUID } from "node:crypto";
+
+/** Namespaced tags (`<invoke>`) are the same leak; Claude emits both forms. */
+const NS = "(?:[A-Za-z][\\w.-]*:)?";
+const INVOKE_OPEN = `<${NS}invoke\\s+name\\s*=\\s*["']([^"']+)["']\\s*>`;
+const INVOKE_CLOSE = `</${NS}invoke\\s*>`;
+const PARAM_OPEN = `<${NS}parameter\\s+name\\s*=\\s*["']([^"']+)["']\\s*>`;
+const PARAM_CLOSE = `</${NS}parameter\\s*>`;
+/** The wrapper Claude puts around a run of invokes, junk once they are cut. Eats
+ *  its own line so removing it does not leave a blank one behind. */
+const EMPTY_WRAPPER = new RegExp(
+	`[ \\t]*<${NS}function_calls\\s*>\\s*</${NS}function_calls\\s*>[ \\t]*\\n?`,
+	"g",
+);
+
+/** Ids we mint ourselves. Same shape as a Claude Code tool_use id — opaque and
+ *  id-safe, so a synthesized call converts, sanitizes and pairs like any other —
+ *  but recognizable, because a result keyed to one has no Claude Code counterpart:
+ *  CC ended that turn as plain text, so no MCP handler is parked on the id and no
+ *  live query is left to resume. See recoveredToolResultPending. */
+const RECOVERED_ID_PREFIX = "toolu_recovered_";
+
+/** Prompt for the turn that carries a recovered call's result back to Claude.
+ *  The result itself rides in the rebuilt transcript; pi's context ends on it, so
+ *  there is no user message to extract and the turn needs a nudge to continue. */
+export const RECOVERED_CONTINUATION_PROMPT = "[continue: tool result above]";
+
+/** Recovered ids carry their own prefix: pi's own transcript is the only place a
+ *  result for one of these comes back, and the continuation turn has to be able
+ *  to tell it from a real tool_use id Claude issued. */
+function newRecoveredToolCallId(): string {
+	return `${RECOVERED_ID_PREFIX}${randomUUID().replace(/-/g, "")}`;
+}
+
+export function isRecoveredToolCallId(id: unknown): boolean {
+	return typeof id === "string" && id.startsWith(RECOVERED_ID_PREFIX);
+}
+
+/** One `<invoke>` block found in assistant text. Values stay as written: XML
+ *  carries no types, and the tool's own schema is the only thing that knows which
+ *  of them is a number — see coerceInvokeArgs. `start`/`end` span the literal
+ *  source so it can be cut once a real call represents it. */
+export interface ParsedInvoke {
+	/** Tool name exactly as written in the tag. */
+	name: string;
+	arguments: Record<string, string>;
+	start: number;
+	end: number;
+}
+
+/** Fresh regex per scan: the parser nests scans, and sharing `lastIndex` between
+ *  an outer and an inner loop is how these get subtly wrong. Only compiled when
+ *  the text actually mentions an invoke, which is the rare case. */
+function scanFrom(source: string, text: string, from: number): RegExpExecArray | null {
+	const re = new RegExp(source, "g");
+	re.lastIndex = from;
+	return re.exec(text);
+}
+
+/** Parameters of one invoke body, or null if the body is malformed — an opening
+ *  `<parameter>` with no close means the text was truncated mid-call. */
+function parseParameters(body: string): Record<string, string> | null {
+	const args: Record<string, string> = {};
+	const open = new RegExp(PARAM_OPEN, "g");
+	let match: RegExpExecArray | null;
+	while ((match = open.exec(body)) !== null) {
+		const valueStart = match.index + match[0].length;
+		// indexOf-style search for the close tag, never a greedy regex over the
+		// body: a parameter value is arbitrary text — newlines, code, `<`, XML —
+		// and a `[^<]*` or `.*` pattern either truncates it or swallows the
+		// sibling parameters after it.
+		const close = scanFrom(PARAM_CLOSE, body, valueStart);
+		if (!close) return null;
+		args[match[1]] = body.slice(valueStart, close.index);
+		open.lastIndex = close.index + close[0].length;
+	}
+	return args;
+}
+
+/** Every well-formed `<invoke>` block in `text`, in source order. Malformed and
+ *  truncated blocks are skipped rather than guessed at. */
+export function parseInvokeBlocks(text: string): ParsedInvoke[] {
+	const found: ParsedInvoke[] = [];
+	if (!text.includes("invoke")) return found;
+	const open = new RegExp(INVOKE_OPEN, "g");
+	let match: RegExpExecArray | null;
+	while ((match = open.exec(text)) !== null) {
+		const bodyStart = match.index + match[0].length;
+		const close = scanFrom(INVOKE_CLOSE, text, bodyStart);
+		if (!close) break; // truncated: nothing from here on is a finished call
+		// A close tag that sits past the next opening tag belongs to that block,
+		// not this one — this one was never closed. Resume at the sibling rather
+		// than parsing the two as a single invoke.
+		const nextOpen = scanFrom(INVOKE_OPEN, text, bodyStart);
+		if (nextOpen && nextOpen.index < close.index) {
+			open.lastIndex = nextOpen.index;
+			continue;
+		}
+		const args = parseParameters(text.slice(bodyStart, close.index));
+		const end = close.index + close[0].length;
+		if (args) found.push({ name: match[1], arguments: args, start: match.index, end });
+		open.lastIndex = end;
+	}
+	return found;
+}
+
+/** A JSON-Schema-ish view of a tool's parameters — enough of TypeBox's output to
+ *  tell a declared number from a declared string. */
+interface ParamSchema {
+	properties?: Record<string, { type?: unknown } | undefined>;
+}
+
+/** Give each parsed parameter the type its tool declares.
+ *
+ *  Every value arrives as text because XML has no types, and a tool that wants
+ *  `timeout: 120` rejects `"120"`. Guessing from the value's shape instead is the
+ *  trap: it turns a file body of `42`, an id of `007`, or a commit message of
+ *  `true` into the wrong type, and those are exactly the parameters a recovered
+ *  call is most likely to be writing somewhere. So only a declared non-string
+ *  type converts, and only when the text round-trips back to itself — anything
+ *  else stays the string Claude wrote and fails in the tool's own validator
+ *  rather than silently writing the wrong bytes.
+ *
+ *  Runs after the caller's key renaming, so `schema` is keyed by the names the pi
+ *  tool declares; values the renamer already typed are passed through. */
+export function coerceInvokeArgs(
+	args: Record<string, unknown>,
+	schema: unknown,
+): Record<string, unknown> {
+	const properties = (schema as ParamSchema | undefined)?.properties;
+	const out: Record<string, unknown> = {};
+	for (const [key, raw] of Object.entries(args)) {
+		const declared = properties?.[key]?.type;
+		if (typeof raw !== "string") {
+			out[key] = raw;
+		} else if (declared === "number" || declared === "integer") {
+			const num = Number(raw);
+			out[key] = raw.trim() !== "" && Number.isFinite(num) && String(num) === raw.trim() ? num : raw;
+		} else if (declared === "boolean") {
+			out[key] = raw === "true" ? true : raw === "false" ? false : raw;
+		} else if (declared === "array" || declared === "object") {
+			try {
+				const parsed: unknown = JSON.parse(raw);
+				out[key] = Array.isArray(parsed) === (declared === "array") && parsed !== null && typeof parsed === "object" ? parsed : raw;
+			} catch {
+				out[key] = raw;
+			}
+		} else {
+			out[key] = raw;
+		}
+	}
+	return out;
+}
+
+/** Remove `spans` from `text`, taking each block's own line with it when it had
+ *  one to itself. Widening is per-span and computed against the original offsets,
+ *  so the surrounding answer is returned byte for byte — a blanket
+ *  trailing-whitespace or blank-line normalization would edit prose and code the
+ *  leak never touched. */
+function cutSpans(text: string, spans: ParsedInvoke[]): string {
+	let out = "";
+	let cursor = 0;
+	for (const span of spans) {
+		let start = span.start;
+		let end = span.end;
+		while (start > 0 && (text[start - 1] === " " || text[start - 1] === "\t")) start--;
+		while (end < text.length && (text[end] === " " || text[end] === "\t")) end++;
+		// Alone on its lines: take the line break too, or cutting leaves a hole.
+		const ownLine = (start === 0 || text[start - 1] === "\n") && text[end] === "\n";
+		if (ownLine) end++;
+		if (start < cursor) start = cursor; // adjacent blocks sharing a break
+		out += text.slice(cursor, start);
+		// A draft between two blank lines leaves both separators behind. One is
+		// the paragraph break the prose already had; the other only existed to
+		// set the draft apart, so it goes with it. Decided at this boundary, not
+		// by normalizing the whole answer.
+		if (ownLine && out.endsWith("\n\n") && text[end] === "\n") end++;
+		cursor = end;
+	}
+	out += text.slice(cursor);
+	return out.replace(EMPTY_WRAPPER, "").trim();
+}
+
+export interface RecoveredCall {
+	id: string;
+	/** pi tool name, already resolved and served. */
+	name: string;
+	arguments: Record<string, unknown>;
+}
+
+export interface InvokeRecoveryPlan {
+	/** Text blocks whose literal draft a real call now represents. */
+	rewrites: Array<{ blockIndex: number; text: string }>;
+	calls: RecoveredCall[];
+}
+
+export interface InvokeRecoveryOptions {
+	/** True when this turn already emitted a structured tool call. */
+	sawToolCall: boolean;
+	/** pi name for a name Claude wrote, or undefined when the bridge does not
+	 *  serve it this turn. */
+	resolveToolName: (name: string) => string | undefined;
+	/** The same argument shaping a structured tool_use gets, plus schema typing. */
+	mapArgs: (piName: string, args: Record<string, string>) => Record<string, unknown>;
+}
+
+/** What to do about literal invoke text in a finished turn, or null for the
+ *  overwhelmingly common case of nothing to do.
+ *
+ *  Pure: the caller applies the plan, which is what keeps this testable without a
+ *  pi stream. Two rules do all the deciding:
+ *
+ *  - a tool the bridge does not serve this turn is left as plain text. Claude
+ *    writing about a tool is not Claude calling one, and synthesizing a call
+ *    nobody serves only trades a stall for a failure.
+ *  - when the turn already has a structured call, nothing is synthesized. That
+ *    turn continues on its own, and an extra call from a draft Claude did not
+ *    dispatch would run a real side effect it never asked for. */
+export function planInvokeRecovery(
+	blocks: ReadonlyArray<{ type: string; text?: string; name?: string }>,
+	options: InvokeRecoveryOptions,
+): InvokeRecoveryPlan | null {
+	const rewrites: InvokeRecoveryPlan["rewrites"] = [];
+	const calls: RecoveredCall[] = [];
+	const structured = new Set(
+		blocks.filter((b) => b.type === "toolCall" && b.name).map((b) => b.name as string),
+	);
+
+	blocks.forEach((block, blockIndex) => {
+		if (block.type !== "text" || !block.text) return;
+		const cut: ParsedInvoke[] = [];
+		for (const invoke of parseInvokeBlocks(block.text)) {
+			const piName = options.resolveToolName(invoke.name);
+			if (!piName) continue;
+			// Matched by tool name only: a draft and the call it became routinely
+			// differ in their arguments, and suppressing on name is what stops the
+			// user seeing the same command twice.
+			if (structured.has(piName)) { cut.push(invoke); continue; }
+			if (options.sawToolCall) continue;
+			calls.push({ id: newRecoveredToolCallId(), name: piName, arguments: options.mapArgs(piName, invoke.arguments) });
+			cut.push(invoke);
+		}
+		if (cut.length) rewrites.push({ blockIndex, text: cutSpans(block.text, cut) });
+	});
+
+	return rewrites.length || calls.length ? { rewrites, calls } : null;
+}
+
+/** True when the tool results pi just delivered include one for a call we
+ *  synthesized. Walks the same context tail as extractAllToolResults: results
+ *  back to the assistant message that owns them, past any steer between them. */
+export function recoveredToolResultPending(
+	messages: ReadonlyArray<{ role: string; toolCallId?: string }>,
+): boolean {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const msg = messages[i];
+		if (msg.role === "toolResult") {
+			if (isRecoveredToolCallId(msg.toolCallId)) return true;
+		} else if (msg.role === "assistant") break;
+	}
+	return false;
+}

--- a/src/invoke-recovery.ts
+++ b/src/invoke-recovery.ts
@@ -1,63 +1,21 @@
-// Recovery for tool calls Claude typed as literal text instead of emitting as a
-// structured tool_use block (issue #36). The leaked shape is the invoke syntax
-// Claude is trained on:
-//
-//     <invoke name="bash">
-//       <parameter name="command">npm test</parameter>
-//     </invoke>
-//
-// When that text is the whole action of a turn, pi sees an ordinary answer and the
-// work stops: nothing was dispatched, nothing failed, the agent just goes quiet.
-// Mostly seen on long 1M-context sessions.
-//
-// Two cases, one pass over the turn's blocks:
-//   1. no structured tool call this turn → synthesize the call the text describes
-//   2. a structured tool call for the same tool exists → the literal text is a
-//      stale draft of it; cut it from the visible answer so the user is not shown
-//      the same command twice
-//
-// The parser is deliberately small and total. It never throws, and anything it
-// cannot parse in full is left as plain text: a half-built call would run the
-// wrong thing, which is worse than the stall it is recovering from.
-//
-// What this deliberately does NOT do is guess at context — an invoke block inside
-// a fenced example is indistinguishable from a leaked one, and refusing to
-// recover fenced text would silently reinstate the stall for the leaks that
-// arrive fenced. The gate is instead the caller's: end_turn, no structured call,
-// and a tool the bridge is actually serving this turn.
-//
-// Kept out of index.ts so it is testable without activating the extension.
+// Recovers literal `<invoke>` text when Claude ends a turn without a tool call.
+// Parsing is strict: malformed input remains visible rather than running a
+// partial command.
 
 import { randomUUID } from "node:crypto";
 
-/** Namespaced tags (`<invoke>`) are the same leak; Claude emits both forms. */
-const NS = "(?:[A-Za-z][\\w.-]*:)?";
+const NS = "([A-Za-z][\\w.-]*:)?";
 const INVOKE_OPEN = `<${NS}invoke\\s+name\\s*=\\s*["']([^"']+)["']\\s*>`;
-const INVOKE_CLOSE = `</${NS}invoke\\s*>`;
 const PARAM_OPEN = `<${NS}parameter\\s+name\\s*=\\s*["']([^"']+)["']\\s*>`;
-const PARAM_CLOSE = `</${NS}parameter\\s*>`;
-/** The wrapper Claude puts around a run of invokes, junk once they are cut. Eats
- *  its own line so removing it does not leave a blank one behind. */
-const EMPTY_WRAPPER = new RegExp(
-	`[ \\t]*<${NS}function_calls\\s*>\\s*</${NS}function_calls\\s*>[ \\t]*\\n?`,
-	"g",
-);
 
-/** Ids we mint ourselves. Same shape as a Claude Code tool_use id — opaque and
- *  id-safe, so a synthesized call converts, sanitizes and pairs like any other —
- *  but recognizable, because a result keyed to one has no Claude Code counterpart:
- *  CC ended that turn as plain text, so no MCP handler is parked on the id and no
- *  live query is left to resume. See recoveredToolResultPending. */
+function closeTag(prefix: string | undefined, name: "invoke" | "parameter"): string {
+	return `</${prefix ?? ""}${name}\\s*>`;
+}
+
 const RECOVERED_ID_PREFIX = "toolu_recovered_";
 
-/** Prompt for the turn that carries a recovered call's result back to Claude.
- *  The result itself rides in the rebuilt transcript; pi's context ends on it, so
- *  there is no user message to extract and the turn needs a nudge to continue. */
 export const RECOVERED_CONTINUATION_PROMPT = "[continue: tool result above]";
 
-/** Recovered ids carry their own prefix: pi's own transcript is the only place a
- *  result for one of these comes back, and the continuation turn has to be able
- *  to tell it from a real tool_use id Claude issued. */
 function newRecoveredToolCallId(): string {
 	return `${RECOVERED_ID_PREFIX}${randomUUID().replace(/-/g, "")}`;
 }
@@ -66,49 +24,38 @@ export function isRecoveredToolCallId(id: unknown): boolean {
 	return typeof id === "string" && id.startsWith(RECOVERED_ID_PREFIX);
 }
 
-/** One `<invoke>` block found in assistant text. Values stay as written: XML
- *  carries no types, and the tool's own schema is the only thing that knows which
- *  of them is a number — see coerceInvokeArgs. `start`/`end` span the literal
- *  source so it can be cut once a real call represents it. */
+/** One strict `<invoke>` block found in assistant text. */
 export interface ParsedInvoke {
-	/** Tool name exactly as written in the tag. */
 	name: string;
 	arguments: Record<string, string>;
-	start: number;
-	end: number;
 }
 
-/** Fresh regex per scan: the parser nests scans, and sharing `lastIndex` between
- *  an outer and an inner loop is how these get subtly wrong. Only compiled when
- *  the text actually mentions an invoke, which is the rare case. */
 function scanFrom(source: string, text: string, from: number): RegExpExecArray | null {
 	const re = new RegExp(source, "g");
 	re.lastIndex = from;
 	return re.exec(text);
 }
 
-/** Parameters of one invoke body, or null if the body is malformed — an opening
- *  `<parameter>` with no close means the text was truncated mid-call. */
+/** Parse a body containing only whitespace-delimited, fully matched parameters. */
 function parseParameters(body: string): Record<string, string> | null {
 	const args: Record<string, string> = {};
-	const open = new RegExp(PARAM_OPEN, "g");
-	let match: RegExpExecArray | null;
-	while ((match = open.exec(body)) !== null) {
-		const valueStart = match.index + match[0].length;
-		// indexOf-style search for the close tag, never a greedy regex over the
-		// body: a parameter value is arbitrary text — newlines, code, `<`, XML —
-		// and a `[^<]*` or `.*` pattern either truncates it or swallows the
-		// sibling parameters after it.
-		const close = scanFrom(PARAM_CLOSE, body, valueStart);
+	let cursor = 0;
+	while (cursor < body.length) {
+		const whitespace = /^[\t\n\r ]*/.exec(body.slice(cursor))![0];
+		cursor += whitespace.length;
+		if (cursor === body.length) return args;
+		const open = scanFrom(PARAM_OPEN, body, cursor);
+		if (!open || open.index !== cursor || args[open[2]] !== undefined) return null;
+		const valueStart = cursor + open[0].length;
+		const close = scanFrom(closeTag(open[1], "parameter"), body, valueStart);
 		if (!close) return null;
-		args[match[1]] = body.slice(valueStart, close.index);
-		open.lastIndex = close.index + close[0].length;
+		args[open[2]] = body.slice(valueStart, close.index);
+		cursor = close.index + close[0].length;
 	}
 	return args;
 }
 
-/** Every well-formed `<invoke>` block in `text`, in source order. Malformed and
- *  truncated blocks are skipped rather than guessed at. */
+/** Every strict, complete `<invoke>` block in source order. */
 export function parseInvokeBlocks(text: string): ParsedInvoke[] {
 	const found: ParsedInvoke[] = [];
 	if (!text.includes("invoke")) return found;
@@ -116,43 +63,24 @@ export function parseInvokeBlocks(text: string): ParsedInvoke[] {
 	let match: RegExpExecArray | null;
 	while ((match = open.exec(text)) !== null) {
 		const bodyStart = match.index + match[0].length;
-		const close = scanFrom(INVOKE_CLOSE, text, bodyStart);
-		if (!close) break; // truncated: nothing from here on is a finished call
-		// A close tag that sits past the next opening tag belongs to that block,
-		// not this one — this one was never closed. Resume at the sibling rather
-		// than parsing the two as a single invoke.
+		const close = scanFrom(closeTag(match[1], "invoke"), text, bodyStart);
+		if (!close) break;
 		const nextOpen = scanFrom(INVOKE_OPEN, text, bodyStart);
-		if (nextOpen && nextOpen.index < close.index) {
-			open.lastIndex = nextOpen.index;
-			continue;
-		}
+		if (nextOpen && nextOpen.index < close.index) return found;
 		const args = parseParameters(text.slice(bodyStart, close.index));
 		const end = close.index + close[0].length;
-		if (args) found.push({ name: match[1], arguments: args, start: match.index, end });
+		if (args) found.push({ name: match[2], arguments: args });
 		open.lastIndex = end;
 	}
 	return found;
 }
 
-/** A JSON-Schema-ish view of a tool's parameters — enough of TypeBox's output to
- *  tell a declared number from a declared string. */
+/** A JSON-Schema-ish view of a tool's parameters. */
 interface ParamSchema {
 	properties?: Record<string, { type?: unknown } | undefined>;
 }
 
-/** Give each parsed parameter the type its tool declares.
- *
- *  Every value arrives as text because XML has no types, and a tool that wants
- *  `timeout: 120` rejects `"120"`. Guessing from the value's shape instead is the
- *  trap: it turns a file body of `42`, an id of `007`, or a commit message of
- *  `true` into the wrong type, and those are exactly the parameters a recovered
- *  call is most likely to be writing somewhere. So only a declared non-string
- *  type converts, and only when the text round-trips back to itself — anything
- *  else stays the string Claude wrote and fails in the tool's own validator
- *  rather than silently writing the wrong bytes.
- *
- *  Runs after the caller's key renaming, so `schema` is keyed by the names the pi
- *  tool declares; values the renamer already typed are passed through. */
+/** Coerce only types explicitly declared by the tool schema. */
 export function coerceInvokeArgs(
 	args: Record<string, unknown>,
 	schema: unknown,
@@ -165,13 +93,22 @@ export function coerceInvokeArgs(
 			out[key] = raw;
 		} else if (declared === "number" || declared === "integer") {
 			const num = Number(raw);
-			out[key] = raw.trim() !== "" && Number.isFinite(num) && String(num) === raw.trim() ? num : raw;
+			out[key] = raw.trim() !== ""
+				&& Number.isFinite(num)
+				&& (declared !== "integer" || Number.isInteger(num))
+				&& String(num) === raw.trim()
+				? num
+				: raw;
 		} else if (declared === "boolean") {
 			out[key] = raw === "true" ? true : raw === "false" ? false : raw;
 		} else if (declared === "array" || declared === "object") {
 			try {
 				const parsed: unknown = JSON.parse(raw);
-				out[key] = Array.isArray(parsed) === (declared === "array") && parsed !== null && typeof parsed === "object" ? parsed : raw;
+				out[key] = (declared === "array"
+					? Array.isArray(parsed)
+					: parsed !== null && typeof parsed === "object" && !Array.isArray(parsed))
+					? parsed
+					: raw;
 			} catch {
 				out[key] = raw;
 			}
@@ -182,103 +119,50 @@ export function coerceInvokeArgs(
 	return out;
 }
 
-/** Remove `spans` from `text`, taking each block's own line with it when it had
- *  one to itself. Widening is per-span and computed against the original offsets,
- *  so the surrounding answer is returned byte for byte — a blanket
- *  trailing-whitespace or blank-line normalization would edit prose and code the
- *  leak never touched. */
-function cutSpans(text: string, spans: ParsedInvoke[]): string {
-	let out = "";
-	let cursor = 0;
-	for (const span of spans) {
-		let start = span.start;
-		let end = span.end;
-		while (start > 0 && (text[start - 1] === " " || text[start - 1] === "\t")) start--;
-		while (end < text.length && (text[end] === " " || text[end] === "\t")) end++;
-		// Alone on its lines: take the line break too, or cutting leaves a hole.
-		const ownLine = (start === 0 || text[start - 1] === "\n") && text[end] === "\n";
-		if (ownLine) end++;
-		if (start < cursor) start = cursor; // adjacent blocks sharing a break
-		out += text.slice(cursor, start);
-		// A draft between two blank lines leaves both separators behind. One is
-		// the paragraph break the prose already had; the other only existed to
-		// set the draft apart, so it goes with it. Decided at this boundary, not
-		// by normalizing the whole answer.
-		if (ownLine && out.endsWith("\n\n") && text[end] === "\n") end++;
-		cursor = end;
-	}
-	out += text.slice(cursor);
-	return out.replace(EMPTY_WRAPPER, "").trim();
-}
-
 export interface RecoveredCall {
 	id: string;
-	/** pi tool name, already resolved and served. */
 	name: string;
 	arguments: Record<string, unknown>;
 }
 
 export interface InvokeRecoveryPlan {
-	/** Text blocks whose literal draft a real call now represents. */
-	rewrites: Array<{ blockIndex: number; text: string }>;
 	calls: RecoveredCall[];
 }
 
 export interface InvokeRecoveryOptions {
-	/** True when this turn already emitted a structured tool call. */
 	sawToolCall: boolean;
-	/** pi name for a name Claude wrote, or undefined when the bridge does not
-	 *  serve it this turn. */
 	resolveToolName: (name: string) => string | undefined;
-	/** The same argument shaping a structured tool_use gets, plus schema typing. */
 	mapArgs: (piName: string, args: Record<string, string>) => Record<string, unknown>;
 }
 
-/** What to do about literal invoke text in a finished turn, or null for the
- *  overwhelmingly common case of nothing to do.
+/** Plan recovered calls for a completed turn.
  *
- *  Pure: the caller applies the plan, which is what keeps this testable without a
- *  pi stream. Two rules do all the deciding:
- *
- *  - a tool the bridge does not serve this turn is left as plain text. Claude
- *    writing about a tool is not Claude calling one, and synthesizing a call
- *    nobody serves only trades a stall for a failure.
- *  - when the turn already has a structured call, nothing is synthesized. That
- *    turn continues on its own, and an extra call from a draft Claude did not
- *    dispatch would run a real side effect it never asked for. */
+ * Literal text is never suppressed: streaming may already have exposed it, and
+ * a same-name draft can differ from the structured call beside it. */
 export function planInvokeRecovery(
-	blocks: ReadonlyArray<{ type: string; text?: string; name?: string }>,
+	blocks: ReadonlyArray<{ type: string; text?: string }>,
 	options: InvokeRecoveryOptions,
 ): InvokeRecoveryPlan | null {
-	const rewrites: InvokeRecoveryPlan["rewrites"] = [];
 	const calls: RecoveredCall[] = [];
-	const structured = new Set(
-		blocks.filter((b) => b.type === "toolCall" && b.name).map((b) => b.name as string),
-	);
+	const recovered = new Set<string>();
 
-	blocks.forEach((block, blockIndex) => {
-		if (block.type !== "text" || !block.text) return;
-		const cut: ParsedInvoke[] = [];
+	blocks.forEach((block) => {
+		if (block.type !== "text" || !block.text || options.sawToolCall) return;
 		for (const invoke of parseInvokeBlocks(block.text)) {
 			const piName = options.resolveToolName(invoke.name);
 			if (!piName) continue;
-			// Matched by tool name only: a draft and the call it became routinely
-			// differ in their arguments, and suppressing on name is what stops the
-			// user seeing the same command twice.
-			if (structured.has(piName)) { cut.push(invoke); continue; }
-			if (options.sawToolCall) continue;
-			calls.push({ id: newRecoveredToolCallId(), name: piName, arguments: options.mapArgs(piName, invoke.arguments) });
-			cut.push(invoke);
+			const arguments_ = options.mapArgs(piName, invoke.arguments);
+			const identity = JSON.stringify([piName, arguments_]);
+			if (recovered.has(identity)) continue;
+			recovered.add(identity);
+			calls.push({ id: newRecoveredToolCallId(), name: piName, arguments: arguments_ });
 		}
-		if (cut.length) rewrites.push({ blockIndex, text: cutSpans(block.text, cut) });
 	});
 
-	return rewrites.length || calls.length ? { rewrites, calls } : null;
+	return calls.length ? { calls } : null;
 }
 
-/** True when the tool results pi just delivered include one for a call we
- *  synthesized. Walks the same context tail as extractAllToolResults: results
- *  back to the assistant message that owns them, past any steer between them. */
+/** Whether the newest turn contains a synthesized call result. */
 export function recoveredToolResultPending(
 	messages: ReadonlyArray<{ role: string; toolCallId?: string }>,
 ): boolean {

--- a/tests/unit-error-result.mjs
+++ b/tests/unit-error-result.mjs
@@ -26,7 +26,7 @@ function makeCtx() {
 
 async function consume(c, messages) {
 	async function* gen() { for (const m of messages) yield m; }
-	await __test.consumeQuery(gen(), new Map(), fakeModel, () => false, c);
+	await __test.consumeQuery(gen(), new Map(), fakeModel, () => false, c, []);
 }
 
 const errorResult = {

--- a/tests/unit-invoke-recovery.mjs
+++ b/tests/unit-invoke-recovery.mjs
@@ -1,0 +1,361 @@
+/**
+ * Issue #36: Claude sometimes types a tool call as literal invoke-tag text
+ * instead of emitting a structured tool_use block, mostly on long 1M-context
+ * sessions. When that is the turn's only action, pi sees an ordinary answer,
+ * nothing is dispatched, nothing fails, and the agent quietly stalls.
+ *
+ * These drive the real provider path — consumeQuery over faked SDK messages —
+ * because the whole bug is about what the turn ends as, and a plan the caller
+ * never applies proves nothing. The parser is exercised directly only where the
+ * hostile input matters more than the wiring.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { QueryContext } from "../src/query-state.js";
+import {
+	coerceInvokeArgs,
+	isRecoveredToolCallId,
+	parseInvokeBlocks,
+	recoveredToolResultPending,
+} from "../src/invoke-recovery.js";
+
+const { __test } = await import("../src/index.js");
+
+// The leak syntax is assembled, never written literally: a source file that
+// contains the raw tags gets read as a tool call by the harnesses that edit it.
+const LT = "<";
+const inv = (name, q = '"') => `${LT}invoke name=${q}${name}${q}>`;
+const invEnd = `${LT}/invoke>`;
+const param = (name, value, q = '"') => `${LT}parameter name=${q}${name}${q}>${value}${LT}/parameter>`;
+const paramOpen = (name) => `${LT}parameter name="${name}">`;
+const wrapOpen = `${LT}function_calls>`;
+const wrapEnd = `${LT}/function_calls>`;
+
+const fakeModel = { api: "anthropic-messages", provider: "anthropic", id: "test-model" };
+
+const toolMap = new Map([
+	["mcp__custom-tools__bash", "bash"],
+	["mcp__custom-tools__write", "write"],
+	["mcp__custom-tools__read", "read"],
+]);
+
+const mcpTools = [
+	{ name: "bash", parameters: { type: "object", properties: { command: { type: "string" }, timeout: { type: "number" } } } },
+	{ name: "write", parameters: { type: "object", properties: { path: { type: "string" }, content: { type: "string" } } } },
+	{ name: "read", parameters: { type: "object", properties: { path: { type: "string" }, limit: { type: "number" } } } },
+];
+
+function fakeStream() {
+	const events = [];
+	return { events, push: (e) => events.push(e), end: () => events.push({ type: "end" }) };
+}
+
+function makeCtx() {
+	const c = new QueryContext();
+	c.currentPiStream = fakeStream();
+	c.resetTurnState(fakeModel);
+	return c;
+}
+
+async function consume(c, messages) {
+	async function* gen() { for (const m of messages) yield m; }
+	await __test.consumeQuery(gen(), toolMap, fakeModel, () => false, c, mcpTools);
+}
+
+const streamEvent = (event) => ({ type: "stream_event", event });
+
+/** One text block, then the turn ends. `stopReason` is the raw Anthropic value. */
+function textTurn(text, stopReason = "end_turn") {
+	return [
+		streamEvent({ type: "message_start", message: {} }),
+		streamEvent({ type: "content_block_start", index: 0, content_block: { type: "text" } }),
+		streamEvent({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text } }),
+		streamEvent({ type: "content_block_stop", index: 0 }),
+		streamEvent({ type: "message_delta", delta: { stop_reason: stopReason } }),
+		streamEvent({ type: "message_stop" }),
+	];
+}
+
+const toolCalls = (c) => c.turnOutput.content.filter((b) => b.type === "toolCall");
+const texts = (c) => c.turnOutput.content.filter((b) => b.type === "text");
+
+describe("literal invoke text with no structured tool call", () => {
+	it("synthesizes the call the text describes and ends the turn on it", async () => {
+		const c = makeCtx();
+		// Recovery nulls currentPiStream the way the tool_use path does, so pi's
+		// next call can swap in its own stream. Hold the reference to inspect it.
+		const stream = c.currentPiStream;
+		await consume(c, textTurn([
+			"Running the suite now.",
+			"",
+			inv("bash"),
+			param("command", "npm test"),
+			invEnd,
+		].join("\n")));
+
+		const calls = toolCalls(c);
+		assert.strictEqual(calls.length, 1);
+		assert.strictEqual(calls[0].name, "bash");
+		// Same shaping a structured tool_use gets, bash's timeout default included.
+		assert.deepStrictEqual(calls[0].arguments, { command: "npm test", timeout: 120 });
+		assert.ok(isRecoveredToolCallId(calls[0].id), `id not recognizable: ${calls[0].id}`);
+
+		// The turn now continues instead of stalling.
+		assert.strictEqual(c.turnOutput.stopReason, "toolUse");
+		const done = stream.events.filter((e) => e.type === "done");
+		assert.deepStrictEqual(done.map((e) => e.reason), ["toolUse"]);
+		assert.strictEqual(stream.events.at(-1).type, "end");
+		assert.strictEqual(c.currentPiStream, null);
+
+		// The literal draft is gone from the answer, the prose around it is not.
+		assert.deepStrictEqual(texts(c).map((b) => b.text), ["Running the suite now."]);
+	});
+
+	it("never routes the synthesized id to an MCP handler that does not exist", async () => {
+		const c = makeCtx();
+		await consume(c, textTurn(inv("bash") + param("command", "ls") + invEnd));
+
+		// turnToolCallIds is what steers a delivered result to a waiting handler.
+		// CC ended this turn as plain text, so no handler is parked on the id: a
+		// result routed there would sit in pendingResults and wedge pi's turn.
+		assert.deepStrictEqual(c.turnToolCallIds, []);
+		assert.strictEqual(c.pendingToolCalls.size, 0);
+	});
+
+	it("keeps a multi-line code parameter verbatim and does not swallow its sibling", async () => {
+		const script = [
+			"#!/usr/bin/env bash",
+			"set -euo pipefail",
+			'if [ "$LHS" -lt "$RHS" ]; then',
+			'  echo "<not-a-tag> & 3 < 4"',
+			"fi",
+			"",
+		].join("\n");
+		const c = makeCtx();
+		await consume(c, textTurn([
+			inv("write"),
+			param("content", script),
+			param("file_path", "/tmp/check.sh"),
+			invEnd,
+		].join("\n")));
+
+		const calls = toolCalls(c);
+		assert.strictEqual(calls.length, 1);
+		assert.strictEqual(calls[0].arguments.content, script);
+		// file_path → path is the same rename a structured call gets, and proves
+		// the value search stopped at the right close tag rather than running on.
+		assert.strictEqual(calls[0].arguments.path, "/tmp/check.sh");
+	});
+
+	it("recovers every sibling invoke in one text run", async () => {
+		const c = makeCtx();
+		await consume(c, textTurn([
+			"Two steps:",
+			"",
+			wrapOpen,
+			inv("bash"),
+			param("command", "npm run build"),
+			invEnd,
+			inv("read"),
+			param("path", "/tmp/out.log"),
+			invEnd,
+			wrapEnd,
+		].join("\n")));
+
+		assert.deepStrictEqual(toolCalls(c).map((b) => b.name), ["bash", "read"]);
+		assert.deepStrictEqual(toolCalls(c).map((b) => b.arguments), [
+			{ command: "npm run build", timeout: 120 },
+			{ path: "/tmp/out.log" },
+		]);
+		// Distinct ids, or pi pairs both results to one call.
+		assert.notStrictEqual(toolCalls(c)[0].id, toolCalls(c)[1].id);
+		// The now-empty wrapper goes with them.
+		assert.deepStrictEqual(texts(c).map((b) => b.text), ["Two steps:"]);
+	});
+
+	it("leaves a tool the bridge does not serve as plain text", async () => {
+		const original = [
+			"You could do it with:",
+			"",
+			inv("WebFetch"),
+			param("url", "https://example.com"),
+			invEnd,
+		].join("\n");
+		const c = makeCtx();
+		await consume(c, textTurn(original));
+
+		// Synthesizing a call nobody serves only trades a stall for a failure.
+		assert.deepStrictEqual(toolCalls(c), []);
+		assert.deepStrictEqual(texts(c).map((b) => b.text), [original]);
+		assert.strictEqual(c.turnOutput.stopReason, "stop");
+	});
+
+	for (const [label, broken] of [
+		["truncated mid-value", `${inv("bash")}\n${paramOpen("command")}npm test`],
+		["parameter never closed", `${inv("bash")}${paramOpen("command")}npm test${invEnd}`],
+		["invoke never closed before its sibling", `${inv("bash")}\n${inv("bash")}${paramOpen("command")}ls`],
+		["opening tag only", inv("bash")],
+	]) {
+		it(`leaves a malformed invoke alone: ${label}`, async () => {
+			const original = `Here is what I would run:\n\n${broken}`;
+			const c = makeCtx();
+			await consume(c, textTurn(original));
+
+			assert.deepStrictEqual(toolCalls(c), []);
+			assert.deepStrictEqual(texts(c).map((b) => b.text), [original]);
+			assert.strictEqual(c.turnOutput.stopReason, "stop");
+		});
+	}
+
+	it("does not synthesize from a turn cut off at max_tokens", async () => {
+		// A length-capped turn can end mid-invoke, and text that merely looks
+		// finished there is the one case where synthesizing runs a half-written
+		// command. The stall it leaves behind is pi's to report, not ours to guess.
+		const original = inv("bash") + param("command", "rm -rf /tmp/scratch") + invEnd;
+		const c = makeCtx();
+		await consume(c, textTurn(original, "max_tokens"));
+
+		assert.deepStrictEqual(toolCalls(c), []);
+		assert.deepStrictEqual(texts(c).map((b) => b.text), [original]);
+		assert.strictEqual(c.turnOutput.stopReason, "length");
+	});
+});
+
+describe("literal invoke text alongside a real structured tool call", () => {
+	it("suppresses the stale draft and emits exactly one call", async () => {
+		const c = makeCtx();
+		const stream = c.currentPiStream;
+		await consume(c, [
+			streamEvent({ type: "message_start", message: {} }),
+			streamEvent({ type: "content_block_start", index: 0, content_block: { type: "text" } }),
+			streamEvent({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: [
+				"Let me check the tests.",
+				"",
+				inv("bash"),
+				param("command", "npm test --watch"),
+				invEnd,
+				"",
+				"Standing by.",
+			].join("\n") } }),
+			streamEvent({ type: "content_block_stop", index: 0 }),
+			streamEvent({ type: "content_block_start", index: 1, content_block: { type: "tool_use", name: "mcp__custom-tools__bash", id: "toolu_real", input: {} } }),
+			streamEvent({ type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: '{"command":"npm test"}' } }),
+			streamEvent({ type: "content_block_stop", index: 1 }),
+			streamEvent({ type: "message_delta", delta: { stop_reason: "tool_use" } }),
+			streamEvent({ type: "message_stop" }),
+		]);
+
+		// One call, and it is Claude's own — a draft it never dispatched must not
+		// become a second real side effect.
+		assert.deepStrictEqual(toolCalls(c).map((b) => b.id), ["toolu_real"]);
+		assert.deepStrictEqual(toolCalls(c)[0].arguments, { command: "npm test", timeout: 120 });
+		assert.deepStrictEqual(c.turnToolCallIds, ["toolu_real"]);
+
+		// The user is not shown the same command twice, and the answer around the
+		// draft survives.
+		assert.deepStrictEqual(texts(c).map((b) => b.text), ["Let me check the tests.\n\nStanding by."]);
+
+		// The final message pi keeps is the one `done` carries, so the cut has to
+		// be visible there.
+		const done = stream.events.filter((e) => e.type === "done");
+		assert.strictEqual(done.length, 1);
+		assert.strictEqual(done[0].reason, "toolUse");
+		assert.ok(!JSON.stringify(done[0].message.content).includes("invoke"));
+	});
+
+	it("suppresses on the assistant-message fallback path too", async () => {
+		const c = makeCtx();
+		await consume(c, [{
+			type: "assistant",
+			message: { content: [
+				{ type: "text", text: `Running it.\n\n${inv("bash")}\n${param("command", "ls")}\n${invEnd}` },
+				{ type: "tool_use", name: "mcp__custom-tools__bash", id: "toolu_real", input: { command: "ls -la" } },
+			] },
+		}]);
+
+		assert.deepStrictEqual(toolCalls(c).map((b) => b.id), ["toolu_real"]);
+		assert.deepStrictEqual(texts(c).map((b) => b.text), ["Running it."]);
+	});
+
+	it("leaves a draft for a different tool alone", async () => {
+		// A turn that already has a structured call continues on its own. Cutting
+		// unrelated text would delete an answer nothing replaced.
+		const draft = `${inv("write")}\n${param("file_path", "/tmp/a")}\n${param("content", "x")}\n${invEnd}`;
+		const c = makeCtx();
+		await consume(c, [
+			streamEvent({ type: "content_block_start", index: 0, content_block: { type: "text" } }),
+			streamEvent({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: draft } }),
+			streamEvent({ type: "content_block_stop", index: 0 }),
+			streamEvent({ type: "content_block_start", index: 1, content_block: { type: "tool_use", name: "mcp__custom-tools__bash", id: "toolu_real", input: {} } }),
+			streamEvent({ type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: "{}" } }),
+			streamEvent({ type: "content_block_stop", index: 1 }),
+			streamEvent({ type: "message_stop" }),
+		]);
+
+		assert.deepStrictEqual(toolCalls(c).map((b) => b.id), ["toolu_real"]);
+		assert.deepStrictEqual(texts(c).map((b) => b.text), [draft]);
+	});
+});
+
+describe("parseInvokeBlocks", () => {
+	it("reads namespaced tags and single quotes", () => {
+		const found = parseInvokeBlocks(`${LT}ns:invoke name='bash'>${LT}ns:parameter name='command'>ls${LT}/ns:parameter>${LT}/ns:invoke>`);
+		assert.deepStrictEqual(found.map((f) => [f.name, f.arguments]), [["bash", { command: "ls" }]]);
+	});
+
+	it("costs nothing on ordinary prose", () => {
+		assert.deepStrictEqual(parseInvokeBlocks("No tags here, just 1 < 2 and a </div>."), []);
+	});
+
+	it("keeps an empty-bodied invoke, which is a real no-argument call", () => {
+		assert.deepStrictEqual(parseInvokeBlocks(inv("ls") + invEnd).map((f) => f.arguments), [{}]);
+	});
+});
+
+describe("coerceInvokeArgs", () => {
+	const schema = { properties: { path: { type: "string" }, limit: { type: "number" }, all: { type: "boolean" } } };
+
+	it("types a value the tool declares as a number", () => {
+		assert.deepStrictEqual(coerceInvokeArgs({ path: "/etc/hosts", limit: "50" }, schema), { path: "/etc/hosts", limit: 50 });
+	});
+
+	it("leaves a declared string alone even when it looks like a number", () => {
+		// The trap this exists to avoid: a file body of `42` written as a number.
+		assert.deepStrictEqual(coerceInvokeArgs({ path: "42" }, schema), { path: "42" });
+	});
+
+	it("keeps text a declared type cannot represent, rather than mangling it", () => {
+		assert.deepStrictEqual(coerceInvokeArgs({ limit: "007", all: "yes" }, schema), { limit: "007", all: "yes" });
+	});
+
+	it("passes everything through when the tool has no schema", () => {
+		assert.deepStrictEqual(coerceInvokeArgs({ n: "1" }, undefined), { n: "1" });
+	});
+});
+
+describe("recoveredToolResultPending", () => {
+	const recovered = "toolu_recovered_deadbeef";
+
+	it("spots a result for a call we synthesized, past an interleaved steer", () => {
+		assert.strictEqual(recoveredToolResultPending([
+			{ role: "user" }, { role: "assistant" },
+			{ role: "toolResult", toolCallId: recovered },
+			{ role: "user" },
+		]), true);
+	});
+
+	it("ignores a result from Claude's own call", () => {
+		assert.strictEqual(recoveredToolResultPending([
+			{ role: "assistant" }, { role: "toolResult", toolCallId: "toolu_01real" },
+		]), false);
+	});
+
+	it("stops at the assistant message that owns the turn", () => {
+		// An older recovered result belongs to a turn pi already closed out.
+		assert.strictEqual(recoveredToolResultPending([
+			{ role: "toolResult", toolCallId: recovered },
+			{ role: "assistant" },
+			{ role: "toolResult", toolCallId: "toolu_01real" },
+		]), false);
+	});
+});

--- a/tests/unit-invoke-recovery.mjs
+++ b/tests/unit-invoke-recovery.mjs
@@ -16,6 +16,7 @@ import {
 	coerceInvokeArgs,
 	isRecoveredToolCallId,
 	parseInvokeBlocks,
+	planInvokeRecovery,
 	recoveredToolResultPending,
 } from "../src/invoke-recovery.js";
 
@@ -107,8 +108,9 @@ describe("literal invoke text with no structured tool call", () => {
 		assert.strictEqual(stream.events.at(-1).type, "end");
 		assert.strictEqual(c.currentPiStream, null);
 
-		// The literal draft is gone from the answer, the prose around it is not.
-		assert.deepStrictEqual(texts(c).map((b) => b.text), ["Running the suite now."]);
+		assert.deepStrictEqual(texts(c).map((b) => b.text), [[
+			"Running the suite now.", "", inv("bash"), param("command", "npm test"), invEnd,
+		].join("\n")]);
 	});
 
 	it("never routes the synthesized id to an MCP handler that does not exist", async () => {
@@ -169,8 +171,19 @@ describe("literal invoke text with no structured tool call", () => {
 		]);
 		// Distinct ids, or pi pairs both results to one call.
 		assert.notStrictEqual(toolCalls(c)[0].id, toolCalls(c)[1].id);
-		// The now-empty wrapper goes with them.
-		assert.deepStrictEqual(texts(c).map((b) => b.text), ["Two steps:"]);
+		assert.deepStrictEqual(texts(c).map((b) => b.text), [[
+			"Two steps:", "", wrapOpen, inv("bash"), param("command", "npm run build"),
+			invEnd, inv("read"), param("path", "/tmp/out.log"), invEnd, wrapEnd,
+		].join("\n")]);
+	});
+
+	it("deduplicates an identical call repeated across text blocks", () => {
+		const text = inv("bash") + param("command", "npm test") + invEnd;
+		const plan = planInvokeRecovery(
+			[{ type: "text", text }, { type: "text", text }],
+			{ sawToolCall: false, resolveToolName: (name) => name, mapArgs: (_name, args) => args },
+		);
+		assert.strictEqual(plan.calls.length, 1);
 	});
 
 	it("leaves a tool the bridge does not serve as plain text", async () => {
@@ -193,7 +206,10 @@ describe("literal invoke text with no structured tool call", () => {
 	for (const [label, broken] of [
 		["truncated mid-value", `${inv("bash")}\n${paramOpen("command")}npm test`],
 		["parameter never closed", `${inv("bash")}${paramOpen("command")}npm test${invEnd}`],
-		["invoke never closed before its sibling", `${inv("bash")}\n${inv("bash")}${paramOpen("command")}ls`],
+		["stray invoke-body text", `${inv("bash")}not a parameter${invEnd}`],
+		["duplicate parameter", `${inv("bash")}${param("command", "a")}${param("command", "b")}${invEnd}`],
+		["mismatched parameter close", `${LT}ns:invoke name="bash">${LT}ns:parameter name="command">ls${LT}/parameter>${LT}/ns:invoke>`],
+		["leftover tag", `${inv("bash")}${param("command", "ls")}${LT}/parameter>${invEnd}`],
 		["opening tag only", inv("bash")],
 	]) {
 		it(`leaves a malformed invoke alone: ${label}`, async () => {
@@ -222,21 +238,17 @@ describe("literal invoke text with no structured tool call", () => {
 });
 
 describe("literal invoke text alongside a real structured tool call", () => {
-	it("suppresses the stale draft and emits exactly one call", async () => {
+	it("preserves a same-name literal draft and emits only Claude's call", async () => {
 		const c = makeCtx();
 		const stream = c.currentPiStream;
+		const draft = [
+			"Let me check the tests.", "", inv("bash"), param("command", "npm test --watch"),
+			invEnd, "", "Standing by.",
+		].join("\n");
 		await consume(c, [
 			streamEvent({ type: "message_start", message: {} }),
 			streamEvent({ type: "content_block_start", index: 0, content_block: { type: "text" } }),
-			streamEvent({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: [
-				"Let me check the tests.",
-				"",
-				inv("bash"),
-				param("command", "npm test --watch"),
-				invEnd,
-				"",
-				"Standing by.",
-			].join("\n") } }),
+			streamEvent({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: draft } }),
 			streamEvent({ type: "content_block_stop", index: 0 }),
 			streamEvent({ type: "content_block_start", index: 1, content_block: { type: "tool_use", name: "mcp__custom-tools__bash", id: "toolu_real", input: {} } }),
 			streamEvent({ type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: '{"command":"npm test"}' } }),
@@ -245,53 +257,23 @@ describe("literal invoke text alongside a real structured tool call", () => {
 			streamEvent({ type: "message_stop" }),
 		]);
 
-		// One call, and it is Claude's own — a draft it never dispatched must not
-		// become a second real side effect.
 		assert.deepStrictEqual(toolCalls(c).map((b) => b.id), ["toolu_real"]);
-		assert.deepStrictEqual(toolCalls(c)[0].arguments, { command: "npm test", timeout: 120 });
-		assert.deepStrictEqual(c.turnToolCallIds, ["toolu_real"]);
-
-		// The user is not shown the same command twice, and the answer around the
-		// draft survives.
-		assert.deepStrictEqual(texts(c).map((b) => b.text), ["Let me check the tests.\n\nStanding by."]);
-
-		// The final message pi keeps is the one `done` carries, so the cut has to
-		// be visible there.
+		assert.deepStrictEqual(texts(c).map((b) => b.text), [draft]);
 		const done = stream.events.filter((e) => e.type === "done");
 		assert.strictEqual(done.length, 1);
-		assert.strictEqual(done[0].reason, "toolUse");
-		assert.ok(!JSON.stringify(done[0].message.content).includes("invoke"));
+		assert.ok(JSON.stringify(done[0].message.content).includes("invoke"));
 	});
 
-	it("suppresses on the assistant-message fallback path too", async () => {
+	it("preserves literal prose on the assistant-message fallback path", async () => {
 		const c = makeCtx();
+		const draft = `Running it.\n\n${inv("bash")}\n${param("command", "ls")}\n${invEnd}`;
 		await consume(c, [{
 			type: "assistant",
 			message: { content: [
-				{ type: "text", text: `Running it.\n\n${inv("bash")}\n${param("command", "ls")}\n${invEnd}` },
+				{ type: "text", text: draft },
 				{ type: "tool_use", name: "mcp__custom-tools__bash", id: "toolu_real", input: { command: "ls -la" } },
 			] },
 		}]);
-
-		assert.deepStrictEqual(toolCalls(c).map((b) => b.id), ["toolu_real"]);
-		assert.deepStrictEqual(texts(c).map((b) => b.text), ["Running it."]);
-	});
-
-	it("leaves a draft for a different tool alone", async () => {
-		// A turn that already has a structured call continues on its own. Cutting
-		// unrelated text would delete an answer nothing replaced.
-		const draft = `${inv("write")}\n${param("file_path", "/tmp/a")}\n${param("content", "x")}\n${invEnd}`;
-		const c = makeCtx();
-		await consume(c, [
-			streamEvent({ type: "content_block_start", index: 0, content_block: { type: "text" } }),
-			streamEvent({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: draft } }),
-			streamEvent({ type: "content_block_stop", index: 0 }),
-			streamEvent({ type: "content_block_start", index: 1, content_block: { type: "tool_use", name: "mcp__custom-tools__bash", id: "toolu_real", input: {} } }),
-			streamEvent({ type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: "{}" } }),
-			streamEvent({ type: "content_block_stop", index: 1 }),
-			streamEvent({ type: "message_stop" }),
-		]);
-
 		assert.deepStrictEqual(toolCalls(c).map((b) => b.id), ["toolu_real"]);
 		assert.deepStrictEqual(texts(c).map((b) => b.text), [draft]);
 	});
@@ -303,33 +285,30 @@ describe("parseInvokeBlocks", () => {
 		assert.deepStrictEqual(found.map((f) => [f.name, f.arguments]), [["bash", { command: "ls" }]]);
 	});
 
-	it("costs nothing on ordinary prose", () => {
-		assert.deepStrictEqual(parseInvokeBlocks("No tags here, just 1 < 2 and a </div>."), []);
+	it("rejects stray text, duplicate names, and mismatched or leftover tags", () => {
+		for (const broken of [
+			`${inv("bash")}stray${invEnd}`,
+			`${inv("bash")}${param("command", "a")}${param("command", "b")}${invEnd}`,
+			`${LT}ns:invoke name="bash">${LT}ns:parameter name="command">ls${LT}/parameter>${LT}/ns:invoke>`,
+			`${inv("bash")}${param("command", "ls")}${LT}/parameter>${invEnd}`,
+		]) assert.deepStrictEqual(parseInvokeBlocks(broken), []);
 	});
 
-	it("keeps an empty-bodied invoke, which is a real no-argument call", () => {
-		assert.deepStrictEqual(parseInvokeBlocks(inv("ls") + invEnd).map((f) => f.arguments), [{}]);
-	});
 });
 
 describe("coerceInvokeArgs", () => {
-	const schema = { properties: { path: { type: "string" }, limit: { type: "number" }, all: { type: "boolean" } } };
-
+	const schema = { properties: { path: { type: "string" }, limit: { type: "number" }, count: { type: "integer" }, all: { type: "boolean" } } };
 	it("types a value the tool declares as a number", () => {
 		assert.deepStrictEqual(coerceInvokeArgs({ path: "/etc/hosts", limit: "50" }, schema), { path: "/etc/hosts", limit: 50 });
 	});
-
-	it("leaves a declared string alone even when it looks like a number", () => {
-		// The trap this exists to avoid: a file body of `42` written as a number.
-		assert.deepStrictEqual(coerceInvokeArgs({ path: "42" }, schema), { path: "42" });
+	it("requires integers and rejects arrays for object parameters", () => {
+		assert.deepStrictEqual(coerceInvokeArgs(
+			{ count: "1.5", object: "[]", validObject: "{\"ok\":true}" },
+			{ properties: { count: { type: "integer" }, object: { type: "object" }, validObject: { type: "object" } } },
+		), { count: "1.5", object: "[]", validObject: { ok: true } });
 	});
-
-	it("keeps text a declared type cannot represent, rather than mangling it", () => {
+	it("leaves text a declared type cannot represent", () => {
 		assert.deepStrictEqual(coerceInvokeArgs({ limit: "007", all: "yes" }, schema), { limit: "007", all: "yes" });
-	});
-
-	it("passes everything through when the tool has no schema", () => {
-		assert.deepStrictEqual(coerceInvokeArgs({ n: "1" }, undefined), { n: "1" });
 	});
 });
 

--- a/tests/unit-stream-replay.mjs
+++ b/tests/unit-stream-replay.mjs
@@ -43,7 +43,7 @@ async function replay(name, { toolNames = ["read"] } = {}) {
 
 	const messages = fixture(name);
 	async function* stream() { for (const m of messages) yield m; }
-	const { capturedSessionId } = await __test.consumeQuery(stream(), customToolNameToPi, model, () => false, c);
+	const { capturedSessionId } = await __test.consumeQuery(stream(), customToolNameToPi, model, () => false, c, []);
 	return { events, ctx: c, messages, capturedSessionId };
 }
 

--- a/tests/unit-unserved-tool-use.mjs
+++ b/tests/unit-unserved-tool-use.mjs
@@ -32,7 +32,7 @@ function makeCtx() {
 
 async function consume(c, messages) {
 	async function* gen() { for (const m of messages) yield m; }
-	await __test.consumeQuery(gen(), toolMap, fakeModel, () => false, c);
+	await __test.consumeQuery(gen(), toolMap, fakeModel, () => false, c, []);
 }
 
 const streamEvent = (event) => ({ type: "stream_event", event });


### PR DESCRIPTION
Recover complete literal `<invoke>` tool calls that Claude emits instead of structured `tool_use`.

The parser rejects malformed calls, unknown tools, duplicate parameters, and invalid schema coercions. It deduplicates repeated calls and leaves literal text visible.

Risk: the bridge still promotes model text into executable tool calls. Quoted or injected invoke text can therefore run. Keep this PR draft until the execution boundary is agreed.

Fixes #36.
