### PR TITLE
fix: derive AskClaude schema from configured defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- **Fix: AskClaude reports its effective configured defaults (issue #65)** — its schema, description, and TUI now agree on mode and isolation, and disabling full mode removes it from the enum.
+
 - **Fix: better isolate AskClaude tool (issue #59)** — AskClaude children no longer inherit the user's `~/.claude` `CLAUDE.md` files or skill listing, and now always get Claude Code's system prompt preset instead of only when pi-side skills exist. Thanks @JAtkinsonKO.
 - **Fix: Bogus debug message about "record count mismatch" after switching providers** — the post-rebuild integrity check did not take `@file` expansion into account when switching providers.
 

--- a/src/askclaude-schema.ts
+++ b/src/askclaude-schema.ts
@@ -14,11 +14,22 @@ const PACKAGE_DEFAULT_MODE: AskClaudeMode = "read";
 const PACKAGE_DEFAULT_ISOLATED = false;
 
 export function resolveAskClaudeDefaults(conf: Config["askClaude"]): AskClaudeDefaults {
-	const allowFull = conf?.allowFullMode !== false;
-	const configuredMode = conf?.defaultMode ?? PACKAGE_DEFAULT_MODE;
-	// The full-mode lockout must also override a configured default.
-	const mode = !allowFull && configuredMode === "full" ? PACKAGE_DEFAULT_MODE : configuredMode;
-	return { mode, isolated: conf?.defaultIsolated ?? PACKAGE_DEFAULT_ISOLATED, allowFull };
+	const rawAllowFull: unknown = conf?.allowFullMode;
+	const allowFull = rawAllowFull == null ? true : rawAllowFull === true;
+	const configuredMode: unknown = conf?.defaultMode;
+	const mode = configuredMode == null
+		? PACKAGE_DEFAULT_MODE
+		: configuredMode === "full" || configuredMode === "read" || configuredMode === "none"
+			? configuredMode
+			: "none";
+	return { mode: !allowFull && mode === "full" ? PACKAGE_DEFAULT_MODE : mode, isolated: conf?.defaultIsolated ?? PACKAGE_DEFAULT_ISOLATED, allowFull };
+}
+
+export function resolveAskClaudeMode(mode: unknown, defaults: AskClaudeDefaults): AskClaudeMode {
+	const resolved = mode === undefined ? defaults.mode : mode;
+	if (resolved !== "full" && resolved !== "read" && resolved !== "none") throw new Error(`Invalid AskClaude mode: ${String(resolved)}`);
+	if (resolved === "full" && !defaults.allowFull) throw new Error("AskClaude full mode is disabled.");
+	return resolved;
 }
 
 function modeDescription(defaults: AskClaudeDefaults): string {
@@ -49,8 +60,8 @@ export function buildAskClaudeParams(defaults: AskClaudeDefaults) {
 	});
 }
 
-export function askClaudeToolDescription(defaults: AskClaudeDefaults, override?: string): string {
-	if (override !== undefined) return override;
+export function askClaudeToolDescription(defaults: AskClaudeDefaults, override?: string | null): string {
+	if (override != null) return override;
 	const suffix = " Prefer to handle straightforward tasks yourself.";
 	if (!defaults.allowFull) {
 		const middle = defaults.mode === "none"
@@ -72,7 +83,7 @@ export function askClaudeCallTags(
 ): string[] {
 	const tags: string[] = [];
 	const mode = args.mode ?? defaults.mode;
-	if (mode !== PACKAGE_DEFAULT_MODE) tags.push(`mode=${mode}`);
+	if (mode !== PACKAGE_DEFAULT_MODE || (args.mode !== undefined && args.mode !== defaults.mode)) tags.push(`mode=${mode}`);
 	if (args.model) tags.push(`model=${args.model}`);
 	if (args.thinking) tags.push(`thinking=${args.thinking}`);
 	if ((args.isolated ?? defaults.isolated) !== PACKAGE_DEFAULT_ISOLATED) tags.push("isolated");

--- a/src/askclaude-schema.ts
+++ b/src/askclaude-schema.ts
@@ -1,0 +1,80 @@
+import { StringEnum } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import type { Config } from "./config.js";
+
+export type AskClaudeMode = "full" | "read" | "none";
+
+export interface AskClaudeDefaults {
+	mode: AskClaudeMode;
+	isolated: boolean;
+	allowFull: boolean;
+}
+
+const PACKAGE_DEFAULT_MODE: AskClaudeMode = "read";
+const PACKAGE_DEFAULT_ISOLATED = false;
+
+export function resolveAskClaudeDefaults(conf: Config["askClaude"]): AskClaudeDefaults {
+	const allowFull = conf?.allowFullMode !== false;
+	const configuredMode = conf?.defaultMode ?? PACKAGE_DEFAULT_MODE;
+	// The full-mode lockout must also override a configured default.
+	const mode = !allowFull && configuredMode === "full" ? PACKAGE_DEFAULT_MODE : configuredMode;
+	return { mode, isolated: conf?.defaultIsolated ?? PACKAGE_DEFAULT_ISOLATED, allowFull };
+}
+
+function modeDescription(defaults: AskClaudeDefaults): string {
+	const mark = (mode: AskClaudeMode) => (mode === defaults.mode ? " (default)" : "");
+	const parts = [
+		`"read"${mark("read")}: questions about the codebase — review, analysis, explain.`,
+		`"none"${mark("none")}: general knowledge only (no file access).`,
+	];
+	if (defaults.allowFull) {
+		parts.push(`"full"${mark("full")}: allows writing and bash execution (careful: runs without feedback to pi).`);
+	}
+	return parts.join(" ");
+}
+
+export function buildAskClaudeParams(defaults: AskClaudeDefaults) {
+	const visibility = defaults.isolated
+		? "By default Claude sees only this prompt (isolated session)."
+		: "By default Claude sees the full conversation history.";
+	const trueDefault = defaults.isolated ? " (default)" : "";
+	const falseDefault = defaults.isolated ? "" : " (default)";
+	const modeValues: readonly AskClaudeMode[] = defaults.allowFull ? ["read", "full", "none"] : ["read", "none"];
+	return Type.Object({
+		prompt: Type.String({ description: `The question or task for Claude Code. ${visibility} Don't research up front, let Claude explore.` }),
+		mode: Type.Optional(StringEnum(modeValues, { description: modeDescription(defaults) })),
+		model: Type.Optional(Type.String({ description: 'Claude model (e.g. "opus", "sonnet", "haiku", or full ID). Defaults to "opus".' })),
+		thinking: Type.Optional(StringEnum(["off", "minimal", "low", "medium", "high", "xhigh"] as const, { description: "Thinking effort level. Omit to use Claude Code's default." })),
+		isolated: Type.Optional(Type.Boolean({ description: `When true${trueDefault}, Claude sees only this prompt (clean session). When false${falseDefault}, Claude sees the full conversation history.` })),
+	});
+}
+
+export function askClaudeToolDescription(defaults: AskClaudeDefaults, override?: string): string {
+	if (override !== undefined) return override;
+	const suffix = " Prefer to handle straightforward tasks yourself.";
+	if (!defaults.allowFull) {
+		const middle = defaults.mode === "none"
+			? 'Defaults to no file access — pass mode "read" to let Claude Code explore the codebase; it can never make changes.'
+			: "Read-only — Claude Code can explore the codebase but not make changes.";
+		return `Delegate to Claude Code for a second opinion or analysis (code review, architecture questions, debugging theories). ${middle}${suffix}`;
+	}
+	const middle = defaults.mode === "full"
+		? 'Defaults to full mode — Claude Code writes files and runs bash without feedback to pi; pass mode "read" to keep it to exploration.'
+		: defaults.mode === "none"
+			? 'Defaults to no file access — pass mode "read" to let Claude Code explore the codebase, or "full" for a task that requires changes.'
+			: "Defaults to read-only mode — use full mode when the user wants to delegate a task that requires changes.";
+	return `Delegate to Claude Code for a second opinion or analysis (code review, architecture questions, debugging theories), or to autonomously handle a task. ${middle}${suffix}`;
+}
+
+export function askClaudeCallTags(
+	args: { mode?: AskClaudeMode; model?: string; thinking?: string; isolated?: boolean },
+	defaults: AskClaudeDefaults,
+): string[] {
+	const tags: string[] = [];
+	const mode = args.mode ?? defaults.mode;
+	if (mode !== PACKAGE_DEFAULT_MODE) tags.push(`mode=${mode}`);
+	if (args.model) tags.push(`model=${args.model}`);
+	if (args.thinking) tags.push(`thinking=${args.thinking}`);
+	if ((args.isolated ?? defaults.isolated) !== PACKAGE_DEFAULT_ISOLATED) tags.push("isolated");
+	return tags;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
-import { calculateCost, StringEnum, type AssistantMessage, type AssistantMessageEventStream, type Context, type ImageContent, type Model, type SimpleStreamOptions, type TextContent, type Tool, type UserMessage } from "@earendil-works/pi-ai";
+import { calculateCost, type AssistantMessage, type AssistantMessageEventStream, type Context, type ImageContent, type Model, type SimpleStreamOptions, type TextContent, type Tool, type UserMessage } from "@earendil-works/pi-ai";
 import * as piAi from "@earendil-works/pi-ai";
 import { getModels } from "@earendil-works/pi-ai/compat";
 import { buildSessionContext, compact, generateBranchSummary, keyHint, type BranchSummaryResult, type CompactionEntry, type ExtensionAPI, type ExtensionContext, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import { query, type EffortLevel, type SDKMessage, type SettingSource } from "@anthropic-ai/claude-agent-sdk";
 import type { Base64ImageSource, ContentBlockParam } from "@anthropic-ai/sdk/resources";
-import { Type } from "typebox";
 import { Text } from "@earendil-works/pi-tui";
 import { createSession, deleteSession, openSession, repairToolPairing } from "cc-session-io";
 import { appendFileSync, mkdirSync, realpathSync, statSync } from "fs";
@@ -26,6 +25,7 @@ import {
 import { collectCarriedAttachments, placeCarriedAttachments, type CarriedAttachment } from "./attachments.js";
 import { createToolServer } from "./mcp-server.js";
 import { buildActionSummary, type ToolCallState } from "./askclaude-ui.js";
+import { askClaudeCallTags, askClaudeToolDescription, buildAskClaudeParams, resolveAskClaudeDefaults } from "./askclaude-schema.js";
 
 // Compat (#2): use factory if available (pi-ai ≥0.66), else fall back to constructor (gsd-pi etc.)
 const _piAi = piAi as any;
@@ -1915,9 +1915,6 @@ async function promptAndWait(
 
 // --- Extension registration ---
 
-const DEFAULT_TOOL_DESCRIPTION_FULL = "Delegate to Claude Code for a second opinion or analysis (code review, architecture questions, debugging theories), or to autonomously handle a task. Defaults to read-only mode — use full mode when the user wants to delegate a task that requires changes. Prefer to handle straightforward tasks yourself.";
-const DEFAULT_TOOL_DESCRIPTION = "Delegate to Claude Code for a second opinion or analysis (code review, architecture questions, debugging theories). Read-only — Claude Code can explore the codebase but not make changes. Prefer to handle straightforward tasks yourself.";
-
 const PREVIEW_MAX_CHARS = 1000;
 const PREVIEW_MAX_LINES = 6;
 
@@ -2092,36 +2089,19 @@ export default function (pi: ExtensionAPI) {
 	// --- AskClaude tool ---
 
 	const askConf = config.askClaude;
-	const allowFull = askConf?.allowFullMode !== false;
-	const defaultMode = askConf?.defaultMode ?? "read";
-	const defaultIsolated = askConf?.defaultIsolated ?? false;
+	const askDefaults = resolveAskClaudeDefaults(askConf);
 	askClaudeToolName = askConf?.name ?? "AskClaude";
 
-	const modeValues = allowFull ? ["read", "full", "none"] as const : ["read", "none"] as const;
-	let modeDesc = `"read" (default): questions about the codebase — review, analysis, explain. "none": general knowledge only (no file access).`;
-	if (allowFull) modeDesc += ` "full": allows writing and bash execution (careful: runs without feedback to pi).`;
-
 	if (askConf?.enabled) {
-		const askClaudeParams = Type.Object({
-			prompt: Type.String({ description: "The question or task for Claude Code. By default Claude sees the full conversation history. Don't research up front, let Claude explore." }),
-			mode: Type.Optional(StringEnum(modeValues, { description: modeDesc })),
-			model: Type.Optional(Type.String({ description: 'Claude model (e.g. "opus", "sonnet", "haiku", or full ID). Defaults to "opus".' })),
-			thinking: Type.Optional(StringEnum(["off", "minimal", "low", "medium", "high", "xhigh"] as const, { description: "Thinking effort level. Omit to use Claude Code's default." })),
-			isolated: Type.Optional(Type.Boolean({ description: "When true, Claude sees only this prompt (clean session). When false (default), Claude sees the full conversation history." })),
-		});
+		const askClaudeParams = buildAskClaudeParams(askDefaults);
 		pi.registerTool<typeof askClaudeParams>({
 			name: askConf?.name ?? "AskClaude",
 			label: askConf?.label ?? "Ask Claude Code",
-			description: askConf?.description ?? (allowFull ? DEFAULT_TOOL_DESCRIPTION_FULL : DEFAULT_TOOL_DESCRIPTION),
+			description: askClaudeToolDescription(askDefaults, askConf?.description),
 			parameters: askClaudeParams,
 			renderCall(args, theme) {
 				let text = theme.fg("mdLink", theme.bold("AskClaude "));
-				const mode = args.mode ?? defaultMode;
-				const tags: string[] = [];
-				if (mode !== defaultMode) tags.push(`mode=${mode}`);
-				if (args.model) tags.push(`model=${args.model}`);
-				if (args.thinking) tags.push(`thinking=${args.thinking}`);
-				if (args.isolated) tags.push("isolated");
+				const tags = askClaudeCallTags(args, askDefaults);
 				if (tags.length) text += `${theme.fg("accent", `[${tags.join(", ")}]`)} `;
 				const truncated = args.prompt.length > PREVIEW_MAX_CHARS ? args.prompt.substring(0, PREVIEW_MAX_CHARS) : args.prompt;
 				const lines = truncated.split("\n").slice(0, PREVIEW_MAX_LINES);
@@ -2169,8 +2149,8 @@ export default function (pi: ExtensionAPI) {
 					};
 				}
 
-				const mode = (params.mode ?? defaultMode) as "full" | "read" | "none";
-				const isolated = params.isolated ?? defaultIsolated;
+				const mode = params.mode ?? askDefaults.mode;
+				const isolated = params.isolated ?? askDefaults.isolated;
 				const toolCalls = new Map<string, ToolCallState>();
 				const start = Date.now();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import {
 import { collectCarriedAttachments, placeCarriedAttachments, type CarriedAttachment } from "./attachments.js";
 import { createToolServer } from "./mcp-server.js";
 import { buildActionSummary, type ToolCallState } from "./askclaude-ui.js";
-import { askClaudeCallTags, askClaudeToolDescription, buildAskClaudeParams, resolveAskClaudeDefaults } from "./askclaude-schema.js";
+import { askClaudeCallTags, askClaudeToolDescription, buildAskClaudeParams, resolveAskClaudeDefaults, resolveAskClaudeMode, type AskClaudeMode } from "./askclaude-schema.js";
 
 // Compat (#2): use factory if available (pi-ai ≥0.66), else fall back to constructor (gsd-pi etc.)
 const _piAi = piAi as any;
@@ -186,10 +186,8 @@ const ASKCLAUDE_ALWAYS_BLOCKED = [
 	"ToolSearch", // probes for blocked tools, wastes tokens
 	"ScheduleWakeup", // no harness to fire wakeup from inside a delegated subagent
 ];
-const MODE_DISALLOWED_TOOLS: Record<string, string[]> = {
-	full: [
-		...ASKCLAUDE_ALWAYS_BLOCKED,
-	],
+const MODE_DISALLOWED_TOOLS: Record<AskClaudeMode, string[]> = {
+	full: ASKCLAUDE_ALWAYS_BLOCKED,
 	read: [
 		...ASKCLAUDE_ALWAYS_BLOCKED,
 		"Write", "Edit", "Bash", "NotebookEdit",
@@ -1768,7 +1766,7 @@ async function promptAndWait(
 	}
 
 	// Mode → disallowed tools
-	const disallowedTools = MODE_DISALLOWED_TOOLS[mode] ?? [];
+	const disallowedTools = MODE_DISALLOWED_TOOLS[mode];
 
 	// AskClaude uses Claude Code's native Read tool rather than Pi's MCP bridge.
 	// Same resolver as the provider path: a prompt neither recorded nor derivable
@@ -2149,7 +2147,7 @@ export default function (pi: ExtensionAPI) {
 					};
 				}
 
-				const mode = params.mode ?? askDefaults.mode;
+				const mode = resolveAskClaudeMode(params.mode, askDefaults);
 				const isolated = params.isolated ?? askDefaults.isolated;
 				const toolCalls = new Map<string, ToolCallState>();
 				const start = Date.now();

--- a/tests/unit-askclaude-schema.mjs
+++ b/tests/unit-askclaude-schema.mjs
@@ -1,0 +1,88 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+	askClaudeCallTags,
+	askClaudeToolDescription,
+	buildAskClaudeParams,
+	resolveAskClaudeDefaults,
+} from "../src/askclaude-schema.js";
+
+const props = (conf) => buildAskClaudeParams(resolveAskClaudeDefaults(conf)).properties;
+const toolDescription = (conf) => askClaudeToolDescription(resolveAskClaudeDefaults(conf), conf?.description);
+const tags = (args, conf) => askClaudeCallTags(args, resolveAskClaudeDefaults(conf));
+
+describe("default configuration", () => {
+	it("keeps the existing descriptions", () => {
+		const parameters = props(undefined);
+		assert.equal(parameters.prompt.description, "The question or task for Claude Code. By default Claude sees the full conversation history. Don't research up front, let Claude explore.");
+		assert.equal(parameters.mode.description, '"read" (default): questions about the codebase — review, analysis, explain. "none": general knowledge only (no file access). "full": allows writing and bash execution (careful: runs without feedback to pi).');
+		assert.equal(parameters.isolated.description, "When true, Claude sees only this prompt (clean session). When false (default), Claude sees the full conversation history.");
+		assert.equal(toolDescription(undefined), "Delegate to Claude Code for a second opinion or analysis (code review, architecture questions, debugging theories), or to autonomously handle a task. Defaults to read-only mode — use full mode when the user wants to delegate a task that requires changes. Prefer to handle straightforward tasks yourself.");
+	});
+
+	it("offers every mode and tags nothing on a bare call", () => {
+		assert.deepEqual(props({}).mode.enum, ["read", "full", "none"]);
+		assert.deepEqual(tags({ prompt: "hi" }, {}), []);
+	});
+
+	it("tags explicit non-default options", () => {
+		assert.deepEqual(tags({ prompt: "hi", mode: "full", model: "sonnet", thinking: "high", isolated: true }, {}),
+			["mode=full", "model=sonnet", "thinking=high", "isolated"]);
+	});
+});
+
+describe("defaultMode: full", () => {
+	const conf = { defaultMode: "full" };
+
+	it("states full as the default", () => {
+		assert.match(props(conf).mode.description, /"full" \(default\)/);
+		assert.doesNotMatch(props(conf).mode.description, /"read" \(default\)/);
+		assert.match(toolDescription(conf), /Defaults to full mode/);
+	});
+
+	it("shows inherited write access in the status line", () => {
+		assert.deepEqual(tags({ prompt: "review this" }, conf), ["mode=full"]);
+		assert.deepEqual(tags({ prompt: "review this", mode: "read" }, conf), []);
+	});
+});
+
+describe("defaultIsolated: true", () => {
+	const conf = { defaultIsolated: true };
+
+	it("states isolation as the default", () => {
+		const parameters = props(conf);
+		assert.equal(parameters.isolated.description, "When true (default), Claude sees only this prompt (clean session). When false, Claude sees the full conversation history.");
+		assert.match(parameters.prompt.description, /By default Claude sees only this prompt \(isolated session\)\./);
+	});
+
+	it("shows inherited isolation in the status line", () => {
+		assert.deepEqual(tags({ prompt: "review this" }, conf), ["isolated"]);
+		assert.deepEqual(tags({ prompt: "review this", isolated: false }, conf), []);
+	});
+});
+
+describe("allowFullMode: false", () => {
+	it("removes full from the schema", () => {
+		const parameters = props({ allowFullMode: false });
+		assert.deepEqual(parameters.mode.enum, ["read", "none"]);
+		assert.doesNotMatch(parameters.mode.description, /"full"/);
+	});
+
+	it("overrides a conflicting full default", () => {
+		const conf = { allowFullMode: false, defaultMode: "full" };
+		assert.equal(resolveAskClaudeDefaults(conf).mode, "read");
+		assert.deepEqual(tags({ prompt: "hi" }, conf), []);
+	});
+});
+
+describe("other configured defaults", () => {
+	it("states and renders none as the default mode", () => {
+		assert.match(props({ defaultMode: "none" }).mode.description, /"none" \(default\)/);
+		assert.match(toolDescription({ defaultMode: "none" }), /Defaults to no file access/);
+		assert.deepEqual(tags({ prompt: "what is a monad" }, { defaultMode: "none" }), ["mode=none"]);
+	});
+
+	it("preserves a description override verbatim", () => {
+		assert.equal(toolDescription({ description: "Ask the other Claude.", defaultMode: "full", defaultIsolated: true }), "Ask the other Claude.");
+	});
+});

--- a/tests/unit-askclaude-schema.mjs
+++ b/tests/unit-askclaude-schema.mjs
@@ -5,6 +5,7 @@ import {
 	askClaudeToolDescription,
 	buildAskClaudeParams,
 	resolveAskClaudeDefaults,
+	resolveAskClaudeMode,
 } from "../src/askclaude-schema.js";
 
 const props = (conf) => buildAskClaudeParams(resolveAskClaudeDefaults(conf)).properties;
@@ -40,9 +41,9 @@ describe("defaultMode: full", () => {
 		assert.match(toolDescription(conf), /Defaults to full mode/);
 	});
 
-	it("shows inherited write access in the status line", () => {
+	it("shows inherited write access and a read-only override in the status line", () => {
 		assert.deepEqual(tags({ prompt: "review this" }, conf), ["mode=full"]);
-		assert.deepEqual(tags({ prompt: "review this", mode: "read" }, conf), []);
+		assert.deepEqual(tags({ prompt: "review this", mode: "read" }, conf), ["mode=read"]);
 	});
 });
 
@@ -73,16 +74,50 @@ describe("allowFullMode: false", () => {
 		assert.equal(resolveAskClaudeDefaults(conf).mode, "read");
 		assert.deepEqual(tags({ prompt: "hi" }, conf), []);
 	});
+
+	it("rejects full mode during execution even if a caller bypasses the schema", () => {
+		const defaults = resolveAskClaudeDefaults({ allowFullMode: false });
+		assert.throws(() => resolveAskClaudeMode("full", defaults), /full mode is disabled/);
+		assert.throws(() => resolveAskClaudeMode("unexpected", defaults), /Invalid AskClaude mode/);
+		assert.throws(() => resolveAskClaudeMode(null, defaults), /Invalid AskClaude mode/);
+		assert.equal(resolveAskClaudeMode(undefined, defaults), "read");
+	});
+
+	it("fails closed for a malformed non-boolean allowFullMode", () => {
+		assert.equal(resolveAskClaudeDefaults({ allowFullMode: "false" }).allowFull, false);
+		assert.equal(resolveAskClaudeDefaults({ allowFullMode: 0 }).allowFull, false);
+	});
+
+	it("keeps the package default true for a null or omitted allowFullMode", () => {
+		assert.equal(resolveAskClaudeDefaults({ allowFullMode: null }).allowFull, true);
+		assert.equal(resolveAskClaudeDefaults({}).allowFull, true);
+		assert.equal(resolveAskClaudeDefaults(undefined).allowFull, true);
+	});
 });
 
 describe("other configured defaults", () => {
-	it("states and renders none as the default mode", () => {
-		assert.match(props({ defaultMode: "none" }).mode.description, /"none" \(default\)/);
-		assert.match(toolDescription({ defaultMode: "none" }), /Defaults to no file access/);
-		assert.deepEqual(tags({ prompt: "what is a monad" }, { defaultMode: "none" }), ["mode=none"]);
+	it("states and renders none as the default mode, including an explicit read escalation", () => {
+		const conf = { defaultMode: "none" };
+		assert.match(props(conf).mode.description, /"none" \(default\)/);
+		assert.match(toolDescription(conf), /Defaults to no file access/);
+		assert.deepEqual(tags({ prompt: "what is a monad" }, conf), ["mode=none"]);
+		assert.deepEqual(tags({ prompt: "review this", mode: "read" }, conf), ["mode=read"]);
 	});
 
-	it("preserves a description override verbatim", () => {
-		assert.equal(toolDescription({ description: "Ask the other Claude.", defaultMode: "full", defaultIsolated: true }), "Ask the other Claude.");
+	it("falls back to generated text for a null description", () => {
+		assert.equal(toolDescription({ description: null }), toolDescription({}));
+	});
+
+	it("returns a non-null configured description verbatim", () => {
+		const conf = { defaultMode: "none", description: "Custom override text" };
+		assert.equal(toolDescription(conf), "Custom override text");
+	});
+
+	it("treats a null configured mode as unset, falling back to the package default", () => {
+		assert.equal(resolveAskClaudeDefaults({ defaultMode: null }).mode, "read");
+	});
+
+	it("fails closed for an invalid configured mode", () => {
+		assert.equal(resolveAskClaudeDefaults({ defaultMode: "unexpected" }).mode, "none");
 	});
 });


### PR DESCRIPTION
Make AskClaude's schema, tags, description, and runtime policy match its configured defaults.

- hide full mode when disabled and reject bypass attempts at execution
- show risky defaults and explicit mode changes in the status line
- fail closed on invalid modes
- use the generated description when config supplies null

Fixes #65.
