### PR TITLE
fix: recover from Claude stream failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- **Fix: classify and recover from Claude stream failures (issues #35, #43, #58)** — exhausted subscription limits reach Pi's model fallback, a transient overload before output retries once, and a tool-aware watchdog aborts half-open streams.
+
 - **Fix: better isolate AskClaude tool (issue #59)** — AskClaude children no longer inherit the user's `~/.claude` `CLAUDE.md` files or skill listing, and now always get Claude Code's system prompt preset instead of only when pi-side skills exist. Thanks @JAtkinsonKO.
 - **Fix: Bogus debug message about "record count mismatch" after switching providers** — the post-rebuild integrity check did not take `@file` expansion into account when switching providers.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - **Fix: classify and recover from Claude stream failures (issues #35, #43, #58)** — exhausted subscription limits reach Pi's model fallback, a transient overload before output retries once, and a tool-aware watchdog aborts half-open streams.
 
+- **Fix: the same rate-limit warning notified once per concurrent stream** — every subagent's stream carries its own `rate_limit_event` frames for one account-wide state, and a long stream re-emits them as its headers refresh, so a session with three subagents printed the same "78% used" warning four times. Warnings are now deduped per rate limit type. Utilization is also scaled to a percentage, having displayed as `0% used`.
+
 - **Fix: better isolate AskClaude tool (issue #59)** — AskClaude children no longer inherit the user's `~/.claude` `CLAUDE.md` files or skill listing, and now always get Claude Code's system prompt preset instead of only when pi-side skills exist. Thanks @JAtkinsonKO.
 - **Fix: Bogus debug message about "record count mismatch" after switching providers** — the post-rebuild integrity check did not take `@file` expansion into account when switching providers.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1281,7 +1281,7 @@ async function consumeQuery(
 				const resetsAt = info.resetsAt ? new Date(info.resetsAt).toLocaleTimeString() : "unknown";
 				piUI?.notify(`Claude rate limited (${info.rateLimitType ?? "unknown"}) — resets at ${resetsAt}`, "warning");
 			} else if (info?.status === "allowed_warning") {
-				piUI?.notify(`Claude rate limit warning: ${Math.round(info.utilization ?? 0)}% used (${info.rateLimitType ?? ""})`, "warning");
+				piUI?.notify(`Claude rate limit warning: ${Math.round((info.utilization ?? 0) * 100)}% used (${info.rateLimitType ?? ""})`, "warning");
 			}
 			continue;
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { calculateCost, StringEnum, type AssistantMessage, type AssistantMessage
 import * as piAi from "@earendil-works/pi-ai";
 import { getModels } from "@earendil-works/pi-ai/compat";
 import { buildSessionContext, compact, generateBranchSummary, keyHint, type BranchSummaryResult, type CompactionEntry, type ExtensionAPI, type ExtensionContext, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
-import { query, type EffortLevel, type SDKMessage, type SettingSource } from "@anthropic-ai/claude-agent-sdk";
+import { query, type EffortLevel, type Query as ClaudeQuery, type SDKMessage, type SettingSource } from "@anthropic-ai/claude-agent-sdk";
 import type { Base64ImageSource, ContentBlockParam } from "@anthropic-ai/sdk/resources";
 import { Type } from "typebox";
 import { Text } from "@earendil-works/pi-tui";
@@ -26,6 +26,7 @@ import {
 import { collectCarriedAttachments, placeCarriedAttachments, type CarriedAttachment } from "./attachments.js";
 import { createToolServer } from "./mcp-server.js";
 import { buildActionSummary, type ToolCallState } from "./askclaude-ui.js";
+import { classifyFailure, decideRetry, stallTimeoutMs, StreamMonitor, TRANSIENT_RETRY_DELAY_MS } from "./stream-resilience.js";
 
 // Compat (#2): use factory if available (pi-ai ≥0.66), else fall back to constructor (gsd-pi etc.)
 const _piAi = piAi as any;
@@ -445,7 +446,7 @@ async function runIsolatedSummary(
 	options: SimpleStreamOptions | undefined,
 	stream: AssistantMessageEventStream,
 ): Promise<void> {
-	let sdkQuery: ReturnType<typeof query> | undefined;
+	let sdkQuery: ClaudeQuery | undefined;
 	let wasAborted = false;
 	const onAbort = () => {
 		wasAborted = true;
@@ -740,6 +741,7 @@ export const __test = {
 	syncSharedSession,
 	extractUserPromptBlocks,
 	consumeQuery,
+	consumeQueryWithRetry,
 	finalizeCurrentStream,
 	resultErrorText,
 	deliverToolResults,
@@ -1233,7 +1235,7 @@ function processAssistantMessage(message: SDKMessage, model: Model<any>, customT
  *  whichever path handles it first (processStreamEvent or processAssistantMessage),
  *  and the MCP handler blocks the generator until pi delivers the tool result. */
 async function consumeQuery(
-	sdkQuery: ReturnType<typeof query>,
+	sdkQuery: ClaudeQuery,
 	customToolNameToPi: Map<string, string>,
 	model: Model<any>,
 	wasAborted: () => boolean,
@@ -1243,6 +1245,7 @@ async function consumeQuery(
 
 	for await (const message of sdkQuery) {
 		if (RECORD_STREAM_PATH) appendFileSync(RECORD_STREAM_PATH, `${JSON.stringify(message)}\n`);
+		queryCtx.streamMonitor?.onSdkEvent(message.type);
 		if (wasAborted()) break;
 		// Everything below the currentPiStream guard is content, which there is
 		// nowhere to put once a turn has ended on a tool call. These three are not
@@ -1262,15 +1265,17 @@ async function consumeQuery(
 			logServedContextWindow("result", message, model);
 			resultError = resultErrorText(message);
 			if (resultError !== undefined) {
-				debug(`consumeQuery: error result, subtype=${message.subtype}, error=${resultError}`);
+				const classified = classifyFailure(resultError, queryCtx.streamMonitor?.rateLimitRejected ?? false);
+				debug(`consumeQuery: error result classified as ${classified.kind}`);
 				if (queryCtx.turnOutput) {
 					queryCtx.turnOutput.stopReason = "error";
-					queryCtx.turnOutput.errorMessage = resultError;
+					queryCtx.turnOutput.errorMessage = classified.message;
 				}
 			}
 		}
 		if (message.type === "rate_limit_event") {
 			const info = (message as any).rate_limit_info;
+			queryCtx.streamMonitor?.noteRateLimitEvent(info);
 			debug("consumeQuery: rate_limit_event", JSON.stringify(info).slice(0, 300));
 			if (info?.status === "rejected") {
 				const resetsAt = info.resetsAt ? new Date(info.resetsAt).toLocaleTimeString() : "unknown";
@@ -1327,6 +1332,76 @@ async function consumeQuery(
 	debug(`consumeQuery: for-await loop exited, wasAborted=${wasAborted()}, capturedSessionId=${capturedSessionId?.slice(0, 8) ?? "none"}`);
 
 	return { capturedSessionId };
+}
+
+interface QueryAttempt {
+	current: () => ClaudeQuery;
+	restart: () => void;
+	abort: () => void;
+}
+
+async function consumeQueryWithRetry(
+	attempt: QueryAttempt,
+	customToolNameToPi: Map<string, string>,
+	model: Model<any>,
+	wasAborted: () => boolean,
+	queryCtx: QueryContext,
+): Promise<{ capturedSessionId?: string }> {
+	for (let retriesUsed = 0; ; retriesUsed++) {
+		const monitor = new StreamMonitor({
+			idleMs: stallTimeoutMs(),
+			hasPendingWork: () => queryCtx.pendingToolCalls.size > 0,
+			onStall: (error) => {
+				if (queryCtx.turnOutput) {
+					queryCtx.turnOutput.stopReason = "error";
+					queryCtx.turnOutput.errorMessage = error.message;
+				}
+				attempt.abort();
+			},
+			log: debug,
+		});
+		queryCtx.streamMonitor = monitor;
+
+		let failure: unknown;
+		let outcome: { capturedSessionId?: string } | undefined;
+		try {
+			monitor.arm();
+			outcome = await consumeQuery(attempt.current(), customToolNameToPi, model, wasAborted, queryCtx);
+			if (monitor.stalled) failure = monitor.stallError;
+			else if (queryCtx.turnOutput?.stopReason === "error") failure = new Error(queryCtx.turnOutput.errorMessage);
+			if (!failure) return outcome;
+		} catch (error) {
+			failure = monitor.stalled ? monitor.stallError ?? error : error;
+		} finally {
+			monitor.stop();
+		}
+
+		const outputStarted = queryCtx.turnStarted || queryCtx.turnSawStreamEvent || queryCtx.turnSawToolCall
+			|| (queryCtx.turnOutput?.content.length ?? 0) > 0;
+		const decision = decideRetry({
+			failure,
+			rateLimitRejected: monitor.rateLimitRejected,
+			outputStarted,
+			retriesUsed,
+			aborted: wasAborted(),
+		});
+		debug(`consumeQueryWithRetry: attempt ${retriesUsed + 1} failed (${decision.kind}): ${decision.reason}`);
+
+		if (!decision.retry) {
+			if (queryCtx.turnOutput && decision.kind !== "fatal") {
+				queryCtx.turnOutput.stopReason = "error";
+				queryCtx.turnOutput.errorMessage = decision.message;
+			}
+			if (outcome) return outcome;
+			throw failure;
+		}
+
+		queryCtx.resetTurnState(model);
+		if (sharedSession) sharedSession = { ...sharedSession, needsRebuild: true };
+		await new Promise<void>((resolve) => setTimeout(resolve, TRANSIENT_RETRY_DELAY_MS));
+		if (wasAborted()) throw failure;
+		attempt.restart();
+	}
 }
 
 /** The trailing user turn as content blocks, or null if there isn't one.
@@ -1547,10 +1622,6 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// that `isSingleUserTurn` is false, so the SDK no longer closes stdin on the
 	// first result — consumeQuery ends the stream explicitly instead, or the
 	// query would never terminate.
-	const promptStream = makePromptStream();
-	void promptStream.push(userMessage(promptBlocks ?? [{ type: "text", text: promptText }]))
-		.catch((error) => debug(`provider: initial prompt push rejected:`, error));
-	queryCtx.promptStream = promptStream;
 	const mcpServers = buildMcpServers(mcpTools, queryCtx);
 
 	// MCP auto-loading suppression: CC reads MCP servers from ~/.claude.json (top-level
@@ -1611,10 +1682,23 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		`ctxFiles=${promptCapture?.contextFiles.length ?? 0} strictMcp=${strictMcpConfigEnabled}`,
 		`prompt=${promptText.slice(0, 60)}${promptBlocks ? " [+images]" : ""}`);
 
-	// 3. Start SDK query and claim it for this context
+	// A retry needs a fresh prompt iterable because image prompt streams are
+	// single-use. Keep both handles mutable so abort and cleanup target the live
+	// attempt.
 	let wasAborted = false;
-	const sdkQuery = query({ prompt: promptStream.stream, options: queryOptions });
-	queryCtx.activeQuery = sdkQuery;
+	let promptStream!: PromptStream;
+	let sdkQuery!: ClaudeQuery;
+	const startAttempt = () => {
+		promptStream?.fail(new Error("query restarted after a transient failure"));
+		try { sdkQuery?.close(); } catch {}
+		promptStream = makePromptStream();
+		void promptStream.push(userMessage(promptBlocks ?? [{ type: "text", text: promptText }]))
+			.catch((error) => debug(`provider: initial prompt push rejected:`, error));
+		queryCtx.promptStream = promptStream;
+		sdkQuery = query({ prompt: promptStream.stream, options: queryOptions });
+		queryCtx.activeQuery = sdkQuery;
+	};
+	startAttempt();
 	activeQueryContexts.add(queryCtx);
 
 	// 4. Capture context for abort handling
@@ -1637,7 +1721,13 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	}
 
 	// Background consumer — runs until query ends
-	consumeQuery(sdkQuery, customToolNameToPi, model, () => wasAborted, queryCtx)
+	consumeQueryWithRetry(
+		{ current: () => sdkQuery, restart: startAttempt, abort: requestAbort },
+		customToolNameToPi,
+		model,
+		() => wasAborted,
+		queryCtx,
+	)
 		.then(async ({ capturedSessionId }) => {
 			debug(`provider: consumeQuery completed, stopReason=${queryCtx.turnOutput?.stopReason}, error=${queryCtx.turnOutput?.errorMessage}, aborted=${wasAborted}`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1312,6 +1312,7 @@ async function consumeQuery(
 			case "system":
 				if ((message as any).subtype === "init" && (message as any).session_id) {
 					capturedSessionId = (message as any).session_id;
+					queryCtx.capturedSessionId = capturedSessionId;
 				}
 				break;
 			case "user":
@@ -1348,16 +1349,19 @@ async function consumeQueryWithRetry(
 	queryCtx: QueryContext,
 ): Promise<{ capturedSessionId?: string }> {
 	for (let retriesUsed = 0; ; retriesUsed++) {
+		const onStall = (error: Error): void => {
+			// After `result`, only generator shutdown is hung; preserve the recorded
+			// outcome and abort the generator.
+			if (!monitor.resultReceived && queryCtx.turnOutput) {
+				queryCtx.turnOutput.stopReason = "error";
+				queryCtx.turnOutput.errorMessage = error.message;
+			}
+			attempt.abort();
+		};
 		const monitor = new StreamMonitor({
 			idleMs: stallTimeoutMs(),
 			hasPendingWork: () => queryCtx.pendingToolCalls.size > 0,
-			onStall: (error) => {
-				if (queryCtx.turnOutput) {
-					queryCtx.turnOutput.stopReason = "error";
-					queryCtx.turnOutput.errorMessage = error.message;
-				}
-				attempt.abort();
-			},
+			onStall,
 			log: debug,
 		});
 		queryCtx.streamMonitor = monitor;
@@ -1376,8 +1380,13 @@ async function consumeQueryWithRetry(
 			monitor.stop();
 		}
 
+		if (monitor.stalled && monitor.resultReceived) {
+			debug("consumeQueryWithRetry: post-result stall during shutdown, keeping recorded outcome");
+			return { capturedSessionId: outcome?.capturedSessionId ?? queryCtx.capturedSessionId };
+		}
+
 		const outputStarted = queryCtx.turnStarted || queryCtx.turnSawStreamEvent || queryCtx.turnSawToolCall
-			|| (queryCtx.turnOutput?.content.length ?? 0) > 0;
+			|| (queryCtx.turnOutput?.content.length ?? 0) > 0 || queryCtx.turnToolCallIds.length > 0;
 		const decision = decideRetry({
 			failure,
 			rateLimitRejected: monitor.rateLimitRejected,
@@ -1397,7 +1406,6 @@ async function consumeQueryWithRetry(
 		}
 
 		queryCtx.resetTurnState(model);
-		if (sharedSession) sharedSession = { ...sharedSession, needsRebuild: true };
 		await new Promise<void>((resolve) => setTimeout(resolve, TRANSIENT_RETRY_DELAY_MS));
 		if (wasAborted()) throw failure;
 		attempt.restart();
@@ -1596,8 +1604,8 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// cliModel is the actual id sent to Claude Code (may carry [1m]); model.id is the
 	// pi-registered id. Log cliModel so debug lines reflect what CC actually received.
 	const cliModel = claudeCodeModelId(model, longContextSettings);
-	const syncResult = syncSharedSession(context.messages, cwd, customToolNameToSdk, cliModel);
-	const { sessionId: resumeSessionId } = syncResult;
+	let syncResult = syncSharedSession(context.messages, cwd, customToolNameToSdk, cliModel);
+	let resumeSessionId = syncResult.sessionId;
 	const promptBlocks = extractUserPromptBlocks(context.messages);
 	let promptText = extractUserPrompt(context.messages) ?? "";
 
@@ -1617,11 +1625,6 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		promptText = "[continue]";
 	}
 
-	// Always stream the prompt rather than passing a string: a parked input
-	// generator is what lets us write steers to CC's stdin mid-turn. The cost is
-	// that `isSingleUserTurn` is false, so the SDK no longer closes stdin on the
-	// first result — consumeQuery ends the stream explicitly instead, or the
-	// query would never terminate.
 	const mcpServers = buildMcpServers(mcpTools, queryCtx);
 
 	// MCP auto-loading suppression: CC reads MCP servers from ~/.claude.json (top-level
@@ -1657,7 +1660,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// threshold with CC's, including CC's anti-thrashing guard (issue #8).
 	// Manual /compact in CC still works (we never invoke it).
 	const childEnv = { ...process.env, ...CC_CHILD_ENV };
-	const queryOptions: NonNullable<Parameters<typeof query>[0]["options"]> = {
+	const makeQueryOptions = (resume: string | null | undefined): NonNullable<Parameters<typeof query>[0]["options"]> => ({
 		cwd,
 		env: childEnv,
 		tools: [],
@@ -1671,10 +1674,10 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		extraArgs,
 		...(effort ? { effort } : {}),
 		...(mcpServers ? { mcpServers } : {}),
-		...(resumeSessionId ? { resume: resumeSessionId } : {}),
+		...(resume ? { resume } : {}),
 		...(claudeExecutable ? { pathToClaudeCodeExecutable: claudeExecutable } : {}),
 		...makeCliDebugOptions("provider"),
-	};
+	});
 
 	debug("provider: fresh query",
 		`model=${cliModel} msgs=${context.messages.length} tools=${mcpTools.length}`,
@@ -1682,20 +1685,29 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		`ctxFiles=${promptCapture?.contextFiles.length ?? 0} strictMcp=${strictMcpConfigEnabled}`,
 		`prompt=${promptText.slice(0, 60)}${promptBlocks ? " [+images]" : ""}`);
 
-	// A retry needs a fresh prompt iterable because image prompt streams are
-	// single-use. Keep both handles mutable so abort and cleanup target the live
-	// attempt.
+	// Keep handles mutable so abort and cleanup target the current attempt.
 	let wasAborted = false;
 	let promptStream!: PromptStream;
 	let sdkQuery!: ClaudeQuery;
-	const startAttempt = () => {
+	const startAttempt = (retry = false) => {
+		if (retry) {
+			if (syncResult.preserveSharedSession) {
+				resumeSessionId = null;
+			} else {
+				if (sharedSession) sharedSession = { ...sharedSession, needsRebuild: true, forceRotate: true };
+				syncResult = syncSharedSession(context.messages, cwd, customToolNameToSdk, cliModel);
+				resumeSessionId = syncResult.sessionId;
+			}
+		}
 		promptStream?.fail(new Error("query restarted after a transient failure"));
 		try { sdkQuery?.close(); } catch {}
+		queryCtx.capturedSessionId = undefined;
+		// Retry attempts need a fresh prompt stream; image streams are single-use.
 		promptStream = makePromptStream();
 		void promptStream.push(userMessage(promptBlocks ?? [{ type: "text", text: promptText }]))
 			.catch((error) => debug(`provider: initial prompt push rejected:`, error));
 		queryCtx.promptStream = promptStream;
-		sdkQuery = query({ prompt: promptStream.stream, options: queryOptions });
+		sdkQuery = query({ prompt: promptStream.stream, options: makeQueryOptions(resumeSessionId) });
 		queryCtx.activeQuery = sdkQuery;
 	};
 	startAttempt();
@@ -1722,7 +1734,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 
 	// Background consumer — runs until query ends
 	consumeQueryWithRetry(
-		{ current: () => sdkQuery, restart: startAttempt, abort: requestAbort },
+		{ current: () => sdkQuery, restart: () => startAttempt(true), abort: requestAbort },
 		customToolNameToPi,
 		model,
 		() => wasAborted,

--- a/src/index.ts
+++ b/src/index.ts
@@ -738,6 +738,9 @@ export const __test = {
 	setPiUI(ui: ExtensionUIContext | null) {
 		piUI = ui;
 	},
+	resetRateLimitNotifyDedupe() {
+		lastNotifiedRateLimitState.clear();
+	},
 	syncSharedSession,
 	extractUserPromptBlocks,
 	consumeQuery,
@@ -836,6 +839,17 @@ function showStartupNoticeOnce(): void {
 // Captures of what pi assembled per agent; see src/prompt-capture.ts for why this
 // is keyed rather than held in a single slot.
 const promptCaptures = new PromptCaptures();
+
+// A rate-limit warning is duplicated by two independent sources: N concurrent
+// SDK streams (one per subagent plus the main agent) each get their own
+// `rate_limit_event` frames for the same account-wide state, and a single
+// long-running stream re-emits the event as its headers refresh. Dedup by the
+// fields the rendered message actually carries, not a boolean, so a genuine
+// change (a different percentage, or a status escalation to `rejected`) still
+// reaches `piUI.notify`. Keyed per rate limit type rather than one slot: two
+// buckets near their thresholds alternate across streams, and a single slot
+// would read every alternation as a change and re-spam.
+const lastNotifiedRateLimitState = new Map<string, string>();
 
 /** Whatever a settled session left behind, named in one greppable line.
  *
@@ -1277,11 +1291,21 @@ async function consumeQuery(
 			const info = (message as any).rate_limit_info;
 			queryCtx.streamMonitor?.noteRateLimitEvent(info);
 			debug("consumeQuery: rate_limit_event", JSON.stringify(info).slice(0, 300));
+			const rateLimitType = info?.rateLimitType ?? "";
 			if (info?.status === "rejected") {
 				const resetsAt = info.resetsAt ? new Date(info.resetsAt).toLocaleTimeString() : "unknown";
-				piUI?.notify(`Claude rate limited (${info.rateLimitType ?? "unknown"}) — resets at ${resetsAt}`, "warning");
+				const state = `rejected:${resetsAt}`;
+				if (state !== lastNotifiedRateLimitState.get(rateLimitType)) {
+					lastNotifiedRateLimitState.set(rateLimitType, state);
+					piUI?.notify(`Claude rate limited (${info.rateLimitType ?? "unknown"}) — resets at ${resetsAt}`, "warning");
+				}
 			} else if (info?.status === "allowed_warning") {
-				piUI?.notify(`Claude rate limit warning: ${Math.round((info.utilization ?? 0) * 100)}% used (${info.rateLimitType ?? ""})`, "warning");
+				const percentUsed = Math.round((info.utilization ?? 0) * 100);
+				const state = `allowed_warning:${percentUsed}`;
+				if (state !== lastNotifiedRateLimitState.get(rateLimitType)) {
+					lastNotifiedRateLimitState.set(rateLimitType, state);
+					piUI?.notify(`Claude rate limit warning: ${percentUsed}% used (${rateLimitType})`, "warning");
+				}
 			}
 			continue;
 		}
@@ -2048,6 +2072,7 @@ export default function (pi: ExtensionAPI) {
 	const clearSession = (event: string) => {
 		debug(`${event}: clearing session ${sharedSession?.sessionId?.slice(0, 8) ?? "none"}`);
 		sharedSession = null;
+		lastNotifiedRateLimitState.clear();
 
 		// Clear the global streamSimple if this instance registered it.
 		// This allows /reload to work — the old instance clears the flag so

--- a/src/query-state.ts
+++ b/src/query-state.ts
@@ -9,6 +9,7 @@
 import type { AssistantMessage, AssistantMessageEventStream, Model } from "@earendil-works/pi-ai";
 import type { McpResult } from "./extract-tool-results.js";
 import type { PromptStream } from "./prompt-stream.js";
+import type { StreamMonitor } from "./stream-resilience.js";
 
 export interface PendingToolCall {
 	toolName: string;
@@ -20,6 +21,7 @@ export class QueryContext {
 	activeQuery: unknown | null = null;
 	currentPiStream: AssistantMessageEventStream | null = null;
 	latestCursor = 0;
+	streamMonitor: StreamMonitor | null = null;
 	pendingToolCalls = new Map<string, PendingToolCall>();
 	pendingResults = new Map<string, McpResult>();
 	/** tool_use ids emitted this turn. Sole purpose is routing a delivered result

--- a/src/query-state.ts
+++ b/src/query-state.ts
@@ -28,6 +28,9 @@ export class QueryContext {
 	 *  to the owning query when several queries are in flight — pairing a result
 	 *  to its call is done by id from Claude's tools/call _meta, not from here. */
 	turnToolCallIds: string[] = [];
+	/** Session id from the active attempt, retained through an aborted generator
+	 *  shutdown so provider finalization can still record it. */
+	capturedSessionId: string | undefined;
 	/** Streaming-input handle for the active query — how steers reach CC mid-turn. */
 	promptStream: PromptStream | null = null;
 

--- a/src/stream-resilience.ts
+++ b/src/stream-resilience.ts
@@ -1,7 +1,9 @@
 export type FailureClass = "rate-limit" | "transient" | "fatal";
 
+const AUTH_PERMISSION_PATTERN =
+	/\b(401|403)\b|authentication|unauthenticated|unauthorized|invalid[ _-]?api[ _-]?key|api[ _-]?key not|oauth|please (log|sign) ?in|credential|permission denied|forbidden|not permitted/i;
 const FATAL_PATTERN =
-	/\b(401|403)\b|authentication|unauthenticated|unauthorized|invalid[ _-]?api[ _-]?key|api[ _-]?key not|oauth|please (log|sign) ?in|credential|permission denied|forbidden|not permitted|payment|billing|insufficient[ _](quota|funds|credits?)|credit balance|out of budget|quota exceeded/i;
+	/payment|billing|insufficient[ _](quota|funds|credits?)|credit balance|out of budget|quota exceeded/i;
 const TRANSIENT_PATTERN =
 	/temporarily limiting requests|not your usage limit|overloaded|\b(429|500|502|503|504|524|529)\b|service unavailable|server error|internal error|rate limited|too many requests|ECONNRESET|ETIMEDOUT|EPIPE|ENETUNREACH|EAI_AGAIN|socket hang up|fetch failed|premature close|other side closed|stream (ended|closed) (before|without)|ended without|timed out|timeout|network error|connection (error|refused|reset|lost)/i;
 const SUBSCRIPTION_LIMIT_PATTERN =
@@ -28,14 +30,12 @@ export interface ClassifiedFailure {
 
 export function classifyFailure(text: string, rateLimitRejected = false): ClassifiedFailure {
 	const message = (text ?? "").trim();
-	if (message && FATAL_PATTERN.test(message)) return { kind: "fatal", message };
-	if (rateLimitRejected) return { kind: "rate-limit", message: rateLimitMessage(message) };
-	if (message && TRANSIENT_PATTERN.test(message) && !SUBSCRIPTION_LIMIT_PATTERN.test(message)) {
-		return { kind: "transient", message };
-	}
-	if (message && SUBSCRIPTION_LIMIT_PATTERN.test(message)) {
+	if (message && AUTH_PERMISSION_PATTERN.test(message)) return { kind: "fatal", message };
+	if (rateLimitRejected || (message && SUBSCRIPTION_LIMIT_PATTERN.test(message))) {
 		return { kind: "rate-limit", message: rateLimitMessage(message) };
 	}
+	if (message && FATAL_PATTERN.test(message)) return { kind: "fatal", message };
+	if (message && TRANSIENT_PATTERN.test(message)) return { kind: "transient", message };
 	return { kind: "fatal", message };
 }
 
@@ -102,6 +102,8 @@ export class StreamMonitor {
 	stalled = false;
 	stallError: StreamStalledError | undefined;
 	rateLimitRejected = false;
+	/** A result followed by a stall means generator shutdown hung; preserve the outcome. */
+	resultReceived = false;
 
 	private timer: ReturnType<typeof setTimeout> | undefined;
 	private finished = false;
@@ -116,12 +118,12 @@ export class StreamMonitor {
 	}
 
 	onSdkEvent(type?: string): void {
-		if (type === "result") this.stop();
-		else this.arm();
+		if (type === "result") this.resultReceived = true;
+		this.arm();
 	}
 
 	noteRateLimitEvent(info: RateLimitInfo | undefined): void {
-		this.rateLimitRejected = info?.status === "rejected" || info?.overageStatus === "rejected";
+		this.rateLimitRejected ||= info?.status === "rejected" || info?.overageStatus === "rejected";
 	}
 
 	stop(): void {

--- a/src/stream-resilience.ts
+++ b/src/stream-resilience.ts
@@ -1,0 +1,152 @@
+export type FailureClass = "rate-limit" | "transient" | "fatal";
+
+const FATAL_PATTERN =
+	/\b(401|403)\b|authentication|unauthenticated|unauthorized|invalid[ _-]?api[ _-]?key|api[ _-]?key not|oauth|please (log|sign) ?in|credential|permission denied|forbidden|not permitted|payment|billing|insufficient[ _](quota|funds|credits?)|credit balance|out of budget|quota exceeded/i;
+const TRANSIENT_PATTERN =
+	/temporarily limiting requests|not your usage limit|overloaded|\b(429|500|502|503|504|524|529)\b|service unavailable|server error|internal error|rate limited|too many requests|ECONNRESET|ETIMEDOUT|EPIPE|ENETUNREACH|EAI_AGAIN|socket hang up|fetch failed|premature close|other side closed|stream (ended|closed) (before|without)|ended without|timed out|timeout|network error|connection (error|refused|reset|lost)/i;
+const SUBSCRIPTION_LIMIT_PATTERN =
+	/you('?ve|'?re| have)? ?(hit|reached) your [^.\n]*limit|usage limit reached|\blimits?\b[^.\n]{0,60}\bresets?\b/i;
+const PI_NON_RETRYABLE_PATTERN =
+	/GoUsageLimitError|FreeUsageLimitError|Monthly usage limit reached|available balance|insufficient_quota|out of budget|quota exceeded|billing/i;
+
+export const RATE_LIMIT_PREFIX = "Rate limit (429) from Claude Code";
+const RATE_LIMIT_FALLBACK_DETAIL = "subscription or plan limit reached";
+
+export function rateLimitMessage(detail: string): string {
+	const trimmed = detail.trim();
+	if (trimmed.startsWith(RATE_LIMIT_PREFIX)) return trimmed;
+	if (!trimmed || PI_NON_RETRYABLE_PATTERN.test(trimmed)) {
+		return `${RATE_LIMIT_PREFIX}: ${RATE_LIMIT_FALLBACK_DETAIL}`;
+	}
+	return `${RATE_LIMIT_PREFIX}: ${trimmed}`;
+}
+
+export interface ClassifiedFailure {
+	kind: FailureClass;
+	message: string;
+}
+
+export function classifyFailure(text: string, rateLimitRejected = false): ClassifiedFailure {
+	const message = (text ?? "").trim();
+	if (message && FATAL_PATTERN.test(message)) return { kind: "fatal", message };
+	if (rateLimitRejected) return { kind: "rate-limit", message: rateLimitMessage(message) };
+	if (message && TRANSIENT_PATTERN.test(message) && !SUBSCRIPTION_LIMIT_PATTERN.test(message)) {
+		return { kind: "transient", message };
+	}
+	if (message && SUBSCRIPTION_LIMIT_PATTERN.test(message)) {
+		return { kind: "rate-limit", message: rateLimitMessage(message) };
+	}
+	return { kind: "fatal", message };
+}
+
+export const TRANSIENT_RETRY_DELAY_MS = 800;
+const MAX_TRANSIENT_RETRIES = 1;
+
+export interface RetryDecision {
+	retry: boolean;
+	reason: string;
+	kind: FailureClass;
+	message: string;
+}
+
+export function decideRetry(input: {
+	failure: unknown;
+	rateLimitRejected?: boolean;
+	outputStarted: boolean;
+	retriesUsed: number;
+	aborted?: boolean;
+}): RetryDecision {
+	const text = input.failure instanceof Error ? input.failure.message : String(input.failure ?? "");
+	const classified = input.failure instanceof StreamStalledError
+		? { kind: "transient" as FailureClass, message: text }
+		: classifyFailure(text, input.rateLimitRejected ?? false);
+	const decision = (retry: boolean, reason: string): RetryDecision => ({ retry, reason, kind: classified.kind, message: classified.message });
+
+	if (input.aborted) return decision(false, "aborted");
+	if (classified.kind !== "transient") return decision(false, `${classified.kind} failure is never retried`);
+	if (input.outputStarted) return decision(false, "output already started");
+	if (input.retriesUsed >= MAX_TRANSIENT_RETRIES) return decision(false, "retry budget exhausted");
+	return decision(true, "transient failure before any output");
+}
+
+export class StreamStalledError extends Error {
+	constructor(idleMs: number) {
+		super(`Claude Code stream stalled: no SDK events for ${Math.round(idleMs / 1000)}s with no tool call in flight, request timed out`);
+		this.name = "StreamStalledError";
+	}
+}
+
+export const DEFAULT_STALL_TIMEOUT_MS = 300_000;
+
+export function stallTimeoutMs(env: Record<string, string | undefined> = process.env): number {
+	const raw = env.CLAUDE_BRIDGE_STALL_TIMEOUT_MS;
+	if (raw === undefined || raw === "") return DEFAULT_STALL_TIMEOUT_MS;
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed)) return DEFAULT_STALL_TIMEOUT_MS;
+	return parsed > 0 ? parsed : 0;
+}
+
+interface RateLimitInfo {
+	status?: string;
+	overageStatus?: string;
+}
+
+export interface StreamMonitorOptions {
+	idleMs: number;
+	hasPendingWork: () => boolean;
+	onStall: (error: StreamStalledError) => void;
+	log?: (message: string) => void;
+}
+
+export class StreamMonitor {
+	stalled = false;
+	stallError: StreamStalledError | undefined;
+	rateLimitRejected = false;
+
+	private timer: ReturnType<typeof setTimeout> | undefined;
+	private finished = false;
+
+	constructor(private readonly options: StreamMonitorOptions) {}
+
+	arm(): void {
+		if (this.finished || this.options.idleMs <= 0) return;
+		this.disarm();
+		this.timer = setTimeout(() => this.fire(), this.options.idleMs);
+		this.timer.unref?.();
+	}
+
+	onSdkEvent(type?: string): void {
+		if (type === "result") this.stop();
+		else this.arm();
+	}
+
+	noteRateLimitEvent(info: RateLimitInfo | undefined): void {
+		this.rateLimitRejected = info?.status === "rejected" || info?.overageStatus === "rejected";
+	}
+
+	stop(): void {
+		this.finished = true;
+		this.disarm();
+	}
+
+	private disarm(): void {
+		if (this.timer === undefined) return;
+		clearTimeout(this.timer);
+		this.timer = undefined;
+	}
+
+	private fire(): void {
+		this.timer = undefined;
+		if (this.finished) return;
+		if (this.options.hasPendingWork()) {
+			this.options.log?.("stall watchdog: tool call in flight, re-arming");
+			this.arm();
+			return;
+		}
+		this.finished = true;
+		this.stalled = true;
+		this.stallError = new StreamStalledError(this.options.idleMs);
+		this.options.log?.(`stall watchdog: ${this.stallError.message}`);
+		this.options.onStall(this.stallError);
+	}
+}

--- a/tests/unit-rate-limit-notify-dedupe.mjs
+++ b/tests/unit-rate-limit-notify-dedupe.mjs
@@ -1,0 +1,148 @@
+/**
+ * Rate-limit notification dedupe: N concurrent SDK streams (one per subagent)
+ * each carry their own `rate_limit_event` frames for the same account-wide
+ * state, and a single long-running stream re-emits the event as its headers
+ * refresh. Both sources must collapse into one `piUI.notify` call per distinct
+ * state, while the per-stream watchdog (`noteRateLimitEvent`) and debug log
+ * keep firing on every event regardless.
+ */
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { QueryContext } from "../src/query-state.js";
+import { StreamMonitor } from "../src/stream-resilience.js";
+
+const { __test } = await import("../src/index.js");
+
+const model = { api: "anthropic-messages", provider: "anthropic", id: "claude-opus-4-5" };
+
+function harness() {
+	const c = new QueryContext();
+	c.currentPiStream = { push: () => {}, end: () => {} };
+	c.resetTurnState(model);
+	const rateLimitEvents = [];
+	c.streamMonitor = new StreamMonitor({ idleMs: 0, hasPendingWork: () => false, onStall: () => {} });
+	const originalNote = c.streamMonitor.noteRateLimitEvent.bind(c.streamMonitor);
+	c.streamMonitor.noteRateLimitEvent = (info) => {
+		rateLimitEvents.push(info);
+		return originalNote(info);
+	};
+	return { c, rateLimitEvents };
+}
+
+async function* streamOf(messages) {
+	for (const m of messages) yield m;
+}
+
+describe("rate-limit warning notify dedupe", () => {
+	let notices;
+
+	beforeEach(() => {
+		notices = [];
+		__test.setPiUI({ notify: (message, kind) => notices.push({ message, kind }) });
+		__test.resetRateLimitNotifyDedupe();
+	});
+
+	it("collapses identical allowed_warning events from concurrent streams into one notify", async () => {
+		const { c: c1, rateLimitEvents: events1 } = harness();
+		const { c: c2, rateLimitEvents: events2 } = harness();
+		const { c: c3, rateLimitEvents: events3 } = harness();
+		const event = { type: "rate_limit_event", rate_limit_info: { status: "allowed_warning", rateLimitType: "seven_day", utilization: 0.78 } };
+
+		await __test.consumeQuery(streamOf([event]), new Map(), model, () => false, c1, []);
+		await __test.consumeQuery(streamOf([event]), new Map(), model, () => false, c2, []);
+		await __test.consumeQuery(streamOf([event]), new Map(), model, () => false, c3, []);
+
+		assert.deepEqual(notices, [{ message: "Claude rate limit warning: 78% used (seven_day)", kind: "warning" }]);
+		assert.equal(events1.length, 1, "per-stream watchdog still sees its own event");
+		assert.equal(events2.length, 1, "per-stream watchdog still sees its own event");
+		assert.equal(events3.length, 1, "per-stream watchdog still sees its own event");
+	});
+
+	it("collapses identical allowed_warning events re-emitted within one long stream", async () => {
+		const { c } = harness();
+		const event = { type: "rate_limit_event", rate_limit_info: { status: "allowed_warning", rateLimitType: "seven_day", utilization: 0.78 } };
+
+		await __test.consumeQuery(streamOf([event, event, event]), new Map(), model, () => false, c, []);
+
+		assert.deepEqual(notices, [{ message: "Claude rate limit warning: 78% used (seven_day)", kind: "warning" }]);
+	});
+
+	it("notifies again when the rounded utilization percentage changes", async () => {
+		const { c } = harness();
+
+		await __test.consumeQuery(streamOf([
+			{ type: "rate_limit_event", rate_limit_info: { status: "allowed_warning", rateLimitType: "seven_day", utilization: 0.77 } },
+			{ type: "rate_limit_event", rate_limit_info: { status: "allowed_warning", rateLimitType: "seven_day", utilization: 0.78 } },
+		]), new Map(), model, () => false, c, []);
+
+		assert.deepEqual(notices, [
+			{ message: "Claude rate limit warning: 77% used (seven_day)", kind: "warning" },
+			{ message: "Claude rate limit warning: 78% used (seven_day)", kind: "warning" },
+		]);
+	});
+
+	it("notifies again when the rateLimitType changes at the same percentage", async () => {
+		const { c } = harness();
+
+		await __test.consumeQuery(streamOf([
+			{ type: "rate_limit_event", rate_limit_info: { status: "allowed_warning", rateLimitType: "seven_day", utilization: 0.78 } },
+			{ type: "rate_limit_event", rate_limit_info: { status: "allowed_warning", rateLimitType: "five_hour", utilization: 0.78 } },
+		]), new Map(), model, () => false, c, []);
+
+		assert.deepEqual(notices, [
+			{ message: "Claude rate limit warning: 78% used (seven_day)", kind: "warning" },
+			{ message: "Claude rate limit warning: 78% used (five_hour)", kind: "warning" },
+		]);
+	});
+
+	it("collapses two buckets alternating across concurrent streams into one notify each", async () => {
+		const sevenDay = { type: "rate_limit_event", rate_limit_info: { status: "allowed_warning", rateLimitType: "seven_day", utilization: 0.78 } };
+		const fiveHour = { type: "rate_limit_event", rate_limit_info: { status: "allowed_warning", rateLimitType: "five_hour", utilization: 0.4 } };
+
+		for (const event of [sevenDay, fiveHour, sevenDay, fiveHour]) {
+			const { c } = harness();
+			await __test.consumeQuery(streamOf([event]), new Map(), model, () => false, c, []);
+		}
+
+		assert.deepEqual(notices, [
+			{ message: "Claude rate limit warning: 78% used (seven_day)", kind: "warning" },
+			{ message: "Claude rate limit warning: 40% used (five_hour)", kind: "warning" },
+		]);
+	});
+
+	it("notifies again when status escalates from allowed_warning to rejected", async () => {
+		const { c } = harness();
+
+		await __test.consumeQuery(streamOf([
+			{ type: "rate_limit_event", rate_limit_info: { status: "allowed_warning", rateLimitType: "seven_day", utilization: 0.78 } },
+			{ type: "rate_limit_event", rate_limit_info: { status: "rejected", rateLimitType: "seven_day", resetsAt: 0 } },
+		]), new Map(), model, () => false, c, []);
+
+		assert.equal(notices.length, 2);
+		assert.equal(notices[0].message, "Claude rate limit warning: 78% used (seven_day)");
+		assert.match(notices[1].message, /^Claude rate limited \(seven_day\) — resets at /);
+	});
+
+	it("collapses identical rejected events across concurrent streams", async () => {
+		const { c: c1 } = harness();
+		const { c: c2 } = harness();
+		const event = { type: "rate_limit_event", rate_limit_info: { status: "rejected", rateLimitType: "overage", resetsAt: 0 } };
+
+		await __test.consumeQuery(streamOf([event]), new Map(), model, () => false, c1, []);
+		await __test.consumeQuery(streamOf([event]), new Map(), model, () => false, c2, []);
+
+		assert.equal(notices.length, 1);
+	});
+
+	it("resets after clearSession-equivalent teardown so a new session sees the warning again", async () => {
+		const { c: c1 } = harness();
+		const { c: c2 } = harness();
+		const event = { type: "rate_limit_event", rate_limit_info: { status: "allowed_warning", rateLimitType: "seven_day", utilization: 0.78 } };
+
+		await __test.consumeQuery(streamOf([event]), new Map(), model, () => false, c1, []);
+		__test.resetRateLimitNotifyDedupe();
+		await __test.consumeQuery(streamOf([event]), new Map(), model, () => false, c2, []);
+
+		assert.equal(notices.length, 2);
+	});
+});

--- a/tests/unit-stream-resilience.mjs
+++ b/tests/unit-stream-resilience.mjs
@@ -1,0 +1,213 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isRetryableAssistantError } from "@earendil-works/pi-ai";
+import { QueryContext } from "../src/query-state.js";
+import {
+	DEFAULT_STALL_TIMEOUT_MS,
+	classifyFailure,
+	decideRetry,
+	stallTimeoutMs,
+	StreamMonitor,
+	StreamStalledError,
+} from "../src/stream-resilience.js";
+
+const { __test } = await import("../src/index.js");
+
+const model = { api: "anthropic-messages", provider: "anthropic", id: "claude-opus-4-5" };
+const LIMIT_TEXT = "You've hit your limit · resets 9am (Europe/Paris)";
+const OVERLOAD_TEXT = "Server is temporarily limiting requests (not your usage limit): Rate limited";
+const asPiMessage = (errorMessage) => ({ role: "assistant", stopReason: "error", errorMessage });
+
+function harness() {
+	const events = [];
+	const context = new QueryContext();
+	context.currentPiStream = { push: (event) => events.push(event), end: () => events.push({ type: "end" }) };
+	context.resetTurnState(model);
+	return { context, events };
+}
+
+async function* streamOf(messages) {
+	for (const message of messages) yield message;
+}
+
+async function* failedStream(error) {
+	yield* [];
+	throw error;
+}
+
+describe("subscription limit fallback", () => {
+	it("rewrites Claude's limit text into a failure Pi classifies as retryable", () => {
+		assert.equal(isRetryableAssistantError(asPiMessage(LIMIT_TEXT)), false);
+		const classified = classifyFailure(LIMIT_TEXT);
+		assert.equal(classified.kind, "rate-limit");
+		assert.equal(isRetryableAssistantError(asPiMessage(classified.message)), true);
+	});
+
+	it("uses a rejected rate-limit event for opaque failures", async () => {
+		const { context } = harness();
+		context.streamMonitor = new StreamMonitor({ idleMs: 0, hasPendingWork: () => false, onStall: () => {} });
+		await __test.consumeQuery(streamOf([
+			{ type: "rate_limit_event", rate_limit_info: { status: "rejected", overageStatus: "rejected", resetsAt: 0 } },
+			{ type: "result", subtype: "success", is_error: true, result: "Claude Code failed: error_during_execution" },
+		]), new Map(), model, () => false, context);
+
+		assert.equal(context.streamMonitor.rateLimitRejected, true);
+		assert.equal(context.turnOutput.stopReason, "error");
+		assert.equal(isRetryableAssistantError(asPiMessage(context.turnOutput.errorMessage)), true);
+	});
+
+	it("does not let non-retryable wording defeat fallback classification", () => {
+		const classified = classifyFailure("You've hit your limit · enable available balance to continue");
+		assert.equal(classified.kind, "rate-limit");
+		assert.doesNotMatch(classified.message, /available balance/);
+		assert.equal(isRetryableAssistantError(asPiMessage(classified.message)), true);
+	});
+
+	it("never retries subscription, auth, billing, or permission failures", () => {
+		for (const text of [LIMIT_TEXT, "401 Unauthorized", "Credit balance is too low", "permission denied"]) {
+			const decision = decideRetry({ failure: new Error(text), outputStarted: false, retriesUsed: 0 });
+			assert.equal(decision.retry, false, text);
+		}
+	});
+});
+
+describe("transient overload retry", () => {
+	it("retries exactly once before output and then succeeds", async () => {
+		const { context, events } = harness();
+		let starts = 0;
+		let restarts = 0;
+		const attempt = {
+			current: () => {
+				starts++;
+				if (starts === 1) return failedStream(new Error(OVERLOAD_TEXT));
+				return streamOf([{ type: "result", subtype: "success", result: "recovered" }]);
+			},
+			restart: () => { restarts++; },
+			abort: () => {},
+		};
+
+		await __test.consumeQueryWithRetry(attempt, new Map(), model, () => false, context);
+
+		assert.equal(starts, 2);
+		assert.equal(restarts, 1);
+		assert.equal(context.turnOutput.stopReason, "stop");
+		assert.equal(context.turnOutput.errorMessage, undefined);
+		assert.deepEqual(events.filter((event) => event.type === "text_end").map((event) => event.content), ["recovered"]);
+	});
+
+	it("retries transient error results as well as rejected queries", async () => {
+		const { context } = harness();
+		let starts = 0;
+		const attempt = {
+			current: () => {
+				starts++;
+				if (starts === 1) return streamOf([{ type: "result", subtype: "success", is_error: true, result: OVERLOAD_TEXT }]);
+				return streamOf([{ type: "result", subtype: "success", result: "recovered" }]);
+			},
+			restart: () => {},
+			abort: () => {},
+		};
+
+		await __test.consumeQueryWithRetry(attempt, new Map(), model, () => false, context);
+		assert.equal(starts, 2);
+		assert.equal(context.turnOutput.stopReason, "stop");
+	});
+
+	it("does not retry after output starts", async () => {
+		const { context, events } = harness();
+		let starts = 0;
+		const attempt = {
+			current: () => {
+				starts++;
+				return (async function* () {
+					yield { type: "assistant", message: { content: [{ type: "text", text: "partial answer" }], stop_reason: "end_turn" } };
+					throw new Error(OVERLOAD_TEXT);
+				})();
+			},
+			restart: () => { assert.fail("must not restart after output"); },
+			abort: () => {},
+		};
+
+		await assert.rejects(
+			__test.consumeQueryWithRetry(attempt, new Map(), model, () => false, context),
+			/temporarily limiting requests/,
+		);
+		assert.equal(starts, 1);
+		assert.deepEqual(events.filter((event) => event.type === "text_end").map((event) => event.content), ["partial answer"]);
+	});
+
+	it("stops after one failed retry", async () => {
+		const { context } = harness();
+		let starts = 0;
+		const attempt = {
+			current: () => {
+				starts++;
+				return failedStream(new Error(OVERLOAD_TEXT));
+			},
+			restart: () => {},
+			abort: () => {},
+		};
+
+		await assert.rejects(
+			__test.consumeQueryWithRetry(attempt, new Map(), model, () => false, context),
+			/temporarily limiting requests/,
+		);
+		assert.equal(starts, 2);
+	});
+});
+
+describe("idle stall watchdog", () => {
+	it("parses the timeout override without turning junk into an immediate stall", () => {
+		assert.equal(stallTimeoutMs({}), DEFAULT_STALL_TIMEOUT_MS);
+		assert.equal(stallTimeoutMs({ CLAUDE_BRIDGE_STALL_TIMEOUT_MS: "250" }), 250);
+		assert.equal(stallTimeoutMs({ CLAUDE_BRIDGE_STALL_TIMEOUT_MS: "0" }), 0);
+		assert.equal(stallTimeoutMs({ CLAUDE_BRIDGE_STALL_TIMEOUT_MS: "junk" }), DEFAULT_STALL_TIMEOUT_MS);
+	});
+
+	it("waits through pending tool work, then stalls after the stream goes idle", async () => {
+		let pending = true;
+		let stalled;
+		const monitor = new StreamMonitor({
+			idleMs: 20,
+			hasPendingWork: () => pending,
+			onStall: (error) => { stalled = error; },
+		});
+		monitor.arm();
+		await new Promise((resolve) => setTimeout(resolve, 30));
+		assert.equal(stalled, undefined);
+
+		pending = false;
+		await new Promise((resolve) => setTimeout(resolve, 30));
+		assert.ok(stalled instanceof StreamStalledError);
+	});
+
+	it("aborts and retries a stalled query once", async () => {
+		const previous = process.env.CLAUDE_BRIDGE_STALL_TIMEOUT_MS;
+		process.env.CLAUDE_BRIDGE_STALL_TIMEOUT_MS = "20";
+		const keepAlive = setInterval(() => {}, 1_000);
+		try {
+			const { context } = harness();
+			let starts = 0;
+			let release;
+			const attempt = {
+				current: () => {
+					starts++;
+					if (starts === 2) return streamOf([{ type: "result", subtype: "success", result: "recovered" }]);
+					return (async function* () {
+						await new Promise((resolve) => { release = resolve; });
+					})();
+				},
+				restart: () => {},
+				abort: () => release?.(),
+			};
+
+			await __test.consumeQueryWithRetry(attempt, new Map(), model, () => false, context);
+			assert.equal(starts, 2);
+			assert.equal(context.turnOutput.stopReason, "stop");
+		} finally {
+			clearInterval(keepAlive);
+			if (previous === undefined) delete process.env.CLAUDE_BRIDGE_STALL_TIMEOUT_MS;
+			else process.env.CLAUDE_BRIDGE_STALL_TIMEOUT_MS = previous;
+		}
+	});
+});

--- a/tests/unit-stream-resilience.mjs
+++ b/tests/unit-stream-resilience.mjs
@@ -1,5 +1,10 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createSession, deleteSession } from "cc-session-io";
 import { isRetryableAssistantError } from "@earendil-works/pi-ai";
 import { QueryContext } from "../src/query-state.js";
 import {
@@ -31,7 +36,6 @@ async function* streamOf(messages) {
 }
 
 async function* failedStream(error) {
-	yield* [];
 	throw error;
 }
 
@@ -61,6 +65,18 @@ describe("subscription limit fallback", () => {
 		assert.equal(classified.kind, "rate-limit");
 		assert.doesNotMatch(classified.message, /available balance/);
 		assert.equal(isRetryableAssistantError(asPiMessage(classified.message)), true);
+	});
+
+	it("keeps rejected fallback authoritative over billing words but not auth", () => {
+		assert.equal(classifyFailure(`${LIMIT_TEXT}: billing quota exceeded`).kind, "rate-limit");
+		assert.equal(classifyFailure("permission denied", true).kind, "fatal");
+	});
+
+	it("latches rejection after later allowed warnings", () => {
+		const monitor = new StreamMonitor({ idleMs: 0, hasPendingWork: () => false, onStall: () => {} });
+		monitor.noteRateLimitEvent({ status: "rejected" });
+		monitor.noteRateLimitEvent({ status: "allowed_warning" });
+		assert.equal(monitor.rateLimitRejected, true);
 	});
 
 	it("never retries subscription, auth, billing, or permission failures", () => {
@@ -136,6 +152,28 @@ describe("transient overload retry", () => {
 		assert.deepEqual(events.filter((event) => event.type === "text_end").map((event) => event.content), ["partial answer"]);
 	});
 
+	it("blocks retry when tool work survives a resetTurnState", async () => {
+		const { context } = harness();
+		context.turnToolCallIds.push("toolu_01");
+		context.resetTurnState(model);
+		let starts = 0;
+		const attempt = {
+			current: () => {
+				starts++;
+				return failedStream(new Error(OVERLOAD_TEXT));
+			},
+			restart: () => { assert.fail("must not restart after tool work survived reset"); },
+			abort: () => {},
+		};
+
+		await assert.rejects(
+			__test.consumeQueryWithRetry(attempt, new Map(), model, () => false, context),
+			/temporarily limiting requests/,
+		);
+		assert.equal(starts, 1);
+		assert.deepEqual(context.turnToolCallIds, ["toolu_01"]);
+	});
+
 	it("stops after one failed retry", async () => {
 		const { context } = harness();
 		let starts = 0;
@@ -153,6 +191,30 @@ describe("transient overload retry", () => {
 			/temporarily limiting requests/,
 		);
 		assert.equal(starts, 2);
+	});
+});
+
+describe("retry session resume", () => {
+	it("rotates the retry resume session and clears its rebuild markers", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "retry-resume-"));
+		const sessionId = randomUUID();
+		try {
+			createSession({ sessionId, projectPath: cwd }).save();
+			__test.setSharedSession({ sessionId, cursor: 0, cwd, needsRebuild: true, forceRotate: true });
+			const result = __test.syncSharedSession([
+				{ role: "user", content: "first", timestamp: Date.now() },
+				{ role: "assistant", content: [{ type: "text", text: "done" }], timestamp: Date.now() },
+				{ role: "user", content: "retry this", timestamp: Date.now() },
+			], cwd);
+			assert.notEqual(result.sessionId, sessionId);
+			assert.deepEqual(__test.getSharedSession(), { sessionId: result.sessionId, cursor: 2, cwd });
+		} finally {
+			const rotatedSessionId = __test.getSharedSession()?.sessionId;
+			__test.resetSharedSession();
+			if (rotatedSessionId && rotatedSessionId !== sessionId) deleteSession(rotatedSessionId, cwd);
+			deleteSession(sessionId, cwd);
+			rmSync(cwd, { recursive: true, force: true });
+		}
 	});
 });
 
@@ -204,6 +266,90 @@ describe("idle stall watchdog", () => {
 			await __test.consumeQueryWithRetry(attempt, new Map(), model, () => false, context);
 			assert.equal(starts, 2);
 			assert.equal(context.turnOutput.stopReason, "stop");
+		} finally {
+			clearInterval(keepAlive);
+			if (previous === undefined) delete process.env.CLAUDE_BRIDGE_STALL_TIMEOUT_MS;
+			else process.env.CLAUDE_BRIDGE_STALL_TIMEOUT_MS = previous;
+		}
+	});
+});
+
+describe("post-result shutdown watchdog", () => {
+	it("stalls after a result while generator shutdown is still pending", async () => {
+		let stalled;
+		const monitor = new StreamMonitor({
+			idleMs: 20,
+			hasPendingWork: () => false,
+			onStall: (error) => { stalled = error; },
+		});
+		monitor.arm();
+		monitor.onSdkEvent("result");
+		await new Promise((resolve) => setTimeout(resolve, 30));
+		assert.ok(stalled instanceof StreamStalledError);
+		assert.equal(monitor.resultReceived, true);
+	});
+
+	it("preserves a successful turn and the captured session id when shutdown hangs after result", async () => {
+		const previous = process.env.CLAUDE_BRIDGE_STALL_TIMEOUT_MS;
+		process.env.CLAUDE_BRIDGE_STALL_TIMEOUT_MS = "20";
+		const keepAlive = setInterval(() => {}, 1_000);
+		try {
+			const { context } = harness();
+			let starts = 0;
+			let release;
+			const attempt = {
+				current: () => {
+					starts++;
+					return (async function* () {
+						yield { type: "system", subtype: "init", session_id: "sess-post-result" };
+						yield { type: "result", subtype: "success", result: "done" };
+						await new Promise((resolve) => { release = resolve; });
+					})();
+				},
+				restart: () => { assert.fail("must not restart after a successful result"); },
+				abort: () => release?.(),
+			};
+
+			const outcome = await __test.consumeQueryWithRetry(attempt, new Map(), model, () => false, context);
+
+			assert.equal(starts, 1);
+			assert.equal(context.turnOutput.stopReason, "stop");
+			assert.equal(context.turnOutput.errorMessage, undefined);
+			assert.equal(outcome.capturedSessionId, "sess-post-result");
+		} finally {
+			clearInterval(keepAlive);
+			if (previous === undefined) delete process.env.CLAUDE_BRIDGE_STALL_TIMEOUT_MS;
+			else process.env.CLAUDE_BRIDGE_STALL_TIMEOUT_MS = previous;
+		}
+	});
+
+	it("preserves a failing result when shutdown hangs", async () => {
+		const previous = process.env.CLAUDE_BRIDGE_STALL_TIMEOUT_MS;
+		process.env.CLAUDE_BRIDGE_STALL_TIMEOUT_MS = "20";
+		const keepAlive = setInterval(() => {}, 1_000);
+		try {
+			const { context } = harness();
+			let starts = 0;
+			let release;
+			const attempt = {
+				current: () => {
+					starts++;
+					return (async function* () {
+						yield { type: "system", subtype: "init", session_id: "sess-post-error" };
+						yield { type: "result", subtype: "success", is_error: true, result: LIMIT_TEXT };
+						await new Promise((resolve) => { release = resolve; });
+					})();
+				},
+				restart: () => { assert.fail("must not restart after a failing result"); },
+				abort: () => release?.(),
+			};
+
+			const outcome = await __test.consumeQueryWithRetry(attempt, new Map(), model, () => false, context);
+
+			assert.equal(starts, 1);
+			assert.equal(context.turnOutput.stopReason, "error");
+			assert.match(context.turnOutput.errorMessage, /Rate limit \(429\)/);
+			assert.equal(outcome.capturedSessionId, "sess-post-error");
 		} finally {
 			clearInterval(keepAlive);
 			if (previous === undefined) delete process.env.CLAUDE_BRIDGE_STALL_TIMEOUT_MS;


### PR DESCRIPTION
Recover cleanly when Claude streams fail before useful output.

- turn rejected subscription limits into Pi fallback signals
- retry one transient failure from a freshly synced session
- keep rate-limit rejection authoritative for the full attempt
- keep the idle watchdog active through generator shutdown
- notify a rate-limit warning once, not once per concurrent stream

Fixes #35, #43, and #58.