### PR TITLE
Serve other extensions' own model calls as self-contained Claude Code sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- **Fix: another extension's own agent loop killed pi** — an extension that drives its own `agentLoop` is served by pi-ai's default stream function, which resolves the api id in pi-ai's registry rather than in pi's model runtime, where `pi.registerProvider` put the provider. On a bridge model that threw "No API provider registered for api: claude-bridge", and since `agentLoop` never catches its own rejection, the process exited. The bridge now registers there too and serves such a call as a self-contained Claude Code session: the caller's system prompt verbatim (no prompt-capture lookup, which cannot account for a prompt pi never assembled), the caller's tools over MCP, its own session deleted when the call ends, and no read or write of the shared session — including on failure, where the error path used to discard it. Setup failures are now reported on the stream instead of thrown, since the caller cannot handle a throw.
+
 - **Fix: better isolate AskClaude tool (issue #59)** — AskClaude children no longer inherit the user's `~/.claude` `CLAUDE.md` files or skill listing, and now always get Claude Code's system prompt preset instead of only when pi-side skills exist. Thanks @JAtkinsonKO.
 - **Fix: Bogus debug message about "record count mismatch" after switching providers** — the post-rebuild integrity check did not take `@file` expansion into account when switching providers.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Use `/model` to select `claude-bridge/claude-fable-5`, `claude-bridge/claude-opu
 
 Behind the scenes, pi's tools are bridged to Claude Code but it should all work like normal in pi. Bash commands get a 120-second default timeout (matching Claude Code's default) since pi's bash has no timeout by default. Skills in pi are copied over to Claude Code's system prompt so should work as they would with any other pi provider. Steering works mid-turn: a message sent while Claude is running a tool reaches it at that tool boundary, not after the whole turn finishes.
 
+**Other extensions' own model calls:** some extensions run a small agent of their own — to summarize, label or take notes — rather than going through the conversation. On a bridge model those calls used to crash pi outright; they now run as their own Claude Code session, using the calling extension's system prompt and tools and leaving your conversation's session alone. Each one is a Claude Code subprocess on the model you selected, so if an extension makes them often, consider pointing it at a cheaper model where it lets you.
+
 **1M Context:** Opus 5, Opus 4.8, and Opus 4.7 get 1M context by default. Opus 4.6 only gets 1M if you're on a Max plan or pay for Extra Usage. Sonnet 4.6 only gets 1M if you pay for Extra Usage. You will need to set `provider.plan` and/or `provider.longContextExtraUsage` for 1M context in Opus 4.6/Sonnet 4.6 as described in [Configuration](#configuration).
 
 ## AskClaude Tool

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
+        "@earendil-works/pi-agent-core": "^0.83.0",
         "@earendil-works/pi-ai": "^0.83.0",
         "@earendil-works/pi-coding-agent": "^0.83.0",
         "@earendil-works/pi-tui": "^0.83.0",
@@ -702,6 +703,30 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.83.0.tgz",
+      "integrity": "sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.83.0",
+        "diff": "8.0.4",
+        "ignore": "7.0.5",
+        "typebox": "1.3.7",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-agent-core/node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@earendil-works/pi-ai": {
       "version": "0.83.0",
@@ -3811,6 +3836,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4402,6 +4437,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/inherits": {
@@ -5248,6 +5293,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.73.0",
+    "@earendil-works/pi-agent-core": "^0.83.0",
     "@earendil-works/pi-ai": "^0.83.0",
     "@earendil-works/pi-coding-agent": "^0.83.0",
     "@earendil-works/pi-tui": "^0.83.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { calculateCost, StringEnum, type AssistantMessage, type AssistantMessageEventStream, type Context, type ImageContent, type Model, type SimpleStreamOptions, type TextContent, type Tool, type UserMessage } from "@earendil-works/pi-ai";
 import * as piAi from "@earendil-works/pi-ai";
-import { getModels } from "@earendil-works/pi-ai/compat";
+import { getApiProvider, getModels, registerApiProvider, unregisterApiProviders } from "@earendil-works/pi-ai/compat";
 import { buildSessionContext, compact, generateBranchSummary, keyHint, type BranchSummaryResult, type CompactionEntry, type ExtensionAPI, type ExtensionContext, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import { query, type EffortLevel, type SDKMessage, type SettingSource } from "@anthropic-ai/claude-agent-sdk";
 import type { Base64ImageSource, ContentBlockParam } from "@anthropic-ai/sdk/resources";
@@ -149,6 +149,12 @@ function diagDump(label: string, data: Record<string, unknown>) {
 // On session_shutdown (including /reload), clearSession() resets this so a fresh
 // registration can occur for the next session.
 const ACTIVE_STREAM_SIMPLE_KEY = Symbol.for("claude-bridge:activeStreamSimple");
+
+// Ours among pi-ai's api-provider registrations, so shutdown removes only the one
+// this module instance made. Per instance, not per package: a subagent instance
+// that skipped registration must not be able to unregister the parent's.
+const API_PROVIDER_SOURCE_ID = `claude-bridge:${moduleInstanceId}`;
+let registeredApiProvider = false;
 
 // Claude Code's own builtin tools, for the AskClaude path where CC really runs
 // them. The provider path never sees these — it starts CC with `tools: []`.
@@ -723,6 +729,32 @@ function syncSharedSession(
 	return { sessionId: session.sessionId };
 }
 
+/**
+ * A throwaway Claude Code session holding a side request's own prior messages.
+ *
+ * Deliberately not `syncSharedSession`: that function is about keeping one
+ * long-lived session aligned with pi's history, and every one of its paths reads
+ * or writes `sharedSession`. A side request's history belongs to its caller, so it
+ * gets a session of its own, rebuilt per call and deleted when the query ends.
+ */
+function buildSideRequestSession(
+	priorMessages: Context["messages"],
+	cwd: string,
+	customToolNameToSdk?: Map<string, string>,
+	modelId?: string,
+): string {
+	const session = createSession({
+		projectPath: cwd,
+		claudeDir: process.env.CLAUDE_CONFIG_DIR,
+		...(modelId ? { model: modelId } : {}),
+	});
+	convertAndImportMessages(session, priorMessages, customToolNameToSdk, []);
+	session.save();
+	verifyWrittenSession(session.jsonlPath, session.sessionId, session.records.length, cwd);
+	debug(`side request: built session ${session.sessionId.slice(0, 8)} from ${priorMessages.length} prior messages, ${session.records.length} records`);
+	return session.sessionId;
+}
+
 // @internal
 export const __test = {
 	resetSharedSession() {
@@ -738,6 +770,7 @@ export const __test = {
 		piUI = ui;
 	},
 	syncSharedSession,
+	buildSideRequestSession,
 	extractUserPromptBlocks,
 	consumeQuery,
 	finalizeCurrentStream,
@@ -1421,13 +1454,52 @@ function drainForAbort(c: QueryContext, promptStream: PromptStream): void {
 
 /** Provider entry point. Pi calls this for each new prompt and each tool result.
  *  Two cases: tool result delivery (active query) or fresh query. */
-function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream {
-	showStartupNoticeOnce();
+/**
+ * A request that is not part of pi's conversation.
+ *
+ * Extensions that drive their own `agentLoop` get pi-ai's default stream
+ * function, which resolves the api id in pi-ai's own registry rather than in
+ * pi's model runtime — so such a call never reaches the provider registered
+ * with `pi.registerProvider`. An unresolved api id there does not merely fail
+ * the call: `agentLoop` starts the run with `void runAgentLoop(...).then(...)`
+ * and no `catch`, so the rejection escapes as an unhandled one and takes pi's
+ * process down.
+ *
+ * Such a request carries its own system prompt, its own tools and a
+ * conversation of its own that pi never recorded, so it is served as a
+ * self-contained Claude Code session: no prompt capture, no shared session, and
+ * the session it captures is deleted when it ends.
+ */
+function streamSideRequest(model: Model<any>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream {
+	try {
+		return streamClaudeAgentSdk(model, context, options, true);
+	} catch (err) {
+		// Setup failures are reported on the stream rather than thrown, because a throw
+		// reaches a caller that cannot handle one: `agentLoop` awaits the stream inside
+		// a promise it never catches. An `error` event resolves `result()` with a failed
+		// message instead, which the loop ends the turn on.
+		debug("side request: setup failed", err);
+		const stream = newAssistantMessageEventStream();
+		const failed = new QueryContext();
+		failed.resetTurnState(model);
+		failed.turnOutput!.stopReason = "error";
+		failed.turnOutput!.errorMessage = errorMessage(err);
+		queueMicrotask(() => {
+			stream.push({ type: "error", reason: "error", error: failed.turnOutput! });
+			markStreamComplete(stream);
+			stream.end();
+		});
+		return stream;
+	}
+}
+
+function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: SimpleStreamOptions, side = false): AssistantMessageEventStream {
+	if (!side) showStartupNoticeOnce();
 	const stream = newAssistantMessageEventStream();
 
 	// DEBUG: trace followUp message triggering
 	const lastMsgRole = context.messages[context.messages.length - 1]?.role;
-	debug(`provider: streamClaudeAgentSdk called, activeQuery=${!!ctx().activeQuery}, lastMsgRole=${lastMsgRole}, isReentrant=${ctx().activeQuery !== null}`);
+	debug(`provider: streamClaudeAgentSdk called, side=${side}, activeQuery=${!!ctx().activeQuery}, lastMsgRole=${lastMsgRole}`);
 
 	const activeQuery = ctx().activeQuery !== null;
 	const allResults = activeQueryContexts.size > 0 ? extractAllToolResults(context) : [];
@@ -1485,8 +1557,10 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// --- Fresh query ---
 
 	// 1. Determine reentrancy. Reentrant queries get their own QueryContext so
-	//    background subagents can run concurrently with the parent query.
-	const isReentrant = activeQuery;
+	//    background subagents can run concurrently with the parent query. A side
+	//    request is always its own: it runs alongside pi's conversation, so taking
+	//    the shared context would strand whatever that context is mid-turn.
+	const isReentrant = side || activeQuery;
 	const queryCtx = isReentrant ? new QueryContext() : ctx();
 	debug(`provider: fresh query setup, isReentrant=${isReentrant}, activeContexts=${activeQueryContexts.size}`);
 
@@ -1498,7 +1572,12 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// `--no-skills` reach Claude Code by leaving nothing to forward. A sub-agent's
 	// custom override embeds its parent's assembled Pi prompt; recursive projection
 	// replaces that exact inherited prompt with its already-safe portable parts.
-	const promptCapture = promptCaptures.resolveOrDerive(context.systemPrompt);
+	//
+	// A side request is exempt: its prompt is its own, assembled by whichever
+	// extension is calling and never seen by `before_agent_start`, so there is
+	// nothing to resolve it to and nothing of pi's to forward. It is sent to Claude
+	// Code verbatim instead.
+	const promptCapture = side ? undefined : promptCaptures.resolveOrDerive(context.systemPrompt);
 	const systemPromptAppend = promptCapture
 		? projectPromptCapture(promptCapture, {
 			skillReadTool: mcpTools.some((tool) => tool.name === "read") ? "mcp" : "none",
@@ -1521,7 +1600,19 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 	// cliModel is the actual id sent to Claude Code (may carry [1m]); model.id is the
 	// pi-registered id. Log cliModel so debug lines reflect what CC actually received.
 	const cliModel = claudeCodeModelId(model, longContextSettings);
-	const syncResult = syncSharedSession(context.messages, cwd, customToolNameToSdk, cliModel);
+	// A side request neither reads the shared session nor adopts one: its history is
+	// not pi's, so resuming pi's session would prepend a conversation the caller
+	// never sent. `preserveSharedSession` is what makes the completion handler treat
+	// the session Claude Code creates for it as ephemeral and delete it.
+	const sidePriorMessages = side ? context.messages.slice(0, turnStart(context.messages)) : [];
+	const syncResult: SyncResult = side
+		? {
+			sessionId: sidePriorMessages.length > 0
+				? buildSideRequestSession(sidePriorMessages, cwd, customToolNameToSdk, cliModel)
+				: null,
+			preserveSharedSession: true,
+		}
+		: syncSharedSession(context.messages, cwd, customToolNameToSdk, cliModel);
 	const { sessionId: resumeSessionId } = syncResult;
 	const promptBlocks = extractUserPromptBlocks(context.messages);
 	let promptText = extractUserPrompt(context.messages) ?? "";
@@ -1593,19 +1684,24 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		permissionMode: "bypassPermissions",
 		includePartialMessages: true,
 		settings: { ...claudeCodeSettings(providerSettings), claudeMdExcludes: CLAUDE_MD_EXCLUDES },
-		systemPrompt: {
-			type: "preset", preset: "claude_code",
-			append: systemPromptAppend ? systemPromptAppend : undefined,
-		},
+		// A side request's prompt replaces Claude Code's preset rather than appending to
+		// it: the caller wrote a complete prompt for a single narrow job, and the coding
+		// agent preset would talk it into being a coding agent.
+		systemPrompt: side
+			? context.systemPrompt
+			: {
+				type: "preset", preset: "claude_code",
+				append: systemPromptAppend ? systemPromptAppend : undefined,
+			},
 		extraArgs,
 		...(effort ? { effort } : {}),
 		...(mcpServers ? { mcpServers } : {}),
 		...(resumeSessionId ? { resume: resumeSessionId } : {}),
 		...(claudeExecutable ? { pathToClaudeCodeExecutable: claudeExecutable } : {}),
-		...makeCliDebugOptions("provider"),
+		...makeCliDebugOptions(side ? "side-request" : "provider"),
 	};
 
-	debug("provider: fresh query",
+	debug(side ? "provider: fresh side request" : "provider: fresh query",
 		`model=${cliModel} msgs=${context.messages.length} tools=${mcpTools.length}`,
 		`resume=${resumeSessionId?.slice(0, 8) ?? "none"} effort=${effort ?? "default"}`,
 		`ctxFiles=${promptCapture?.contextFiles.length ?? 0} strictMcp=${strictMcpConfigEnabled}`,
@@ -1643,8 +1739,10 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 
 			// --- Abort detection in normal completion path ---
 			if (wasAborted || options?.signal?.aborted) {
-				if (sharedSession) sharedSession = { ...sharedSession, needsRebuild: true, forceRotate: true };
-				debug(`provider: abort detected, marked sharedSession needsRebuild + forceRotate`);
+				// A side request runs in its own Claude Code session, so aborting it says
+				// nothing about whether pi's session still matches pi's history.
+				if (sharedSession && !side) sharedSession = { ...sharedSession, needsRebuild: true, forceRotate: true };
+				debug(`provider: abort detected, sharedSession needsRebuild + forceRotate=${!side}`);
 				if (queryCtx.turnOutput) {
 					queryCtx.turnOutput.stopReason = "aborted";
 					queryCtx.turnOutput.errorMessage = "Operation aborted";
@@ -1679,10 +1777,15 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		})
 		.catch((error) => {
 			debug(`provider: query error, model=${cliModel}, aborted=${Boolean(options?.signal?.aborted)}, error=`, error);
-			if ((wasAborted || options?.signal?.aborted) && sharedSession) {
-				sharedSession = { ...sharedSession, needsRebuild: true, forceRotate: true };
-			} else {
-				sharedSession = null;
+			// Not for a side request: it owns no part of the shared session, and
+			// discarding pi's on its behalf would cost the next real turn a full rebuild
+			// over a failure that had nothing to do with it.
+			if (!side) {
+				if ((wasAborted || options?.signal?.aborted) && sharedSession) {
+					sharedSession = { ...sharedSession, needsRebuild: true, forceRotate: true };
+				} else {
+					sharedSession = null;
+				}
 			}
 			promptStream.fail(error instanceof Error ? error : new Error(String(error)));
 			if (queryCtx.turnOutput) {
@@ -1708,6 +1811,10 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 			// nothing will resume it. Clear the handle only if a later query
 			// hasn't already claimed the shared context.
 			promptStream.fail(new Error("query ended"));
+			// The session built for a side request is scoped to that request, however it
+			// ended. When Claude Code kept the id we resumed, the completion handler above
+			// has already deleted it and this is a no-op.
+			if (side && syncResult.sessionId) deleteSession(syncResult.sessionId, cwd, process.env.CLAUDE_CONFIG_DIR);
 			if (queryCtx.promptStream === promptStream) queryCtx.promptStream = null;
 			// A later query claiming this context sets activeQuery to its own handle;
 			// null means the .then/.catch above cleared ours and nothing replaced it.
@@ -1979,6 +2086,13 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_shutdown", () => {
 		reportLeaks("session_shutdown");
 		clearSession("session_shutdown");
+		// Not in clearSession: that also runs on session_start, and a live session
+		// still needs to be able to serve side requests.
+		if (registeredApiProvider) {
+			unregisterApiProviders(API_PROVIDER_SOURCE_ID);
+			registeredApiProvider = false;
+			debug("side request: unregistered api provider");
+		}
 	});
 
 	pi.on("session_before_compact", async (event, ctx) => {
@@ -2087,6 +2201,28 @@ export default function (pi: ExtensionAPI) {
 		// ModelRegistry from the parent's registration. Calls to those models
 		// route through the parent's streamSimple via reentrant QueryContexts.
 		debug(`provider: skipping re-registration, parent instance active (module=${moduleInstanceId})`);
+	}
+
+	// pi's model runtime is not the only route to a bridge model. An extension that
+	// drives its own agentLoop is served by pi-ai's default stream function, which
+	// resolves the api id against pi-ai's own registry and never sees what
+	// pi.registerProvider registered. So register there too, or such a call throws
+	// where nothing catches it.
+	//
+	// First instance wins, as above: an in-flight side request delivers its tool
+	// results back through the module instance that started it. /reload needs no
+	// coordination — pi calls resetApiProviders() between shutdown and reactivation.
+	if (!getApiProvider(PROVIDER_ID)) {
+		registerApiProvider({
+			api: PROVIDER_ID,
+			// Cast: both entry points take SimpleStreamOptions, and a side request has no
+			// use for the rich `stream` contract — pi's own provider composer likewise
+			// routes `stream` to an extension's streamSimple.
+			stream: streamSideRequest as any,
+			streamSimple: streamSideRequest as any,
+		}, API_PROVIDER_SOURCE_ID);
+		registeredApiProvider = true;
+		debug(`side request: registered api provider (module=${moduleInstanceId})`);
 	}
 
 	// --- AskClaude tool ---

--- a/tests/fixtures/side-request-extension.ts
+++ b/tests/fixtures/side-request-extension.ts
@@ -1,0 +1,81 @@
+// Test extension: drives a model the way a note-taking extension does — its own
+// `agentLoop`, its own system prompt, its own tool, and no `streamFn`. That last part is what makes this shape distinct: pi-ai's default
+// stream function resolves the api id in pi-ai's registry, so the call reaches the
+// bridge only through its api-provider registration, and no pi-side takeover can
+// intercept it.
+//
+// The result goes to a file rather than the UI so the test can assert on it.
+import { agentLoop, type AgentTool } from "@earendil-works/pi-agent-core";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { writeFileSync } from "node:fs";
+import { Type } from "typebox";
+
+const NOTE_TAKER_SYSTEM =
+	"You record notes about a conversation. Call record_note for each note, "
+	+ "then reply with a short plain-text confirmation to end the run.";
+
+export default function (pi: ExtensionAPI) {
+	async function runSideRequest(model: unknown, outPath: string, word: string) {
+		const recorded: string[] = [];
+		const recordNote: AgentTool<any> = {
+			name: "record_note",
+			label: "Record note",
+			description: "Record one note about the conversation.",
+			parameters: Type.Object({ content: Type.String({ description: "The note, one line." }) }),
+			execute: async (_id: string, params: { content: string }) => {
+				recorded.push(params.content);
+				return { content: [{ type: "text", text: "Recorded. Stop calling the tool and confirm." }], details: undefined };
+			},
+		};
+
+		const result: Record<string, unknown> = { recorded };
+		try {
+			const stream = agentLoop(
+				[{
+					role: "user",
+					content: [{ type: "text", text: `Record a note whose content is exactly the word ${word}.` }],
+					timestamp: Date.now(),
+				}],
+				{ systemPrompt: NOTE_TAKER_SYSTEM, messages: [], tools: [recordNote] },
+				{ model, convertToLlm: (messages) => messages as any, toolExecution: "sequential" } as any,
+				// No streamFn, which is the whole point: pi-ai's default is what routes by
+				// api id, and it is the only route an extension like this one has.
+				undefined,
+				undefined as any,
+			);
+			for await (const _event of stream) {
+				// Drain; the tool's execute collects what we assert on.
+			}
+			const final = await stream.result();
+			result.stopReason = (final as any).at(-1)?.stopReason;
+			result.errorMessage = (final as any).at(-1)?.errorMessage;
+		} catch (err) {
+			// A throw is itself a finding: this caller is the one whose rejections go
+			// unhandled, so the bridge must report failures on the stream instead.
+			result.threw = err instanceof Error ? err.message : String(err);
+		}
+		writeFileSync(outPath, JSON.stringify(result));
+	}
+
+	pi.registerCommand("side-request", {
+		description: "Run a self-contained agent loop beside the conversation",
+		handler: async (args, ctx) => {
+			await runSideRequest(ctx.model, args.trim(), "GAMMA");
+		},
+	});
+
+	// The overlap consolidation really runs in: a side request starting while a turn
+	// of the conversation is still in flight. Running it from a tool the model calls
+	// guarantees that — the main Claude Code query is parked on this tool result.
+	const params = Type.Object({ path: Type.String({ description: "Where to write the result." }) });
+	pi.registerTool<typeof params>({
+		name: "run_side_request",
+		label: "Run side request",
+		description: "Runs a background note-taker over the conversation. Call it exactly once when asked to.",
+		parameters: params,
+		execute: async (_toolCallId, args, _signal, _onUpdate, ctx) => {
+			await runSideRequest(ctx.model, args.path, "DELTA");
+			return { content: [{ type: "text", text: "side request finished" }], details: undefined };
+		},
+	});
+}

--- a/tests/int-side-request.mjs
+++ b/tests/int-side-request.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Side requests, end to end against a real Claude Code subprocess.
+//
+// An extension that drives its own `agentLoop` is served by pi-ai's default stream
+// function, which resolves the api id in pi-ai's own registry — not in pi's model
+// runtime, where `pi.registerProvider` put the provider. Unregistered there, such a
+// call threw, and because `agentLoop` never catches its own rejection, pi exited.
+//
+// Serving one is more than not throwing: it has its own system prompt, its own tool
+// and a conversation of its own, and it runs beside a live session whose Claude Code
+// session it must not disturb. Only a real subprocess shows all of that.
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, rmSync, statSync } from "node:fs";
+import { setTimeout as sleep } from "node:timers/promises";
+import { createRpcHarness } from "./lib/rpc-harness.mjs";
+
+const TEST_TIMEOUT = 180_000;
+
+const harness = createRpcHarness({
+	name: "side-request",
+	args: [
+		"-e", "./tests/fixtures/side-request-extension.ts",
+		"--model", "claude-bridge/claude-haiku-4-5",
+	],
+	defaultTimeout: TEST_TIMEOUT,
+});
+
+describe("side requests", () => {
+	const { startAndWait, stop, send, promptAndWait, DEBUG_LOG, LOGDIR } = harness;
+	const RESULT_PATH = `${LOGDIR}/side-request-result.json`;
+
+	const OVERLAP_PATH = `${LOGDIR}/side-request-overlap.json`;
+
+	before(async () => {
+		rmSync(RESULT_PATH, { force: true });
+		rmSync(OVERLAP_PATH, { force: true });
+		await startAndWait();
+	});
+	after(async () => { await stop(); });
+
+	/** The command returns before the loop finishes and a slash command emits no
+	 *  agent_end, so wait on the file the fixture writes. */
+	async function waitForResult(path, timeout = 150_000) {
+		const deadline = Date.now() + timeout;
+		while (Date.now() < deadline) {
+			if (existsSync(path)) return JSON.parse(readFileSync(path, "utf8"));
+			await sleep(500);
+		}
+		throw new Error(`the side request never produced a result at ${path}`);
+	}
+
+	it("serves a self-contained loop without disturbing the conversation", { timeout: TEST_TIMEOUT }, async () => {
+		// A real turn first, so there is a shared session for the side request to spoil.
+		await promptAndWait("Reply with exactly the word ALPHA and nothing else.");
+
+		const mark = statSync(DEBUG_LOG).size;
+		await send({ type: "prompt", message: `/side-request ${RESULT_PATH}` });
+		const result = await waitForResult(RESULT_PATH);
+		const log = () => readFileSync(DEBUG_LOG, "utf8").slice(mark);
+
+		assert.equal(result.threw, undefined, `a throw here reaches a caller that cannot handle one: ${result.threw}`);
+		assert.equal(result.errorMessage, undefined, `the side request failed: ${result.errorMessage}`);
+		// Tool calling and the turn that follows the result both have to work: the loop
+		// executes the tool itself and calls back with the result appended.
+		assert.deepEqual(result.recorded, ["GAMMA"], `Claude Code did not run the caller's tool: ${JSON.stringify(result)}`);
+		assert.match(log(), /provider: fresh side request/, "the request did not take the side-request path");
+		assert.doesNotMatch(
+			log(),
+			/no capture for this \d+-char system prompt/,
+			"the caller's own prompt was put to the prompt-capture resolver, which cannot account for it",
+		);
+
+		// The conversation's own session must be untouched: it is still aligned with
+		// pi's history, so the next real turn resumes it rather than rebuilding.
+		const beforeNextTurn = statSync(DEBUG_LOG).size;
+		await promptAndWait("Reply with exactly the word BETA and nothing else.");
+		const nextTurn = readFileSync(DEBUG_LOG, "utf8").slice(beforeNextTurn);
+		assert.match(
+			nextTurn,
+			/syncResult: path=reuse/,
+			`the side request cost the next turn its session:\n${nextTurn.slice(-1500)}`,
+		);
+	});
+
+	// Consolidation does not wait for the conversation to go idle, so the case that
+	// matters is a side request starting while a turn is still in flight: two Claude
+	// Code queries alive at once, each having to keep hold of its own tool results.
+	it("runs alongside a turn that is still in flight", { timeout: TEST_TIMEOUT }, async () => {
+		const mark = statSync(DEBUG_LOG).size;
+		const reply = await promptAndWait(
+			`Call the run_side_request tool with path ${OVERLAP_PATH}, then reply with exactly the word EPSILON.`,
+		);
+		const result = await waitForResult(OVERLAP_PATH);
+		const log = readFileSync(DEBUG_LOG, "utf8").slice(mark);
+
+		assert.equal(result.threw, undefined, `the nested side request threw: ${result.threw}`);
+		assert.deepEqual(result.recorded, ["DELTA"], `the nested side request produced nothing: ${JSON.stringify(result)}`);
+		// The parent turn has to survive it: its own tool result still has to come back,
+		// which it only does if the side request never claimed the parent's context.
+		assert.match(reply, /EPSILON/, `the parent turn did not finish:\n${log.slice(-1500)}`);
+	});
+});

--- a/tests/unit-pi-streamfn-inventory.mjs
+++ b/tests/unit-pi-streamfn-inventory.mjs
@@ -38,7 +38,7 @@ const PI_DIST = fileURLToPath(new URL("../node_modules/@earendil-works/pi-coding
  *  A changed count is not automatically a bug; it means read the diff and re-decide. */
 const HANDLED = {
 	"agent-session.js": { mentions: 1, why: "the one hand-off: `streamFn: this.agent.streamFunction` into generateBranchSummary" },
-	"sdk.js": { mentions: 2, why: "constructs the agent, does not summarize" },
+	"sdk.js": { mentions: 2, why: "constructs the agent, does not summarize; also installs pi-ai's compat streamSimple as agent-core's default — the route a caller passing no streamFn takes, covered below" },
 	"compaction/compaction.js": { mentions: 13, why: "taken over via session_before_compact -> isolatedStreamFn" },
 	"compaction/branch-summarization.js": { mentions: 2, why: "taken over via session_before_tree -> isolatedStreamFn" },
 };
@@ -84,6 +84,58 @@ describe("pi streamFn consumers", () => {
 			[],
 			`pi changed how often these reference streamFn: ${drifted.join("; ")}. `
 			+ `Read the diff — a new call site inside a file we already trust is the case a filename-only inventory misses — then update the counts.`,
+		);
+	});
+});
+
+/**
+ * The consumer this inventory could never have found: one that passes no `streamFn`
+ * at all. `agentLoop` then falls back to pi-ai's default, which resolves the model's
+ * api id against pi-ai's own registry — a list `pi.registerProvider` does not
+ * populate. Such a caller exited pi on the unresolved id rather than failing its
+ * own call.
+ *
+ * Probed live against a stand-in api id, so it pins the routing rule the bridge's
+ * api-provider registration depends on without spawning Claude Code.
+ */
+describe("a caller that passes no streamFn", () => {
+	it("is routed by api id through pi-ai's api registry", async () => {
+		// Located by path, and both from pi's own tree: pi-agent-core is nested under
+		// pi-coding-agent with its own pi-ai copy, and it is that pair pi runs. Importing
+		// either by specifier would reach this package's top-level copy instead, whose
+		// registry the loop never consults.
+		const piTree = fileURLToPath(new URL("../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works", import.meta.url));
+		const { agentLoop } = await import(join(piTree, "pi-agent-core/dist/index.js"));
+		const { registerApiProvider, unregisterApiProviders } = await import(join(piTree, "pi-ai/dist/compat.js"));
+		// agent-core ships no default of its own — it throws until something installs one.
+		// pi does that from this module, so the fallback only exists because pi is loaded.
+		await import(fileURLToPath(new URL("../node_modules/@earendil-works/pi-coding-agent/dist/core/sdk.js", import.meta.url)));
+
+		const api = "claude-bridge-inventory-probe";
+		const calls = [];
+		const streamSimple = (model) => {
+			calls.push(model.api);
+			return {
+				async *[Symbol.asyncIterator]() {},
+				result: () => Promise.resolve({ role: "assistant", content: [], stopReason: "stop" }),
+			};
+		};
+		registerApiProvider({ api, stream: streamSimple, streamSimple }, api);
+		try {
+			const loop = agentLoop(
+				[{ role: "user", content: "probe", timestamp: Date.now() }],
+				{ systemPrompt: "probe", messages: [], tools: [] },
+				{ model: { id: "probe", api, provider: api, baseUrl: "probe" }, convertToLlm: (messages) => messages },
+			);
+			await loop.result();
+		} finally {
+			unregisterApiProviders(api);
+		}
+
+		assert.deepEqual(
+			calls,
+			[api],
+			"pi-ai no longer resolves a default-streamFn call by api id — that resolution is how a caller with no streamFn reaches the bridge at all",
 		);
 	});
 });

--- a/tests/unit-side-request.mjs
+++ b/tests/unit-side-request.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+/**
+ * Side requests: the route into a bridge model that pi's model runtime does not own.
+ *
+ * An extension driving its own `agentLoop` is served by pi-ai's default stream
+ * function, which resolves the api id in pi-ai's registry rather than in pi's model
+ * runtime — so `pi.registerProvider` alone leaves it unserved. That was not a failed
+ * call but a dead process: `agentLoop` starts its run with `void
+ * runAgentLoop(...).then(...)` and no `catch`, so the rejection escaped as an
+ * unhandled one and pi exited.
+ *
+ * These pin the registration and the session isolation. Serving one for real needs a
+ * Claude Code subprocess — see tests/int-side-request.mjs.
+ */
+
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { deleteSession, openSession } from "cc-session-io";
+import { getApiProvider } from "@earendil-works/pi-ai/compat";
+
+const { default: activate, __test } = await import("../src/index.js");
+
+function activateWithMockPi() {
+	const handlers = new Map();
+	activate({ on: (event, handler) => handlers.set(event, handler), registerProvider: () => {} });
+	return handlers;
+}
+
+describe("api provider registration", () => {
+	after(() => { __test.resetSharedSession(); });
+
+	it("covers the api id in pi-ai's own registry, not just pi's model runtime", () => {
+		const handlers = activateWithMockPi();
+		assert.ok(
+			getApiProvider("claude-bridge"),
+			"unregistered here, an extension's own agentLoop on a bridge model throws where nothing catches it",
+		);
+
+		// A live session keeps serving side requests, so only shutdown may withdraw it.
+		handlers.get("session_start")({ reason: "new" }, {});
+		assert.ok(getApiProvider("claude-bridge"), "session_start must not withdraw the registration");
+
+		handlers.get("session_shutdown")({}, {});
+		assert.equal(getApiProvider("claude-bridge"), undefined, "shutdown leaves no route to a torn-down module");
+
+		// The /reload shape: pi tears the old instance down before reactivating.
+		activateWithMockPi();
+		assert.ok(getApiProvider("claude-bridge"), "reactivation after shutdown must restore it");
+	});
+});
+
+describe("side request session", () => {
+	it("holds the caller's own history and leaves the shared session alone", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "side-request-"));
+		const mainSession = { sessionId: "11111111-1111-4111-8111-111111111111", cursor: 42, cwd };
+		__test.setSharedSession(mainSession);
+		let sessionId;
+		try {
+			sessionId = __test.buildSideRequestSession([
+				{ role: "user", content: "the caller's own first turn", timestamp: Date.now() },
+				{ role: "assistant", content: [{ type: "text", text: "and its reply" }], timestamp: Date.now() },
+			], cwd, undefined, "claude-haiku-4-5");
+
+			assert.notEqual(sessionId, mainSession.sessionId, "a side request must not write into pi's session");
+			assert.deepEqual(__test.getSharedSession(), mainSession, "nor take over the shared-session bookkeeping");
+
+			// Skipping the rebuild would drop this history silently: the prompt Claude Code
+			// receives is only the caller's last user turn.
+			const written = openSession({ sessionId, projectPath: cwd, claudeDir: process.env.CLAUDE_CONFIG_DIR });
+			assert.equal(written.messages.length, 2, "the caller's prior turns must reach Claude Code");
+		} finally {
+			__test.resetSharedSession();
+			if (sessionId) deleteSession(sessionId, cwd, process.env.CLAUDE_CONFIG_DIR);
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Some extensions run a small agent of their own — to summarize, label or take notes — rather than going through the conversation. On a bridge model those calls previously crashed pi outright: pi-ai's default stream function resolves the api id in its own registry, not in the model runtime where `pi.registerProvider` put us, so such a call threw "No API provider registered for api: claude-bridge", and since `agentLoop` never catches its own rejection, the process exited.

These calls are now served as a self-contained Claude Code session:
- the calling extension's system prompt **verbatim** (no prompt-capture lookup — it cannot account for a prompt pi never assembled)
- the caller's tools over MCP
- its own session, deleted when the call ends; no read or write of the conversation's shared session, including on failure (the error path used to discard it)
- setup failures reported on the stream instead of thrown

Each one is a fresh CC subprocess on the selected model, so extensions making frequent calls can be pointed at cheaper models where they allow it.

## Testing
- `tests/int-side-request.mjs` — end-to-end against a real alternate extension fixture
- `tests/unit-side-request.mjs` and an extended `tests/unit-pi-streamfn-inventory.mjs`