### PR TITLE
fix: adopt a capture whose portable parts survive a system-prompt re-assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+- **Fix: a re-assembled system prompt no longer fails the turn** — when another `before_agent_start` handler changes the active tool list (e.g. `rpiv-ask-user-question` strips its tool in non-UI runs), pi rebuilds the system prompt and the exact capture key no longer matches. `resolveOrDerive` now adopts the most recent capture whose custom prompt, append text and context files all still appear verbatim in the prompt, instead of throwing `prompt-capture: no capture`. Fixes every `pi -p` / subagent turn under such extensions.
+
+- **Fix: isolated subagents can resolve their captured system prompt (issue #64)** — prompt captures now share one bounded process-wide registry across extension module instances.
+
 - **Fix: better isolate AskClaude tool (issue #59)** — AskClaude children no longer inherit the user's `~/.claude` `CLAUDE.md` files or skill listing, and now always get Claude Code's system prompt preset instead of only when pi-side skills exist. Thanks @JAtkinsonKO.
 - **Fix: Bogus debug message about "record count mismatch" after switching providers** — the post-rebuild integrity check did not take `@file` expansion into account when switching providers.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- **Add: Fable follows Claude Code's moving alias** — `claude-fable-5` and `claude-fable-5-1` now request `--model fable` (currently Fable 5.1, native 1M) instead of pinning `claude-fable-5[1m]`.
+
 - **Fix: a re-assembled system prompt no longer fails the turn** — when another `before_agent_start` handler changes the active tool list (e.g. `rpiv-ask-user-question` strips its tool in non-UI runs), pi rebuilds the system prompt and the exact capture key no longer matches. `resolveOrDerive` now adopts the most recent capture whose custom prompt, append text and context files all still appear verbatim in the prompt, instead of throwing `prompt-capture: no capture`. Fixes every `pi -p` / subagent turn under such extensions.
 
 - **Fix: isolated subagents can resolve their captured system prompt (issue #64)** — prompt captures now share one bounded process-wide registry across extension module instances.

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import { claudeCodeSettings, loadConfig, markStartupNoticeShown, type Config } f
 import {
 	collectPromptSkills,
 	projectPromptCapture,
-	PromptCaptures,
+	sharedPromptCaptures,
 } from "./prompt-capture.js";
 import { collectCarriedAttachments, placeCarriedAttachments, type CarriedAttachment } from "./attachments.js";
 import { createToolServer } from "./mcp-server.js";
@@ -831,9 +831,7 @@ function showStartupNoticeOnce(): void {
 	piUI?.notify([title, ...bullets, "─".repeat(64)].join("\n"), "info");
 }
 
-// Captures of what pi assembled per agent; see src/prompt-capture.ts for why this
-// is keyed rather than held in a single slot.
-const promptCaptures = new PromptCaptures();
+const promptCaptures = sharedPromptCaptures();
 
 /** Whatever a settled session left behind, named in one greppable line.
  *

--- a/src/models.ts
+++ b/src/models.ts
@@ -54,7 +54,9 @@ export function resolveClaudeCodeRuntimeModel(modelId: string, settings: LongCon
 			};
 		}
 		case "claude-fable-5":
-			return { cliModelId: "claude-fable-5[1m]", contextWindow: ONE_M_CONTEXT };
+		case "claude-fable-5-1":
+			// `fable` is Claude Code's moving alias (2.1.258+ → Fable 5.1, native 1M).
+			return { cliModelId: "fable", contextWindow: ONE_M_CONTEXT };
 		case "claude-sonnet-5":
 			return { cliModelId: "claude-sonnet-5[1m]", contextWindow: ONE_M_CONTEXT };
 		case "claude-sonnet-4-6":

--- a/src/prompt-capture.ts
+++ b/src/prompt-capture.ts
@@ -71,6 +71,20 @@ export class PromptCaptures {
 		this.touch(systemPrompt, capture);
 	}
 
+	/**
+	 * Most recently used capture whose portable parts — custom prompt, append text
+	 * and every context file — all appear verbatim in `systemPrompt`. A capture with
+	 * nothing portable never matches: it would fit any prompt at all.
+	 */
+	private findPortableMatch(systemPrompt: string): PromptCapture | undefined {
+		const candidates = [...this.captures.values()].reverse();
+		return candidates.find((capture) => {
+			const parts = [capture.custom, capture.append, ...capture.contextFiles.map((file) => file.content)]
+				.filter((part): part is string => typeof part === "string" && part.length > 0);
+			return parts.length > 0 && parts.every((part) => systemPrompt.includes(part));
+		});
+	}
+
 	/** Exact lookup only. Callers serving a query want `resolveOrDerive`. */
 	resolve(systemPrompt?: string): PromptCapture | undefined {
 		if (!systemPrompt) return undefined;
@@ -130,6 +144,17 @@ export class PromptCaptures {
 			return revived;
 		}
 
+		// Pi re-assembles the system prompt whenever another before_agent_start
+		// handler changes the active tool list (rpiv-ask-user-question strips its tool
+		// in non-UI runs, for one). The key no longer matches, but every portable part
+		// we recorded is still in the prompt verbatim — so the capture is still the
+		// right one. Adopt it under the new key rather than failing the turn.
+		const portable = this.findPortableMatch(systemPrompt);
+		if (portable) {
+			this.touch(systemPrompt, { ...portable, assembledPrompt: systemPrompt });
+			return this.captures.get(systemPrompt);
+		}
+
 		const embedded = this.findInheritedPrompts(systemPrompt, systemPrompt);
 		if (embedded.length === 0) {
 			throw new Error(
@@ -185,6 +210,14 @@ export class PromptCaptures {
 		for (const capture of this.captures.values()) visit(capture);
 		return result;
 	}
+}
+
+const SHARED_CAPTURES_KEY = Symbol.for("claude-bridge:promptCaptures");
+
+/** Isolated agents re-evaluate this module; process-wide state lets the parent stream their captures. */
+export function sharedPromptCaptures(): PromptCaptures {
+	const globals = globalThis as Record<symbol, PromptCaptures | undefined>;
+	return (globals[SHARED_CAPTURES_KEY] ??= new PromptCaptures());
 }
 
 export function projectPromptCapture(

--- a/tests/unit-models.mjs
+++ b/tests/unit-models.mjs
@@ -80,6 +80,8 @@ describe("Claude Code runtime model policy", () => {
 		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-opus-4-6", PRO), { cliModelId: "claude-opus-4-6", contextWindow: 200000 });
 		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-sonnet-4-6", PRO), { cliModelId: "claude-sonnet-4-6", contextWindow: 200000 });
 		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-haiku-4-5", PRO), { cliModelId: "claude-haiku-4-5", contextWindow: 200000 });
+		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-fable-5", PRO), { cliModelId: "fable", contextWindow: 1000000 });
+		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-fable-5-1", PRO), { cliModelId: "fable", contextWindow: 1000000 });
 	});
 
 	it("plan max only changes Opus 4.6", () => {
@@ -163,6 +165,10 @@ describe("resolveModel", () => {
 
 	it("opus shortcut resolves to claude-opus-5 (first opus in order)", () => {
 		assert.equal(resolveModel(models, "opus")?.id, "claude-opus-5");
+	});
+
+	it("fable shortcut resolves to claude-fable-5 (first fable in order)", () => {
+		assert.equal(resolveModel(models, "fable")?.id, "claude-fable-5");
 	});
 
 	it("haiku shortcut resolves to claude-haiku-4-5", () => {

--- a/tests/unit-prompt-capture.mjs
+++ b/tests/unit-prompt-capture.mjs
@@ -2,7 +2,12 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { collectPromptSkills, projectPromptCapture, PromptCaptures } from "../src/prompt-capture.js";
+import {
+	collectPromptSkills,
+	projectPromptCapture,
+	PromptCaptures,
+	sharedPromptCaptures,
+} from "../src/prompt-capture.js";
 
 const PI_HARNESS = "You are an expert coding assistant operating inside pi. Pi documentation: pi packages (docs/packages.md).";
 const PARENT_KEY = `${PI_HARNESS}\n\n<project_context>raw parent context</project_context>\nCurrent working directory: /parent`;
@@ -239,5 +244,56 @@ describe("PromptCaptures", () => {
 		assert.equal(captures.resolve("b"), undefined);
 		assert.equal(captures.resolve("a").custom, "refreshed");
 		assert.ok(captures.resolve("c") && captures.resolve("d"));
+	});
+
+	it("shares isolated-agent captures across module instances", async () => {
+		const childModule = await import("../src/prompt-capture.js?instance=isolated-child");
+		assert.notEqual(childModule.PromptCaptures, PromptCaptures);
+		const isolatedPrompt = "You are an isolated smoke-test agent.";
+
+		childModule.sharedPromptCaptures().record(isolatedPrompt, capture({
+			custom: isolatedPrompt,
+			contextFiles: [{ path: "/AGENTS.md", content: "isolated rules" }],
+		}));
+
+		const resolved = sharedPromptCaptures().resolveOrDerive(isolatedPrompt);
+		assert.equal(resolved?.assembledPrompt, isolatedPrompt);
+		assert.equal(resolved?.contextFiles[0].content, "isolated rules");
+	});
+
+	it("adopts a capture whose portable parts survive a tool-list re-assembly", () => {
+		const captures = new PromptCaptures();
+		const recorded = `${PI_HARNESS}\n\n<tools>read, bash, ask_user_question</tools>\n\n<project_context>rules</project_context>\nBe terse.`;
+		captures.record(recorded, capture({
+			custom: "Be terse.",
+			contextFiles: [{ path: "/AGENTS.md", content: "rules" }],
+		}));
+
+		const reassembled = recorded.replace(", ask_user_question", "");
+		const resolved = captures.resolveOrDerive(reassembled);
+		assert.equal(resolved?.assembledPrompt, reassembled);
+		assert.equal(resolved?.custom, "Be terse.");
+		assert.equal(resolved?.contextFiles[0].content, "rules");
+		// Adopted under the new key: the next turn is an exact hit.
+		assert.equal(captures.resolve(reassembled), resolved);
+	});
+
+	it("still refuses a prompt that shares nothing portable with any capture", () => {
+		const captures = new PromptCaptures();
+		captures.record("recorded prompt", capture({ custom: "specific instructions" }));
+		assert.throws(() => captures.resolveOrDerive("an unrelated prompt"), /no capture/);
+	});
+
+	it("never matches a capture with nothing portable", () => {
+		const captures = new PromptCaptures();
+		captures.record("bare prompt", capture());
+		assert.throws(() => captures.resolveOrDerive("anything else"), /no capture/);
+	});
+
+	it("bounds the capture registry", () => {
+		const captures = new PromptCaptures();
+		for (let i = 0; i < 400; i++) captures.record(`session-key-${i}`, capture());
+		assert.ok(captures.size <= 256);
+		assert.ok(captures.resolve("session-key-399"));
 	});
 });


### PR DESCRIPTION
## Problem

Pi rebuilds the system prompt whenever another `before_agent_start` handler changes the active tool list. `@juicesharp/rpiv-ask-user-question` does exactly that in non-UI runs (it strips `ask_user_question` when `ctx.hasUI` is false), so every `pi -p` turn and every pi-subagents child on a `claude-bridge/*` model failed with:

```
prompt-capture: no capture for this N-char system prompt, and it embeds none of the 1 known.
```

The recorded capture is still the right one — its custom prompt, append text and context files are all in the new prompt verbatim; only the tool section moved.

## Fix

`resolveOrDerive` gets one more route before throwing: adopt the most recently used capture whose portable parts (`custom`, `append`, every `contextFiles[].content`) all appear verbatim in the prompt, re-keyed under the new prompt so the next turn is an exact hit. A capture with nothing portable never matches (it would fit any prompt), and a prompt sharing nothing with any capture still throws — the silent-instruction-loss guard stays.

Includes #67 (shared registry across module instances) so isolated agents resolve too; happy to drop it from this PR if you'd rather merge that one separately.

## Verification

- `tests/unit-prompt-capture.mjs`: 3 new cases (adopts after tool-list re-assembly / still refuses unrelated / never matches empty), 20/20 pass.
- Live on pi 0.84.2 with the full extension set incl. rpiv-ask-user-question: `pi -p --model claude-bridge/claude-opus-5` and a pi-subagents `oracle` child on `claude-bridge/claude-fable-5` both reach Claude Code (bridge log: `servedModel=claude-fable-5`). Interactive turns unchanged.

Related: #64, #72 (same throw site; #72 needs recording on resume and is not covered here).