### PR TITLE
feat(models): derive models absent from pi-ai's catalog snapshot

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -2,14 +2,30 @@
 // `resolveModel` returns the first partial match, so `opus` resolves to the first-listed opus entry.
 // Extracted from index.ts so tests can import without activating the extension.
 
-export const MODEL_IDS_IN_ORDER = ["claude-fable-5", "claude-opus-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-5", "claude-sonnet-4-6", "claude-haiku-4-5"];
+// pi-ai's bundled catalog is a release-time snapshot, so a model Anthropic
+// ships after it — Fable 5.1 on 28/08/2026 — is simply absent, and buildModels
+// drops what it cannot find. Rather than invent a context window that pi would
+// put behind its compaction threshold, inherit a verified sibling's metadata
+// and override only identity. Drop the entry when the base is missing too.
+export const DERIVED_FROM: Record<string, { from: string; name: string }> = {
+	"claude-fable-5-1": { from: "claude-fable-5", name: "Claude Fable 5.1" },
+};
+
+function deriveMissing<T extends { id: string; [key: string]: any }>(piAiModels: T[], id: string): T | undefined {
+	const rule = DERIVED_FROM[id];
+	if (!rule) return undefined;
+	const base = piAiModels.find((m) => m.id === rule.from);
+	return base ? { ...base, id, name: rule.name } : undefined;
+}
+
+export const MODEL_IDS_IN_ORDER = ["claude-fable-5-1", "claude-fable-5", "claude-opus-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-5", "claude-sonnet-4-6", "claude-haiku-4-5"];
 
 // Project pi-ai's model entries down to the fields pi's registerProvider expects,
 // and keep MODEL_IDS_IN_ORDER ordering. IDs missing from pi-ai are silently dropped.
 // Context-dependent display labels are applied after plan/long-context config is known.
 export function buildModels<T extends { id: string; [key: string]: any }>(piAiModels: T[]) {
 	return MODEL_IDS_IN_ORDER
-		.map((id) => piAiModels.find((m) => m.id === id))
+		.map((id) => piAiModels.find((m) => m.id === id) ?? deriveMissing(piAiModels, id))
 		.filter((m) => m != null)
 		// Forward thinkingLevelMap so pi-ai's per-model overrides (e.g. opus-4-8
 		// mapping xhigh→xhigh and max→max) are visible to the effort lookup.
@@ -53,6 +69,8 @@ export function resolveClaudeCodeRuntimeModel(modelId: string, settings: LongCon
 				contextWindow: useOneM ? ONE_M_CONTEXT : TWO_HUNDRED_K_CONTEXT,
 			};
 		}
+		case "claude-fable-5-1":
+			return { cliModelId: "claude-fable-5-1[1m]", contextWindow: ONE_M_CONTEXT };
 		case "claude-fable-5":
 			return { cliModelId: "claude-fable-5[1m]", contextWindow: ONE_M_CONTEXT };
 		case "claude-sonnet-5":

--- a/tests/unit-models.mjs
+++ b/tests/unit-models.mjs
@@ -184,3 +184,35 @@ describe("resolveModel", () => {
 		assert.equal(claudeCodeModelId(model, PRO), "claude-opus-5[1m]");
 	});
 });
+
+describe("models absent from pi-ai's snapshot", () => {
+	// pi-ai's catalog is fixed at its release, so a model Anthropic ships later
+	// is missing from it entirely. Deriving from a verified sibling keeps the
+	// registered contextWindow honest instead of inventing one.
+	it("derives a missing id from its declared base", () => {
+		const models = buildModels([mockPiAiModel("claude-fable-5")]);
+		const derived = models.find((m) => m.id === "claude-fable-5-1");
+		assert.ok(derived, "claude-fable-5-1 should be derived from claude-fable-5");
+		assert.equal(derived.name, "Claude Fable 5.1");
+		assert.equal(derived.contextWindow, 200000, "inherits the base entry, not an invented window");
+		assert.equal(derived.maxTokens, 8000);
+		assert.equal(derived.baseUrl, undefined, "projection still strips pi-ai's leaky fields");
+	});
+
+	it("drops a derived id when its base is missing too", () => {
+		const models = buildModels([mockPiAiModel("claude-opus-5")]);
+		assert.equal(models.find((m) => m.id === "claude-fable-5-1"), undefined);
+	});
+
+	it("prefers pi-ai's own entry once the catalog catches up", () => {
+		const real = { ...mockPiAiModel("claude-fable-5-1"), name: "Upstream Name" };
+		const models = buildModels([mockPiAiModel("claude-fable-5"), real]);
+		assert.equal(models.find((m) => m.id === "claude-fable-5-1").name, "Upstream Name");
+	});
+
+	it("requests the 1M runtime id for Fable 5.1", () => {
+		assert.deepEqual(resolveClaudeCodeRuntimeModel("claude-fable-5-1", PRO), {
+			cliModelId: "claude-fable-5-1[1m]", contextWindow: 1000000,
+		});
+	});
+});


### PR DESCRIPTION
## Problem

`buildModels` intersects `MODEL_IDS_IN_ORDER` with pi-ai's catalog and drops ids missing from it. That catalog is a snapshot taken at pi's release, so any model Anthropic ships afterwards is unreachable through the bridge until *both* pi and this repo cut a release.

Concretely today: **Claude Fable 5.1** (`claude-fable-5-1`, listed in the account catalog since 28/08/2026) is entitled and answers on Claude Code >= 2.1.251, but pi 0.84.4 — the latest published `@earendil-works/pi-coding-agent` — has no entry, so it cannot appear in the picker at all.

## Change

Derive an id that pi-ai lacks from a **declared sibling**, overriding only identity:

```ts
export const DERIVED_FROM = {
  "claude-fable-5-1": { from: "claude-fable-5", name: "Claude Fable 5.1" },
};
```

Inheriting the sibling's metadata rather than hardcoding one matters: `models.ts` already warns that the registered `contextWindow` must match what the bridge actually requests, or pi's status bar and auto-compaction threshold misreport. Deriving keeps that invariant instead of inventing a number.

Properties:

- **Fails closed** — if the base is also missing, the entry is dropped, exactly as today.
- **Self-retiring** — `piAiModels.find()` runs first, so pi-ai's own entry wins the moment its catalog catches up. The table can then be emptied with no behaviour change.
- **Scoped** — only ids explicitly listed in `DERIVED_FROM` are ever synthesized.

Also adds the `claude-fable-5-1` -> `claude-fable-5-1[1m]` runtime case (both shapes verified against a live Max subscription on Claude Code 2.1.259).

## Tests

`npm run test:unit` — 188/188 pass, including 4 new cases: derives from base, drops when the base is absent, prefers pi-ai's entry once present, and returns the 1M runtime id.