### PR TITLE
fix: refresh MCP tools after lazy activation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import {
 	PromptCaptures,
 } from "./prompt-capture.js";
 import { collectCarriedAttachments, placeCarriedAttachments, type CarriedAttachment } from "./attachments.js";
-import { createToolServer } from "./mcp-server.js";
+import { createToolServer, type McpToolDef } from "./mcp-server.js";
 import { buildActionSummary, type ToolCallState } from "./askclaude-ui.js";
 
 // Compat (#2): use factory if available (pi-ai ≥0.66), else fall back to constructor (gsd-pi etc.)
@@ -948,8 +948,7 @@ function resolveMcpTools(context: Context, excludeToolName?: string): {
 // it, and a handler that runs first parks its resolver in `pendingToolCalls`.
 // Handlers close over the captured `queryCtx`, ensuring they operate on the
 // correct query's state while multiple queries run concurrently.
-function buildMcpServers(tools: Tool[], queryCtx: QueryContext): Record<string, ReturnType<typeof createToolServer>> | undefined {
-	if (!tools.length) return undefined;
+function makeMcpTools(tools: Tool[], queryCtx: QueryContext): McpToolDef[] {
 	const mcpTools = tools.map((tool) => ({
 		name: tool.name,
 		description: tool.description,
@@ -967,10 +966,20 @@ function buildMcpServers(tools: Tool[], queryCtx: QueryContext): Record<string, 
 			});
 		},
 	}));
-	return { [MCP_SERVER_NAME]: createToolServer(MCP_SERVER_NAME, mcpTools) };
+	return mcpTools;
+}
+
+function buildMcpServers(tools: Tool[], queryCtx: QueryContext): Record<string, ReturnType<typeof createToolServer>> | undefined {
+	if (!tools.length) return undefined;
+	return { [MCP_SERVER_NAME]: createToolServer(MCP_SERVER_NAME, makeMcpTools(tools, queryCtx)) };
 }
 
 // --- Usage helpers ---
+
+const mcpToolServers = new WeakMap<QueryContext, {
+	server: ReturnType<typeof createToolServer>;
+	toolNames: Map<string, string>;
+}>();
 
 function updateUsage(output: AssistantMessage, usage: Record<string, number | undefined>, model: Model<any>): void {
 	if (usage.input_tokens != null) output.usage.input = usage.input_tokens;
@@ -1506,7 +1515,20 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		// Delivery is async because the steer must reach CC's stdin *before* the
 		// tool result does — see deliverToolResults. Detached so the provider
 		// still returns its stream synchronously.
-		void deliverToolResults(resultCtx, allResults, steer, context.messages.length);
+		void (async () => {
+			const toolServer = mcpToolServers.get(resultCtx);
+			if (toolServer) {
+				try {
+					const refreshedTools = resolveMcpTools(context, askClaudeToolName);
+					await toolServer.server.updateTools(makeMcpTools(refreshedTools.mcpTools, resultCtx));
+					toolServer.toolNames.clear();
+					for (const [sdkName, piName] of refreshedTools.customToolNameToPi) toolServer.toolNames.set(sdkName, piName);
+				} catch (error) {
+					debug("provider: MCP tool refresh failed:", error);
+				}
+			}
+			await deliverToolResults(resultCtx, allResults, steer, context.messages.length);
+		})();
 		// The shared cursor tracks the top-level conversation. A reentrant subagent
 		// delivering its own results would drag it to that subagent's message count
 		// — observed pulling a parent from 5 back to 3, which cost the parent's next
@@ -1607,6 +1629,8 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 		.catch((error) => debug(`provider: initial prompt push rejected:`, error));
 	queryCtx.promptStream = promptStream;
 	const mcpServers = buildMcpServers(mcpTools, queryCtx);
+	const mcpToolServer = mcpServers?.[MCP_SERVER_NAME];
+	if (mcpToolServer) mcpToolServers.set(queryCtx, { server: mcpToolServer, toolNames: customToolNameToPi });
 
 	// MCP auto-loading suppression: CC reads MCP servers from ~/.claude.json (top-level
 	// + per-project) and .mcp.json. Since pi executes tools (not CC), those are pure

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -56,18 +56,24 @@ function assertObjectSchema(tool: McpToolDef): void {
 	}
 }
 
-export function createToolServer(name: string, tools: McpToolDef[]) {
-	const server = new McpServer({ name, version: "1.0.0" }, { capabilities: { tools: {} } });
-	const byName = new Map(tools.map((tool) => [tool.name, tool]));
+export function createToolServer(name: string, initialTools: McpToolDef[]) {
+	const server = new McpServer({ name, version: "1.0.0" }, { capabilities: { tools: { listChanged: true } } });
+	let tools = initialTools;
+	let byName = new Map(tools.map((tool) => [tool.name, tool]));
 	for (const tool of tools) assertObjectSchema(tool);
 
-	server.server.setRequestHandler(ListToolsRequestSchema, () => ({
-		tools: tools.map((tool) => ({
-			name: tool.name,
-			description: tool.description,
-			inputSchema: tool.inputSchema as Record<string, unknown>,
-		})),
+	const toolList = () => tools.map((tool) => ({
+		name: tool.name,
+		description: tool.description,
+		inputSchema: tool.inputSchema as Record<string, unknown>,
 	}));
+	const hasSameTools = (next: McpToolDef[]) => JSON.stringify(toolList()) === JSON.stringify(next.map((tool) => ({
+		name: tool.name,
+		description: tool.description,
+		inputSchema: tool.inputSchema,
+	})));
+
+	server.server.setRequestHandler(ListToolsRequestSchema, () => ({ tools: toolList() }));
 
 	server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
 		const tool = byName.get(request.params.name);
@@ -82,5 +88,16 @@ export function createToolServer(name: string, tools: McpToolDef[]) {
 		return { content, isError };
 	});
 
-	return { type: "sdk" as const, name, instance: server };
+	return {
+		type: "sdk" as const,
+		name,
+		instance: server,
+		async updateTools(nextTools: McpToolDef[]): Promise<void> {
+			for (const tool of nextTools) assertObjectSchema(tool);
+			if (hasSameTools(nextTools)) return;
+			tools = nextTools;
+			byName = new Map(tools.map((tool) => [tool.name, tool]));
+			await server.sendToolListChanged();
+		},
+	};
 }

--- a/tests/unit-mcp-server.mjs
+++ b/tests/unit-mcp-server.mjs
@@ -44,10 +44,14 @@ const NESTED_TOOL_SCHEMA = {
 // requests into transport.onmessage, read replies out of transport.send.
 async function connectClient(server) {
 	const pending = new Map();
+	const notifications = [];
 	const transport = {
 		start: async () => {},
 		close: async () => {},
-		send: async (msg) => pending.get(msg.id)?.(msg),
+		send: async (msg) => {
+			if (msg.method === "notifications/tools/list_changed") notifications.push(msg);
+			else pending.get(msg.id)?.(msg);
+		},
 	};
 	await server.instance.connect(transport);
 
@@ -69,11 +73,11 @@ async function connectClient(server) {
 
 	await request("initialize", {
 		protocolVersion: "2025-06-18",
-		capabilities: {},
+		capabilities: { tools: { listChanged: true } },
 		clientInfo: { name: "test", version: "1.0.0" },
 	});
 	transport.onmessage({ jsonrpc: "2.0", method: "notifications/initialized" });
-	return { request, callTool };
+	return { request, callTool, notifications };
 }
 
 describe("MCP tool schema advertisement", () => {
@@ -127,6 +131,36 @@ describe("MCP tool schema advertisement", () => {
 
 	it("preserves anyOf branches", () => {
 		assert.deepStrictEqual(listed.properties.either.anyOf, [{ type: "string" }, { type: "number" }]);
+	});
+});
+
+describe("MCP tool list updates", () => {
+	it("advertises and serves a tool added after the client connects", async () => {
+		const tools = () => [
+			{
+				name: "lazy_tool_search",
+				description: "Load a tool",
+				inputSchema: { type: "object", properties: {} },
+				handler: async () => ({ content: [{ type: "text", text: "loaded" }] }),
+			},
+			{
+				name: "ctx_execute",
+				description: "Execute code",
+				inputSchema: { type: "object", properties: {} },
+				handler: async (toolCallId) => ({ content: [{ type: "text", text: toolCallId }] }),
+			},
+		];
+		const server = createToolServer("custom-tools", [tools()[0]]);
+		const { request, callTool, notifications } = await connectClient(server);
+
+		await server.updateTools(tools());
+		const listed = await request("tools/list", {});
+		assert.deepStrictEqual(listed.result.tools.map((tool) => tool.name), ["lazy_tool_search", "ctx_execute"]);
+		assert.strictEqual(notifications.length, 1);
+		await server.updateTools(tools());
+		assert.strictEqual(notifications.length, 1);
+		const result = await callTool("ctx_execute", "toolu_dynamic");
+		assert.strictEqual(result.result.content[0].text, "toolu_dynamic");
 	});
 });
 


### PR DESCRIPTION
## Background

Pi can defer tools instead of advertising every tool schema to the model at startup. This keeps the initial tool list and prompt smaller. `lazy_tool_search` is the loader for those deferred tools: Claude calls it with a capability such as "execute code", Pi finds the matching registered tool, activates it, and the newly activated tool should then be available for the next tool call in the same query.

In pi-claude-bridge, Claude Code accesses Pi tools through an MCP server. This means that activating a tool in Pi is not enough on its own. The bridge must also update the MCP tool catalog that Claude Code sees.

## Why

This came up during a real Claude Code run that was investigating a path traversal risk. The run needed `ctx_execute`, a deferred tool that executes code while keeping large command output out of the model context. Claude first called `lazy_tool_search` to activate it. Pi registered `ctx_execute` and returned a successful loader result, but the bridge still exposed the MCP tool catalog captured when the client connected. Claude therefore could not use `ctx_execute` for the next step in the same query, even though Pi had already activated it.

The bridge needs to refresh its MCP tool list before it returns the loader result. That lets Claude receive `notifications/tools/list_changed`, fetch the updated catalog, and call the new tool without restarting the query.

## Summary

- advertise MCP tool-list changes when Pi activates tools during a running Claude Code query
- refresh the bridge handler and SDK-to-Pi tool-name mapping before releasing the loader result
- cover a dynamically added `ctx_execute`-style tool with the existing MCP wire test

## Validation

- `npm run typecheck`
- `node --import tsx --import ./tests/lib/setup.mjs --test tests/unit-mcp-server.mjs`

`npm run test:unit` still has 3 unrelated failures in `unit-branch-summary.mjs`: its mock lacks `pi.registerTool`.
