### PR TITLE
fix prompt capture extension ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 
+- **Fix: prompt capture no longer depends on extension load order** — structured prompt inputs are collected in `before_agent_start`, but are now keyed in `agent_start` using Pi's finalized system prompt. Extensions that rewrite the prompt after the bridge no longer cause capture lookup failures or require wrapper-level ordering workarounds.
 - **Fix: git-status changes no longer bust the prompt cache (issue #73)** — the `claude_code` preset embeds a git-status snapshot in the cached system block, so any git transition (new file, staging, commit) rewrote the whole conversation prefix at cache-write rates. The provider path now sets `includeGitInstructions: false`, stripping the block with no other cost.
 - **Fix: rate-limit warning showed 1% and repeated every request** — the SDK reports `utilization` as a fraction (0.98), but the notification rounded it directly, printing "1% used" at 98% of the window. It now shows true percentages and only re-notifies when usage rises past a new 5% step or the threshold changes, instead of once per request while over the threshold.
 - **Fix: an exhausted Claude subscription never triggered fallback models (issue #58)** — Claude Code words a spent quota as "You're out of extra usage · resets 6:30pm", which names no recognizable symptom, so pi-subagents' `fallbackModels` and similar retry logic read it as a fatal error. A failure preceded by a rate-limit rejection is now labelled as one, with its limit type and reset time. Also fixes the rate-limit notification showing a 1970 reset time.

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { claudeCodeSettings, loadConfig, markStartupNoticeShown, type Config } f
 import {
 	collectPromptSkills,
 	projectPromptCapture,
+	PromptCaptureLifecycle,
 	PromptCaptures,
 } from "./prompt-capture.js";
 import { collectCarriedAttachments, placeCarriedAttachments, type CarriedAttachment } from "./attachments.js";
@@ -765,6 +766,9 @@ export const __test = {
 	CC_CHILD_ENV,
 	buildMcpServers,
 	branchSummaryOutcome,
+	resolvePromptCapture(systemPrompt: string) {
+		return promptCaptures.resolve(systemPrompt);
+	},
 };
 
 // --- Provider helpers: tool name mapping ---
@@ -1992,6 +1996,10 @@ const PREVIEW_MAX_LINES = 6;
 let askClaudeToolName = "AskClaude";
 
 export default function (pi: ExtensionAPI) {
+	// Structured prompt inputs are available in `before_agent_start`, while the
+	// finalized prompt is only available after every handler in that chain ran.
+	const promptCaptureLifecycle = new PromptCaptureLifecycle(promptCaptures);
+
 	// Disable non-essential Claude Code traffic (update checks, MCP registry, telemetry)
 	process.env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1";
 
@@ -2027,6 +2035,7 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_start", (event, ctx) => {
 		piUI = ctx.ui;
 		piMode = ctx.mode;
+		promptCaptureLifecycle.clear();
 		if (event.reason === "new" || event.reason === "resume" || event.reason === "fork") {
 			clearSession(`session_start:${event.reason}`);
 		}
@@ -2034,17 +2043,24 @@ export default function (pi: ExtensionAPI) {
 	// `--system-prompt` replaces pi's default rather than adding to it, but Claude
 	// Code's preset carries its own tool and permission guidance that the bridge
 	// still depends on, so both flags are forwarded as an append.
+	//
+	// Capture the structured inputs here, but wait until `agent_start` to key them:
+	// later `before_agent_start` handlers may still rewrite the assembled prompt.
 	pi.on("before_agent_start", (event) => {
 		const options = event.systemPromptOptions;
 		const hasRead = !options?.selectedTools || options.selectedTools.includes("read");
-		promptCaptures.record(event.systemPrompt, {
+		promptCaptureLifecycle.prepare({
 			custom: options?.customPrompt,
 			append: options?.appendSystemPrompt,
 			contextFiles: options?.contextFiles ?? [],
 			skills: hasRead ? options?.skills ?? [] : [],
 		});
 	});
+	pi.on("agent_start", (_event, ctx) => {
+		promptCaptureLifecycle.recordFinal(ctx.getSystemPrompt());
+	});
 	pi.on("session_shutdown", () => {
+		promptCaptureLifecycle.clear();
 		reportLeaks("session_shutdown");
 		clearSession("session_shutdown");
 	});

--- a/src/prompt-capture.ts
+++ b/src/prompt-capture.ts
@@ -232,6 +232,39 @@ export class PromptCaptures {
 	}
 }
 
+/**
+ * Carries structured prompt inputs from `before_agent_start` to `agent_start`.
+ *
+ * Pi chains `before_agent_start` handlers in extension order, so the prompt seen
+ * by the bridge may still be rewritten by a later extension. `agent_start`
+ * runs after that chain and exposes the finalized prompt through
+ * `ctx.getSystemPrompt()`. Keeping the inputs pending until then makes the
+ * capture independent of extension load order.
+ */
+export class PromptCaptureLifecycle {
+	private pending: PromptCaptureInput | undefined;
+
+	constructor(private readonly captures: PromptCaptures) {}
+
+	prepare(input: PromptCaptureInput): void {
+		this.pending = {
+			...input,
+			contextFiles: input.contextFiles.map((file) => ({ ...file })),
+			skills: [...input.skills],
+		};
+	}
+
+	recordFinal(systemPrompt: string): void {
+		const input = this.pending;
+		this.pending = undefined;
+		if (input) this.captures.record(systemPrompt, input);
+	}
+
+	clear(): void {
+		this.pending = undefined;
+	}
+}
+
 export function projectPromptCapture(
 	capture: PromptCapture,
 	options: { skillReadTool: SkillReadTool },

--- a/tests/unit-extension-prompt-capture.mjs
+++ b/tests/unit-extension-prompt-capture.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { default: activate, __test } = await import("../src/index.js");
+
+function activateWithMockPi() {
+	const handlers = new Map();
+	activate({ on: (event, handler) => handlers.set(event, handler), registerProvider: () => {} });
+	return handlers;
+}
+
+describe("extension prompt capture lifecycle", () => {
+	it("records structured inputs against the prompt finalized by later extensions", async () => {
+		const handlers = activateWithMockPi();
+		const intermediatePrompt = "prompt before a later extension rewrites it";
+		const finalPrompt = "completely replaced prompt";
+
+		await handlers.get("before_agent_start")({
+			systemPrompt: intermediatePrompt,
+			systemPromptOptions: {
+				contextFiles: [{ path: "/AGENTS.md", content: "project rules" }],
+				skills: [],
+				selectedTools: ["read"],
+			},
+		}, {});
+
+		assert.equal(__test.resolvePromptCapture(intermediatePrompt), undefined);
+
+		await handlers.get("agent_start")({}, { getSystemPrompt: () => finalPrompt });
+
+		const capture = __test.resolvePromptCapture(finalPrompt);
+		assert.ok(capture);
+		assert.equal(capture.assembledPrompt, finalPrompt);
+		assert.deepEqual(capture.contextFiles, [{ path: "/AGENTS.md", content: "project rules" }]);
+	});
+});

--- a/tests/unit-prompt-capture.mjs
+++ b/tests/unit-prompt-capture.mjs
@@ -2,7 +2,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { collectPromptSkills, projectPromptCapture, PromptCaptures } from "../src/prompt-capture.js";
+import { collectPromptSkills, projectPromptCapture, PromptCaptureLifecycle, PromptCaptures } from "../src/prompt-capture.js";
 
 const PI_HARNESS = "You are an expert coding assistant operating inside pi. Pi documentation: pi packages (docs/packages.md).";
 const PARENT_KEY = `${PI_HARNESS}\n\n<project_context>raw parent context</project_context>\nCurrent working directory: /parent`;
@@ -33,6 +33,37 @@ function project(captures, key, skillReadTool = "mcp") {
 function occurrences(text, needle) {
 	return text.split(needle).length - 1;
 }
+
+describe("PromptCaptureLifecycle", () => {
+	it("keys structured inputs by the finalized system prompt", () => {
+		const captures = new PromptCaptures();
+		const lifecycle = new PromptCaptureLifecycle(captures);
+		const contextFiles = [{ path: "/AGENTS.md", content: "parent rules" }];
+
+		lifecycle.prepare(capture({ contextFiles }));
+		assert.equal(captures.size, 0, "preparing inputs must not choose a lookup key");
+		contextFiles[0].content = "mutated after before_agent_start";
+		lifecycle.recordFinal("prompt rewritten by a later extension");
+
+		assert.equal(captures.resolve(PARENT_KEY), undefined, "only the finalized prompt may become a lookup key");
+		assert.equal(captures.resolve("prompt rewritten by a later extension").contextFiles[0].content, "parent rules");
+	});
+
+	it("consumes or clears pending inputs exactly once", () => {
+		const captures = new PromptCaptures();
+		const lifecycle = new PromptCaptureLifecycle(captures);
+
+		lifecycle.prepare(capture({ custom: "first" }));
+		lifecycle.recordFinal("first prompt");
+		lifecycle.recordFinal("unrelated agent start");
+		assert.equal(captures.resolve("unrelated agent start"), undefined);
+
+		lifecycle.prepare(capture({ custom: "stale" }));
+		lifecycle.clear();
+		lifecycle.recordFinal("later prompt");
+		assert.equal(captures.resolve("later prompt"), undefined);
+	});
+});
 
 describe("PromptCaptures", () => {
 	it("keeps parent and child captures isolated", () => {


### PR DESCRIPTION
We use a Pi wrapper that loads shared resources and instructions to provide a consistent experience across the team. This worked with earlier versions of pi-claude-bridge, but 0.7.0 introduced prompt capture that could record the system prompt before later extensions finished modifying it. The provider then received a different, finalized prompt and failed to resolve the capture.

This PR fixes the issue by collecting the structured prompt inputs early and recording them against Pi’s finalized system prompt, making prompt capture independent of extension load order.