### PR TITLE
Rebuild the startup notice list per factory run instead of appending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 
+- **Fix: startup notice repeated its lines** — pi caches an extension's factory and re-invokes it on the same module instance for every further session loaded in the process, and each run appended the same notice lines again, so the one-time notice could list "Are you using a Max plan?" twice. The list is now rebuilt per factory run.
 - **Fix: git-status changes no longer bust the prompt cache (issue #73)** — the `claude_code` preset embeds a git-status snapshot in the cached system block, so any git transition (new file, staging, commit) rewrote the whole conversation prefix at cache-write rates. The provider path now sets `includeGitInstructions: false`, stripping the block with no other cost.
 - **Fix: rate-limit warning showed 1% and repeated every request** — the SDK reports `utilization` as a fraction (0.98), but the notification rounded it directly, printing "1% used" at 98% of the window. It now shows true percentages and only re-notifies when usage rises past a new 5% step or the threshold changes, instead of once per request while over the threshold.
 - **Fix: an exhausted Claude subscription never triggered fallback models (issue #58)** — Claude Code words a spent quota as "You're out of extra usage · resets 6:30pm", which names no recognizable symptom, so pi-subagents' `fallbackModels` and similar retry logic read it as a fatal error. A failure preceded by a rate-limit rejection is now labelled as one, with its limit type and reset time. Also fixes the rate-limit notification showing a 1970 reset time.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2005,6 +2005,11 @@ export default function (pi: ExtensionAPI) {
 	};
 	const registeredModels = applyLongContext(MODELS, longContextSettings);
 
+	// Rebuilt, not appended to: pi caches the loaded factory and calls it again on
+	// this same module instance whenever another session in the process loads the
+	// extension set (only /reload evicts the cache), so appending showed each line
+	// once per factory run.
+	pendingNotices = [];
 	if (!config.startupNoticeShown) {
 		if (config.provider?.plan === undefined) pendingNotices.push('Are you using a Max plan? You need to set provider.plan to "max" to unlock 1M context in Opus.');
 		if (config.askClaude?.enabled === undefined) pendingNotices.push("The AskClaude tool is opt-in only. Set askClaude.enabled to use it.");


### PR DESCRIPTION
## Summary

The one-time startup notice can repeat its lines:

```
Welcome to pi-claude-bridge — settings live in ~/.pi/agent/claude-bridge.json
 • Are you using a Max plan? You need to set provider.plan to "max" to unlock 1M context in Opus.
 • Are you using a Max plan? You need to set provider.plan to "max" to unlock 1M context in Opus.
 • This message only appears once. See README.md for more.
```

pi caches an extension's loaded factory (`core/extensions/loader.ts`, `extensionCache`) and calls it again on the **same module instance** whenever another session in the process loads the extension set; only `/reload` evicts the cache. pi-simple-agents does exactly that for every subagent it runs (a fresh `DefaultResourceLoader` + `reload()`, `inheritExtensions` on by default). Each factory run appended the same lines to the module-level `pendingNotices`, and the first bridge query then printed them all.

## Reproduction (offline)

A stand-in extension that, like this one, pushes into a module-level array from its factory, loaded by two `DefaultResourceLoader`s in one process:

```
pi-coding-agent 0.83.0
session 1 loads the extension set:
  factory run #1 on this module instance -> pendingNotices = ["Are you using a Max plan?"]
session 2 in the same process (what pi-simple-agents does per subagent) loads it again:
  factory run #2 on this module instance -> pendingNotices = ["Are you using a Max plan?","Are you using a Max plan?"]
```

Same result on 0.84.2.

<details><summary>Script</summary>

`counter.ts`:

```ts
const pendingNotices: string[] = [];
let runs = 0;
export default function (_pi: any) {
	runs++;
	pendingNotices.push("Are you using a Max plan?");
	console.log(`  factory run #${runs} on this module instance -> pendingNotices = ${JSON.stringify(pendingNotices)}`);
}
```

`probe.mjs` (run from a checkout so `@earendil-works/pi-coding-agent` resolves):

```js
import { mkdtempSync } from "node:fs";
import { tmpdir } from "node:os";
import { join } from "node:path";
import { DefaultResourceLoader } from "@earendil-works/pi-coding-agent";
const cwd = mkdtempSync(join(tmpdir(), "notice-probe-cwd-"));
const agentDir = mkdtempSync(join(tmpdir(), "notice-probe-agent-"));
const opts = { cwd, agentDir, additionalExtensionPaths: [new URL("./counter.ts", import.meta.url).pathname], noSkills: true, noPromptTemplates: true, noThemes: true, noContextFiles: true };
console.log("session 1 loads the extension set:");
await new DefaultResourceLoader(opts).reload();
console.log("session 2 in the same process (what pi-simple-agents does per subagent) loads it again:");
await new DefaultResourceLoader(opts).reload();
```

</details>

## Fix

Reset `pendingNotices` at the top of the block that fills it, so each factory run rebuilds the list from the config it just read.

## Tested

- `npm run typecheck`
- `npm run test:unit` — 189/189. There is no unit seam for the factory; the reproduction above is the evidence.
