### PR TITLE
fix: drop latest assistant message when its thinking blocks are unreplayable

### DIFF
--- a/diag/lib/write-path.mjs
+++ b/diag/lib/write-path.mjs
@@ -5,7 +5,7 @@
 
 import { readFileSync } from "node:fs";
 import { createSession, repairToolPairing } from "cc-session-io";
-import { convertPiMessages } from "../../src/convert.js";
+import { convertPiMessages, PROVIDER_ID } from "../../src/convert.js";
 
 /** Record fields that legitimately differ between two builds of the same
  *  history: identity and clock, none of which reaches the Anthropic prompt. */
@@ -43,16 +43,23 @@ export function transcript(piMessages) {
  *  Truncating mid-turn leaves repairToolPairing no choice but to stand in a
  *  synthetic stub for the results that have not arrived, so only settled
  *  prefixes can be expected to extend cleanly. */
+function hasUnreplayableThinking(msg) {
+	return Array.isArray(msg.content) && msg.content.some((b) =>
+		b.type === "thinking" && !(msg.provider === PROVIDER_ID && b.thinkingSignature));
+}
+
 export function settledPrefixes(messages) {
 	const lengths = [];
 	const pending = new Set();
+	let lastAssistantUnreplayable = false;
 	for (let i = 0; i < messages.length; i++) {
 		const msg = messages[i];
 		if (msg.role === "assistant" && Array.isArray(msg.content)) {
 			for (const b of msg.content) if (b.type === "toolCall") pending.add(b.id);
 		}
+		if (msg.role === "assistant") lastAssistantUnreplayable = hasUnreplayableThinking(msg);
 		if (msg.role === "toolResult") pending.delete(msg.toolCallId);
-		if (pending.size === 0) lengths.push(i + 1);
+		if (pending.size === 0 && !lastAssistantUnreplayable) lengths.push(i + 1);
 	}
 	return lengths;
 }

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -94,6 +94,7 @@ function toolResultContent(
 export type DroppedContent = {
 	thinking: number;
 	abortedTurns: number;
+	unreplayableLatest: number;
 	providers: Set<string>;
 	other: Map<string, number>;
 };
@@ -108,14 +109,18 @@ export function convertPiMessages(
 	// What conversion discarded. Nothing downstream can tell: a stripped thinking
 	// block and a message that never carried one convert to the same thing, so
 	// without this the loss is invisible in the log and in a captured request.
-	const dropped: DroppedContent = { thinking: 0, abortedTurns: 0, providers: new Set(), other: new Map() };
+	const dropped: DroppedContent = { thinking: 0, abortedTurns: 0, unreplayableLatest: 0, providers: new Set(), other: new Map() };
+	let lastAssistantIdx = -1;
+	for (let i = messages.length - 1; i >= 0; i--) {
+		if (messages[i].role === "assistant") { lastAssistantIdx = i; break; }
+	}
 	// The user message collecting this assistant turn's tool results, if one has
 	// been emitted yet, and the index of the assistant message it belongs to. Both
 	// are cleared at every assistant message — see the toolResult branch.
 	let turnResults: { role: "user"; content: Array<Record<string, unknown>> } | null = null;
 	let turnAssistantIdx: number | null = null;
 
-	for (const msg of messages) {
+	for (const [msgIdx, msg] of messages.entries()) {
 		if (msg.role === "user") {
 			if (typeof msg.content === "string") {
 				anthropicMessages.push({ role: "user", content: msg.content || "[empty]" });
@@ -133,6 +138,11 @@ export function convertPiMessages(
 			}
 		} else if (msg.role === "assistant") {
 			const content = Array.isArray(msg.content) ? msg.content : [];
+			if (msgIdx === lastAssistantIdx && content.some((block) =>
+				block.type === "thinking" && !(msg.provider === PROVIDER_ID && block.thinkingSignature))) {
+				dropped.unreplayableLatest++;
+				continue;
+			}
 			const blocks = [];
 			for (const block of content) {
 				if (block.type === "text" && block.text) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,6 +276,7 @@ function convertAndImportMessages(
 	const droppedParts = [
 		dropped.thinking ? `${dropped.thinking} thinking (${[...dropped.providers].sort().join(", ")})` : "",
 		dropped.abortedTurns ? `${dropped.abortedTurns} aborted turn(s)` : "",
+		dropped.unreplayableLatest ? `${dropped.unreplayableLatest} unreplayable latest turn(s)` : "",
 		...[...dropped.other].map(([type, n]) => `${n} ${type}`),
 	].filter(Boolean);
 	if (droppedParts.length > 0) {

--- a/tests/unit-convert-latest-thinking.mjs
+++ b/tests/unit-convert-latest-thinking.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { convertPiMessages, PROVIDER_ID } from "../src/convert.js";
+
+const history = [
+	{ role: "user", content: "start" },
+	{ role: "assistant", provider: PROVIDER_ID, content: [
+		{ type: "thinking", thinking: "step one", thinkingSignature: "sig1" },
+		{ type: "toolCall", id: "t1", name: "read", arguments: { path: "a" } },
+	] },
+	{ role: "toolResult", toolCallId: "t1", content: "body" },
+];
+
+const unreplayableTail = [
+	{ type: "thinking", thinking: "settled", thinkingSignature: "sig2" },
+	{ type: "thinking", thinking: "settled too", thinkingSignature: "sig3" },
+	{ type: "thinking", thinking: "cut off mid-thought" },
+];
+
+describe("latest-assistant-message thinking guard", () => {
+	it("drops the whole turn when the latest assistant message has an unreplayable thinking block", () => {
+		const withAnomaly = [...history, { role: "assistant", provider: PROVIDER_ID, content: unreplayableTail }];
+		const { anthropicMessages, dropped } = convertPiMessages(withAnomaly);
+
+		assert.equal(dropped.unreplayableLatest, 1);
+		assert.deepEqual(anthropicMessages.at(-1), { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: "body", is_error: undefined }] });
+	});
+
+	it("keeps the message and only drops the anomalous block once a later turn follows", () => {
+		const withFollowUp = [
+			...history,
+			{ role: "assistant", provider: PROVIDER_ID, content: unreplayableTail },
+			{ role: "user", content: "continue" },
+			{ role: "assistant", provider: PROVIDER_ID, content: [{ type: "text", text: "done" }] },
+		];
+		const { anthropicMessages, dropped } = convertPiMessages(withFollowUp);
+
+		assert.equal(dropped.unreplayableLatest, 0);
+		assert.equal(dropped.thinking, 1);
+		const midTurn = anthropicMessages.find((m) => m.role === "assistant" && Array.isArray(m.content) &&
+			m.content.some((b) => b.type === "thinking" && b.signature === "sig2"));
+		assert.ok(midTurn, "expected the historical turn to keep its signed thinking blocks");
+		assert.equal(midTurn.content.filter((b) => b.type === "thinking").length, 2);
+	});
+
+	it("does not touch a fully signed latest assistant message", () => {
+		const clean = [...history, { role: "assistant", provider: PROVIDER_ID, content: [
+			{ type: "thinking", thinking: "fine", thinkingSignature: "sig9" },
+			{ type: "text", text: "done" },
+		] }];
+		const { anthropicMessages, dropped } = convertPiMessages(clean);
+
+		assert.equal(dropped.unreplayableLatest, 0);
+		assert.equal(anthropicMessages.at(-1).role, "assistant");
+		assert.equal(anthropicMessages.at(-1).content.length, 2);
+	});
+});

--- a/tests/unit-import.mjs
+++ b/tests/unit-import.mjs
@@ -114,9 +114,10 @@ describe("thinking block filtering", () => {
 				{ type: "thinking", thinking: "let me think..." },
 				{ type: "text", text: "answer" },
 			]},
+			{ role: "user", content: "next" },
+			{ role: "assistant", content: [{ type: "text", text: "ok" }] },
 		];
 		const result = convert(msgs);
-		assert.equal(result.length, 1);
 		assert.equal(result[0].content.length, 1);
 		assert.equal(result[0].content[0].type, "text");
 	});
@@ -142,6 +143,8 @@ describe("thinking block filtering", () => {
 				{ type: "thinking", thinking: "hmm", thinkingSignature: "sig456" },
 				{ type: "text", text: "done" },
 			]},
+			{ role: "user", content: "next" },
+			{ role: "assistant", content: [{ type: "text", text: "ok" }] },
 		];
 		const result = convert(msgs);
 		assert.deepEqual(result[0].content, [{ type: "text", text: "done" }]);
@@ -153,6 +156,8 @@ describe("thinking block filtering", () => {
 				{ type: "thinking", thinking: "no sig" },
 				{ type: "text", text: "answer" },
 			]},
+			{ role: "user", content: "next" },
+			{ role: "assistant", content: [{ type: "text", text: "ok" }] },
 		];
 		const result = convert(msgs);
 		assert.equal(result[0].content.length, 1);
@@ -164,10 +169,21 @@ describe("thinking block filtering", () => {
 			{ role: "assistant", provider: "deepseek", content: [
 				{ type: "thinking", thinking: "deep thoughts" },
 			]},
+			{ role: "user", content: "next" },
+			{ role: "assistant", content: [{ type: "text", text: "ok" }] },
 		];
 		const result = convert(msgs);
-		assert.equal(result.length, 1);
 		assert.equal(result[0].content[0].text, "[incompatible content omitted]");
+	});
+
+	it("unreplayable thinking in the latest assistant message drops the whole turn", () => {
+		const msgs = [
+			{ role: "assistant", provider: "deepseek", content: [
+				{ type: "thinking", thinking: "deep thoughts" },
+			]},
+		];
+		const result = convert(msgs);
+		assert.equal(result.length, 0);
 	});
 });
 
@@ -442,9 +458,17 @@ describe("aborted assistant turns", () => {
 	it("a turn whose blocks were all filtered still says so", () => {
 		const result = convert([
 			{ role: "assistant", provider: "deepseek", content: [{ type: "thinking", thinking: "deep thoughts" }] },
+			{ role: "user", content: "next" },
+			{ role: "assistant", content: [{ type: "text", text: "ok" }] },
 		]);
-		assert.equal(result.length, 1);
 		assert.equal(result[0].content[0].text, "[incompatible content omitted]");
+	});
+
+	it("a turn whose blocks were all filtered is dropped instead when it is the latest", () => {
+		const result = convert([
+			{ role: "assistant", provider: "deepseek", content: [{ type: "thinking", thinking: "deep thoughts" }] },
+		]);
+		assert.equal(result.length, 0);
 	});
 
 	// The prompt cache is keyed on exact prefix bytes, so a rebuild must reproduce


### PR DESCRIPTION
## Background

Anthropic requires the *latest* assistant message's `thinking`/`redacted_thinking` blocks to be replayed byte-for-byte from the original API response. Historical messages may be filtered or sanitized; the latest may not — see the upstream `pi` report for the same class of bug: https://github.com/earendil-works/pi/issues/5223.

`convertPiMessages()` already refuses to replay a `thinking` block that lacks a Claude Code signature (aborted mid-thought) or was minted by another provider — it drops the block and keeps the rest of the message. That is correct for historical messages, but wrong for the *trailing* one: dropping even one block there changes the shape of what Anthropic already streamed and cached, which is exactly the "cannot be modified" 400.

## Why

Hit this in production on a long-lived session (1800+ pi messages, spanning several days / several `pi` process restarts). Every time `pi` restarts and resumes an existing session, `sharedSession` (in-memory) resets to `null`, so the very next turn takes the `Case 2: first turn` rebuild path — `convertAndImportMessages` regenerates Claude Code's session JSONL from scratch out of pi's own history.

Root cause, confirmed against the real session that produced the error:

```
API Error: 400 messages.93.content.13: `thinking` or `redacted_thinking` blocks in the
latest assistant message cannot be modified. These blocks must remain as they were in
the original response.
```

The pi message immediately before the failing turn had **three** `thinking` blocks: two signed, one signature-less (the stream was cut mid-thought — no text, no tool call, nothing after it). Because that message happened to be the *last* one in the rebuilt history, `convertPiMessages` silently dropped the unsigned block and replayed the other two — two blocks instead of three, which Claude Code's own session cache correctly rejected on the next request.

## What changed

- `convertPiMessages()`: compute the index of the last assistant message in the input. If *that* message carries a `thinking` block that would be dropped (no signature, or minted by a provider other than `claude-bridge`), drop the whole turn instead of truncating it — the same treatment already given to a turn that streamed nothing at all. A new `dropped.unreplayableLatest` counter surfaces this in the existing debug line.
- `diag/lib/write-path.mjs`'s `settledPrefixes()`: extended so a prefix boundary sitting on such a message is not treated as "settled" — otherwise the shared prefix-stability test in `unit-convert-determinism.mjs` would (correctly) start failing, since the same message converts differently depending on whether it ends up last or not.
- `tests/unit-convert-latest-thinking.mjs` (new): pins the three cases — dropped when latest, kept-with-filtered-block when a later turn follows, untouched when fully signed.
- `tests/unit-import.mjs`: the existing single-message "thinking gets filtered" tests were all, incidentally, testing the *latest-message* case (a bare one-message array). Extended them with a trailing turn so they keep testing the historical-filtering behavior they were written for, and added explicit tests for the now-different latest-message outcome.

## Validation

```
npm run typecheck
node --import tsx --import ./tests/lib/setup.mjs --test tests/unit-*.mjs
```

All green except the 3 pre-existing `unit-branch-summary.mjs` failures noted in #81 (mock lacks `pi.registerTool`, unrelated to this change).

Also replayed the fix against the actual production session that hit the bug (`convertPiMessages` on the real 1490-message prior-history slice): `dropped.unreplayableLatest` is now `1`, and the rebuilt "latest assistant message" is the last fully-signed turn, matching what Claude Code's session cache actually holds.
