### PR TITLE
test(branch-summary): stub registerTool in mock pi so activate() completes

### DIFF
--- a/tests/unit-branch-summary.mjs
+++ b/tests/unit-branch-summary.mjs
@@ -20,7 +20,11 @@ const { default: activate, __test } = await import("../src/index.js");
 
 function activateWithMockPi() {
 	const handlers = new Map();
-	activate({ on: (event, handler) => handlers.set(event, handler), registerProvider: () => {} });
+	// registerTool is stubbed too: activate() calls pi.registerTool when the loaded
+	// config enables AskClaude (e.g. a developer's global ~/.pi/agent/claude-bridge.json),
+	// so a mock missing it throws before any handler is registered. CI has no such
+	// config, which is why this only surfaced locally.
+	activate({ on: (event, handler) => handlers.set(event, handler), registerProvider: () => {}, registerTool: () => {} });
 	return handlers;
 }
 


### PR DESCRIPTION
## Problem

`tests/unit-branch-summary.mjs` can fail locally with:

```
TypeError: pi.registerTool is not a function
```

for all four `branch summarization takeover` tests.

The mock `pi` passed to `activate()` stubs `on` and `registerProvider`, but not `registerTool`. `activate()` calls `pi.registerTool` when the loaded config enables AskClaude — and `loadConfig(process.cwd())` reads the developer's **global** `~/.pi/agent/claude-bridge.json`. On a machine with AskClaude enabled, `activate()` throws before registering any handler, so the handler-presence assertions fail.

CI (and any clean checkout) has no such global config, so AskClaude stays disabled, `registerTool` is never called, and the suite passes — which is why this only surfaces on some developer machines.

## Change

Add a `registerTool: () => {}` stub to the mock `pi`, matching the existing `registerProvider: () => {}`. Now `activate()` completes regardless of the ambient config.

One-line test-only change, independent of any other work.

## Verification

`npm run test:unit` → 193/193 pass, on a machine where AskClaude is globally enabled (previously 4 failures).
